### PR TITLE
Fix artifact uploading

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,4 +1,4 @@
-name: Test
+name: Build packages
 
 on:
   push:
@@ -13,10 +13,13 @@ jobs:
         include:
           - os: windows-latest
             electron_cmd: win
+            package_glob: dist/*.exe
           - os: ubuntu-latest
             electron_cmd: linux
+            package_glob: dist/*.AppImage
           - os: macos-latest
             electron_cmd: mac
+            package_glob: dist/*.dmg
     runs-on: ${{ matrix.os }}
     env:
       NODE_OPTIONS: "--max_old_space_size=4096"
@@ -64,10 +67,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: app_dist_${{ matrix.electron_cmd }}
-          path: |
-            dist/*.exe
-            dist/*.dmg
-            dist/*.deb
+          path: ${{ matrix.package_glob }}
           if-no-files-found: error
 
       # this is needed to ensure that actions/setup-node will pick up yarn cache


### PR DESCRIPTION
## Proposed changes

We now produce AppImage instead of a deb file for linux.

Alongside the bug fix, properly named the CI workflow and cleaned up the code a bit

You can find a working example of the workflow [here](https://github.com/trilitech/umami-v2/actions/runs/4688667648)
 
## Types of changes

_Put an `x` in the boxes that apply_

- [x] Bugfix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation Update

## Further comments

