### PR TITLE
Build deb and rpm packages

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,7 +15,9 @@ jobs:
             package_glob: dist/*.exe
           - os: ubuntu-latest
             electron_cmd: linux
-            package_glob: dist/*.AppImage
+            package_glob: |
+              dist/*.deb
+              dist/*.rpm
           - os: macos-latest
             electron_cmd: mac
             package_glob: dist/*.dmg
@@ -71,7 +73,9 @@ jobs:
 
       - name: Package the electron app Linux
         if: matrix.os == 'ubuntu-latest'
-        run: yarn electron:package:linux
+        run: |
+          sudo apt-get install -y rpm
+          yarn electron:package:linux
 
       - name: Package the electron app Windows
         if: matrix.os == 'windows-latest'

--- a/package.json
+++ b/package.json
@@ -178,9 +178,29 @@
       ]
     },
     "linux": {
-      "target": "AppImage",
+      "icon": "build/logo512.png",
+      "target": [
+        "deb",
+        "rpm"
+      ],
+      "category": "Finance",
       "mimeTypes": [
         "x-scheme-handler/umami"
+      ]
+    },
+    "snap": {
+      "plugs": [
+        "default",
+        "raw-usb",
+        "hidraw"
+      ],
+      "buildPackages": [
+        "libusb-1.0-0-dev",
+        "libudev-dev"
+      ],
+      "stagePackages": [
+        "libusb-1.0-0",
+        "libnss3"
       ]
     },
     "protocols": {


### PR DESCRIPTION
## Proposed changes

Since on umamiwallet.com we provide folks with deb and rpm packages, not AppImage, I've replaced the latter with the formers. The only problem is snap packs, unfortunately, I wasn't able to make it build on GitHub CI due to lots of reasons, so I will build them on my machine and publish when needed. It's manual process anyway on snapcraft.io

[Successful build](https://github.com/trilitech/umami-v2/actions/runs/5012910093?pr=117)

## Types of changes 

_Put an `x` in the boxes that apply_

- [ ] Bugfix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation Update

![2023-05-18 (3)](https://github.com/trilitech/umami-v2/assets/129749432/2e3c3eb7-67d3-4f58-967a-dddad8c9399e)
![2023-05-18 (2)](https://github.com/trilitech/umami-v2/assets/129749432/3d168363-ab77-4251-86fb-0baa5f54ae01)
![2023-05-18 (1)](https://github.com/trilitech/umami-v2/assets/129749432/cc635c61-42b5-48ca-af54-be524eef804b)
![2023-05-18](https://github.com/trilitech/umami-v2/assets/129749432/8756a316-b618-47d6-96f4-b57dbc04e4ae)



