### PR TITLE
Split build_app into build and test job

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,9 +1,12 @@
-name: Build
+name: Test
 
-on: push
+on:
+  push:
+    branches:
+      - main
 
 jobs:
-  build_app:
+  build:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
@@ -15,9 +18,11 @@ jobs:
           - os: macos-latest
             electron_cmd: mac
     runs-on: ${{ matrix.os }}
-
+    env:
+      NODE_OPTIONS: "--max_old_space_size=4096"
     steps:
       - uses: actions/checkout@v3
+
       - uses: actions/setup-node@v3
         with:
           node-version: 18.x
@@ -40,28 +45,11 @@ jobs:
           YARN_CACHE_FOLDER: ${{ steps.yarn-cache-folder.outputs.path }}
         run: yarn install --immutable
 
-      - name: Check format
-        if: matrix.os == 'ubuntu-latest'
-        run: npm run format:ci
-
-      - name: Run linter
-        if: matrix.os == 'ubuntu-latest'
-        run: npm run lint
-
-      - name: Typecheck code
-        if: matrix.os == 'ubuntu-latest'
-        run: npm run typecheck
-
-      - name: Run tests
-        env:
-          CI: true
-        run: npm run test
-
       - name: Build
         run: yarn build
 
       - name: Deploy Github Pages
-        if: matrix.os == 'ubuntu-latest' && github.ref == 'refs/heads/main'
+        if: matrix.os == 'ubuntu-latest'
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -70,12 +58,10 @@ jobs:
       - name: Package the electron app
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        if: github.ref == 'refs/heads/main'
         run: yarn electron:package:${{ matrix.electron_cmd }}
 
       - name: Upload
         uses: actions/upload-artifact@v3
-        if: github.ref == 'refs/heads/main'
         with:
           name: app_dist_${{ matrix.electron_cmd }}
           path: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,51 @@
+name: Test
+
+on: push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      NODE_OPTIONS: "--max_old_space_size=4096"
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18.x
+          cache: "yarn"
+
+      - name: Register yarn 1.x cache folder
+        id: yarn-cache-folder
+        shell: bash
+        run: |
+          echo "path=$(yarn cache dir)" >> $GITHUB_OUTPUT
+
+      - name: Setup yarn 3.x
+        run: |
+          corepack enable
+          corepack prepare yarn@stable --activate
+          yarn --version
+
+      - name: Install packages
+        env:
+          YARN_CACHE_FOLDER: ${{ steps.yarn-cache-folder.outputs.path }}
+        run: yarn install --immutable
+
+      - name: Check format
+        run: yarn run format:ci
+
+      - name: Run linter
+        run: yarn run lint
+
+      - name: Run tests
+        env:
+          CI: true
+        run: yarn run test
+
+      - name: Build
+        run: yarn build
+
+      # this is needed to ensure that actions/setup-node will pick up yarn cache
+      - name: Remove yarn 3.5
+        run: corepack disable

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Just run `./bin/setup`. It'll create a git pre-push hook with all the necessary 
 
 In the project directory, you can run:
 
-### `npm start`
+### `yarn start`
 
 Runs the app in the development mode.\
 Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
@@ -18,18 +18,18 @@ Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
 The page will reload if you make edits.\
 You will also see any lint errors in the console.
 
-### `npm test`
+### `yarn test`
 
 Launches the test runner in the interactive watch mode.\
 See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
 
-### `npm test:tezos:integration`
+### `yarn test:tezos:integration`
 
 Run the tests including Tezos integration tests.
 The Tezos integration tests use real accounts on Ghotnet and Mainnet.
 Therefore these may fail if an account has insufficient balances, a node is down, etc...
 
-### `npm run build`
+### `yarn run build`
 
 Builds the app for production to the `build` folder.\
 It correctly bundles React in production mode and optimizes the build for the best performance.
@@ -39,7 +39,7 @@ Your app is ready to be deployed!
 
 See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
 
-### `npm run eject`
+### `yarn run eject`
 
 **Note: this is a one-way operation. Once you `eject`, you can’t go back!**
 
@@ -49,15 +49,15 @@ Instead, it will copy all the configuration files and the transitive dependencie
 
 You don’t have to ever use `eject`. The curated feature set is suitable for small and middle deployments, and you shouldn’t feel obligated to use this feature. However we understand that this tool wouldn’t be useful if you couldn’t customize it when you are ready for it.
 
-### `npm run electron start`
+### `yarn run electron start`
 
 Runs the electron app in the development mode.
 
-### `npm run electron:package:(mac|win|linux)`
+### `yarn run electron:package:(mac|win|linux)`
 
 Build electron app for desired platform (don't forget to run `yarn build` before running this one)
 
-### `npm run storybook`
+### `yarn run storybook`
 
 Start storybook (duh).
 


### PR DESCRIPTION
## Proposed changes

So, as I mentioned in [slack](https://tezos-dev.slack.com/archives/C04TNKCSBJL/p1681297238237269) I split the job into two and all our PR builds are going to just test and build the app, but not pack or publish it. Packing stage will occur only on the main branch

## Types of changes

_Put an `x` in the boxes that apply_

- [ ] Bugfix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation Update
