### PR TITLE
Introduce code signing for mac builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,9 +1,8 @@
 name: Build packages
 
 on:
-  push:
-    branches:
-      - main
+  release:
+    types: [published]
 
 jobs:
   build:
@@ -23,6 +22,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       NODE_OPTIONS: "--max_old_space_size=4096"
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v3
 
@@ -58,10 +58,24 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./build
 
-      - name: Package the electron app
+      - name: Package the electron app MacOS
+        if: matrix.os == 'macos-latest'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: yarn electron:package:${{ matrix.electron_cmd }}
+          CSC_KEY_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          CSC_LINK: certificate.p12
+          APPLEID: ${{ secrets.APPLE_NOTARIZE_APPLEID }}
+          APPLEIDPASS: ${{ secrets.APPLE_NOTARIZE_PASSWORD }}
+        run: |
+          echo "${{ secrets.APPLE_CERTIFICATE_P12 }}" | base64 -d -o certificate.p12
+          yarn electron:package:mac
+
+      - name: Package the electron app Linux
+        if: matrix.os == 'ubuntu-latest'
+        run: yarn electron:package:linux
+
+      - name: Package the electron app Windows
+        if: matrix.os == 'windows-latest'
+        run: yarn electron:package:win
 
       - name: Upload
         uses: actions/upload-artifact@v3

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "storybook": "start-storybook -p 6006 -s public",
     "electron:start": "concurrently -k \"cross-env BROWSER=none yarn start\" \"wait-on http://localhost:3000 && electronmon .\"",
     "build-storybook": "build-storybook -s public",
-    "electron:package:mac": "electron-builder -m -c.extraMetadata.main=build/electron.js -c.mac.identity=null",
+    "electron:package:mac": "electron-builder -m -c.extraMetadata.main=build/electron.js",
     "electron:package:win": "electron-builder -w -c.extraMetadata.main=build/electron.js",
     "electron:package:linux": "electron-builder -l -c.extraMetadata.main=build/electron.js"
   },
@@ -110,6 +110,7 @@
     "cross-env": "^7.0.3",
     "electron": "^23.2.0",
     "electron-builder": "^23.6.0",
+    "electron-notarize": "^1.2.2",
     "electronmon": "^2.0.2",
     "eslint": "^8.38.0",
     "https-browserify": "^1.0.0",
@@ -142,7 +143,7 @@
     ]
   },
   "build": {
-    "appId": "com.electron.myapp",
+    "appId": "com.trilitech.umami",
     "productName": "Umami",
     "files": [
       "build/**/*",
@@ -187,7 +188,8 @@
       "schemes": [
         "umami"
       ]
-    }
+    },
+    "afterSign": "scripts/notarize.js"
   },
   "packageManager": "yarn@3.5.0",
   "resolutions": {

--- a/scripts/notarize.js
+++ b/scripts/notarize.js
@@ -1,0 +1,18 @@
+const { notarize } = require("electron-notarize");
+
+exports.default = async function notarizing(context) {
+  console.log("Notarizing");
+  const { electronPlatformName, appOutDir } = context;
+  if (electronPlatformName !== "darwin") {
+    return;
+  }
+
+  const appName = context.packager.appInfo.productFilename;
+
+  return await notarize({
+    appBundleId: "com.trilitech.umami",
+    appPath: `${appOutDir}/${appName}.app`,
+    appleId: process.env.APPLEID,
+    appleIdPassword: process.env.APPLEIDPASS,
+  });
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -12190,6 +12190,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"electron-notarize@npm:^1.2.2":
+  version: 1.2.2
+  resolution: "electron-notarize@npm:1.2.2"
+  dependencies:
+    debug: ^4.1.1
+    fs-extra: ^9.0.1
+  checksum: 98909bc90f0840a4bd3da0edc6895d719eb0d17942812a8c8f5a130d323c7fbaafd819245cfe9a6c5b5abfa8dd3b0eb2bd8ee9c0b2dcf0c3b238b6845730c368
+  languageName: node
+  linkType: hard
+
 "electron-osx-sign@npm:^0.6.0":
   version: 0.6.0
   resolution: "electron-osx-sign@npm:0.6.0"
@@ -24273,6 +24283,7 @@ __metadata:
     date-fns: ^2.29.3
     electron: ^23.2.0
     electron-builder: ^23.6.0
+    electron-notarize: ^1.2.2
     electronmon: ^2.0.2
     eslint: ^8.38.0
     framer-motion: ^10.2.5


### PR DESCRIPTION
## Proposed changes

I added code signing and app notarising according to [this guide](https://kilianvalkhof.com/2019/electron/notarizing-your-electron-application/).
I split the electron packaging step into 3 separate ones (one per OS) because they become too different.
Also, from now on we'll be building the app only when we make releases. Otherwise, it's going to be quite costly (on average, it takes ~25 minutes to build Mac OS app because of notarising).

[Successful build](https://github.com/trilitech/umami-v2/actions/runs/4926412132)