### PR TITLE
Refresh beacon peers via query key

### DIFF
--- a/src/utils/beacon/BeaconPeers.tsx
+++ b/src/utils/beacon/BeaconPeers.tsx
@@ -7,26 +7,27 @@ import {
   Image,
 } from "@chakra-ui/react";
 import { BsTrash } from "react-icons/bs";
-import { refreshPeers, usePeers, walletClient } from "./beacon";
+import { usePeers, useRefreshPeers, walletClient } from "./beacon";
 
 // Displays the list of beacon peers
 
-const renderPeer = (p: PeerInfo) => {
-  const icon = (p as any).icon;
+export const PeerDisplay = ({ peerInfo }: { peerInfo: PeerInfo }) => {
+  const refreshPeers = useRefreshPeers();
+  const icon = (peerInfo as any).icon;
   return (
-    <Flex key={p.name} mt={2} mb={2}>
+    <Flex key={peerInfo.name} mt={2} mb={2}>
       <Flex flex={1} alignItems="center">
         <AspectRatio width={12} ratio={4 / 4}>
           <Image width="100%" src={icon} />
         </AspectRatio>
         <Heading size={"sm"} ml={4}>
-          {p.name}
+          {peerInfo.name}
         </Heading>
       </Flex>
 
       <IconButton
         onClick={() => {
-          walletClient.removePeer(p as any).then(refreshPeers);
+          walletClient.removePeer(peerInfo as any).then(refreshPeers); // Bug in types
         }}
         aria-label="Delete Peer"
         icon={<BsTrash />}
@@ -41,7 +42,9 @@ const BeaconPeers = () => {
   return (
     <>
       <Heading>Peers</Heading>
-      {peers.map(renderPeer)}
+      {peers.map((peerInfo) => (
+        <PeerDisplay peerInfo={peerInfo} />
+      ))}
     </>
   );
 };

--- a/src/views/settings/SettingsView.tsx
+++ b/src/views/settings/SettingsView.tsx
@@ -9,7 +9,7 @@ import {
   Divider,
   Input,
 } from "@chakra-ui/react";
-import { addPeer } from "../../utils/beacon/beacon";
+import { useAddPeer } from "../../utils/beacon/beacon";
 import ClickableCard, {
   SettingsCard,
   SettingsCardWithDrawerIcon,
@@ -52,6 +52,7 @@ export default function SettingsView() {
 }
 
 const GeneralSection = () => {
+  const addPeer = useAddPeer();
   return (
     <SectionContainer title="General">
       <SettingsCard left="Theme">


### PR DESCRIPTION
## Proposed changes

Use react query key to refresh beacon peers: `client.refetchQueries(PEERS_QUERY_KEY);`

instead of spaghetti code with event emitter.
