### PR TITLE
Get rid of BigNumber in the persisted state

### DIFF
--- a/src/components/AccountCard.tsx/AccountCard.test.tsx
+++ b/src/components/AccountCard.tsx/AccountCard.test.tsx
@@ -8,7 +8,6 @@ import accountsSlice from "../../utils/store/accountsSlice";
 import assetsSlice from "../../utils/store/assetsSlice";
 import { store } from "../../utils/store/store";
 
-import BigNumber from "bignumber.js";
 import AccountCard from ".";
 import { uUSD } from "../../mocks/fa2Tokens";
 import { render, screen, within } from "../../mocks/testUtils";
@@ -16,7 +15,7 @@ import { hedgeHoge, tzBtsc } from "../../mocks/fa12Tokens";
 const { updateAssets } = assetsSlice.actions;
 const { add, setSelected } = accountsSlice.actions;
 
-const tezBalance = new BigNumber(33200000000);
+const tezBalance = "33200000000";
 
 const account = mockAccount(0);
 const pkh = account.pkh;

--- a/src/components/AccountTile/index.tsx
+++ b/src/components/AccountTile/index.tsx
@@ -1,11 +1,10 @@
 import { format } from "@taquito/utils";
-import BigNumber from "bignumber.js";
 import React from "react";
 import { AccountTileDisplay, Props } from "./AccountTileDisplay";
 
 const AccountTile: React.FC<
   Omit<Props, "balance"> & {
-    balance: BigNumber | null;
+    balance: string | null;
   }
 > = ({ address, onClick, balance, selected = false, label }) => {
   const prettyBalance = balance && `${format("mutez", "tz", balance)} ꜩ`;

--- a/src/components/CSVFileUploader/utils.test.ts
+++ b/src/components/CSVFileUploader/utils.test.ts
@@ -2,7 +2,6 @@ import { mockContract, mockPkh } from "../../mocks/factories";
 import { csvRowToOperationValue, parseToCSVRow } from "./utils";
 import { CSVRow } from "./types";
 import { ghostFA12, ghostFA2, ghostTezzard } from "../../mocks/tokens";
-import { BigNumber } from "bignumber.js";
 import { FA12Token, FA2Token, NFT } from "../../types/Asset";
 
 describe("csv utils", () => {
@@ -79,7 +78,7 @@ describe("csv utils", () => {
     expect(res).toEqual({
       type: "tez",
       value: {
-        amount: new BigNumber(1000000),
+        amount: "1000000",
         recipient: mockPkh(1),
         sender: mockPkh(0),
       },
@@ -100,7 +99,7 @@ describe("csv utils", () => {
       type: "token",
       data: new FA12Token(ghostFA12.contract, ghostFA12.balance),
       value: {
-        amount: new BigNumber(100000000),
+        amount: "100000000",
         recipient: mockPkh(1),
         sender: mockPkh(0),
       },
@@ -127,7 +126,7 @@ describe("csv utils", () => {
         ghostFA2.metadata
       ),
       value: {
-        amount: new BigNumber(100000),
+        amount: "100000",
         recipient: mockPkh(1),
         sender: mockPkh(0),
       },
@@ -157,7 +156,7 @@ describe("csv utils", () => {
         ghostTezzard1.metadata
       ),
       value: {
-        amount: new BigNumber(1),
+        amount: "1",
         recipient: mockPkh(1),
         sender: mockPkh(0),
       },

--- a/src/components/CSVFileUploader/utils.ts
+++ b/src/components/CSVFileUploader/utils.ts
@@ -59,7 +59,7 @@ export const csvRowToOperationValue = (
       value: {
         sender,
         recipient,
-        amount: tezToMutez(csvRow.prettyAmount),
+        amount: tezToMutez(csvRow.prettyAmount).toString(),
       },
     };
   }
@@ -91,7 +91,7 @@ export const csvRowToOperationValue = (
     value: {
       sender,
       recipient,
-      amount: asset.getRealAmount(csvRow.prettyAmount),
+      amount: asset.getRealAmount(csvRow.prettyAmount).toString(),
     },
   };
 };

--- a/src/components/sendForm/SendForm.test.tsx
+++ b/src/components/sendForm/SendForm.test.tsx
@@ -41,7 +41,6 @@ import {
   waitFor,
   within,
 } from "../../mocks/testUtils";
-import BigNumber from "bignumber.js";
 
 jest.mock("../../GoogleAuth", () => ({
   // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -178,11 +177,12 @@ describe("<SendForm />", () => {
         isSimulating: false,
         items: [
           {
-            fee: new BigNumber(33),
+            fee: "33",
             operation: {
               type: "tez",
               value: {
-                amount: new BigNumber(23000000),
+                amount: "23000000",
+                parameter: undefined,
                 recipient: mockPkh(7),
                 sender: mockPkh(1),
               },
@@ -207,22 +207,22 @@ describe("<SendForm />", () => {
         isSimulating: false,
         items: [
           {
-            fee: new BigNumber(33),
+            fee: "33",
             operation: {
               type: "tez",
               value: {
-                amount: new BigNumber(23000000),
+                amount: "23000000",
                 recipient: mockPkh(7),
                 sender: mockPkh(1),
               },
             },
           },
           {
-            fee: new BigNumber(33),
+            fee: "33",
             operation: {
               type: "tez",
               value: {
-                amount: new BigNumber(23000000),
+                amount: "23000000",
                 recipient: mockPkh(7),
                 sender: mockPkh(1),
               },
@@ -267,7 +267,7 @@ describe("<SendForm />", () => {
       };
       expect(transferTezMock).toHaveBeenCalledWith(
         mockPkh(7),
-        new BigNumber(23000000),
+        23000000,
         config,
         undefined
       );
@@ -327,7 +327,7 @@ describe("<SendForm />", () => {
       });
       expect(estimateFA2transferMock).toHaveBeenCalledWith(
         {
-          amount: new BigNumber(1000000),
+          amount: "1000000",
           contract: mockFA2.contract,
           recipient: mockAccount(7).pkh,
           sender: mockAccount(2).pkh,
@@ -361,7 +361,7 @@ describe("<SendForm />", () => {
 
       expect(transferFA2TokenMock).toHaveBeenCalledWith(
         {
-          amount: new BigNumber(1000000),
+          amount: "1000000",
           contract: mockFA2.contract,
           recipient: mockPkh(7),
           sender: mockPkh(2),
@@ -426,7 +426,7 @@ describe("<SendForm />", () => {
 
       expect(estimateFA12transferMock).toHaveBeenCalledWith(
         {
-          amount: new BigNumber(1000000000),
+          amount: "1000000000",
           contract: mockFa1.contract,
           recipient: mockAccount(7).pkh,
           sender: mockAccount(2).pkh,
@@ -459,7 +459,7 @@ describe("<SendForm />", () => {
 
       expect(transferFA12TokenMock).toHaveBeenCalledWith(
         {
-          amount: new BigNumber(1000000000),
+          amount: "1000000000",
           contract: mockFa1.contract,
           recipient: mockPkh(7),
           sender: mockPkh(2),
@@ -554,7 +554,7 @@ describe("<SendForm />", () => {
       };
       expect(transferFA2TokenMock).toHaveBeenCalledWith(
         {
-          amount: new BigNumber(1),
+          amount: "1",
           contract: "KT1GVhG7dQNjPAt4FNBNmc9P9zpiQex4Mxob1",
           recipient: mockPkh(7),
           sender: mockPkh(1),

--- a/src/components/sendForm/SendForm.tsx
+++ b/src/components/sendForm/SendForm.tsx
@@ -59,7 +59,7 @@ const makeSimulation = (
       return estimateMutezTransfer(
         operation.value.sender,
         operation.value.recipient,
-        operation.value.amount,
+        new BigNumber(operation.value.amount),
         pk,
         network,
         operation.value.parameter
@@ -100,7 +100,7 @@ export const SendForm = ({
     mode.type === "batch"
       ? {
           operation: mode.data.batch.items.map((b) => b.operation),
-          fee: getTotalFee(mode.data.batch.items),
+          fee: getTotalFee(mode.data.batch.items).toString(),
         }
       : undefined;
 
@@ -130,7 +130,7 @@ export const SendForm = ({
 
       setTransferValues({
         operation,
-        fee: new BigNumber(estimate.suggestedFeeMutez),
+        fee: String(estimate.suggestedFeeMutez),
       });
     } catch (error: any) {
       toast({ title: "Invalid transaction", description: error.message });

--- a/src/components/sendForm/components/TezAmountRecaps.tsx
+++ b/src/components/sendForm/components/TezAmountRecaps.tsx
@@ -1,10 +1,9 @@
 import { Flex, FlexProps, Heading, Text } from "@chakra-ui/react";
-import { BigNumber } from "bignumber.js";
 import colors from "../../../style/colors";
 import { mutezToTez, prettyTezAmount } from "../../../utils/format";
 import { useTezToDollar } from "../../../utils/hooks/assetsHooks";
 
-type Props = { mutez: BigNumber } & FlexProps;
+type Props = { mutez: string } & FlexProps;
 
 export const TransactionsAmount = ({
   amount,
@@ -75,10 +74,7 @@ export const Total = ({ mutez, ...flexProps }: Props) => {
   );
 };
 
-export const Fee = ({
-  mutez,
-  ...flexProps
-}: { mutez: BigNumber } & FlexProps) => {
+export const Fee = ({ mutez, ...flexProps }: { mutez: string } & FlexProps) => {
   return (
     <Flex
       aria-label="fee"

--- a/src/components/sendForm/steps/FillStep.tsx
+++ b/src/components/sendForm/steps/FillStep.tsx
@@ -343,7 +343,7 @@ export const FillStep: React.FC<{
             onSubmitBatch({
               type: "tez",
               value: {
-                amount: tezToMutez(v.amount),
+                amount: tezToMutez(v.amount).toString(),
                 sender: v.sender,
                 recipient: v.recipient,
                 parameter,
@@ -354,7 +354,7 @@ export const FillStep: React.FC<{
             onSubmit({
               type: "tez",
               value: {
-                amount: tezToMutez(v.amount),
+                amount: tezToMutez(v.amount).toString(),
                 sender: v.sender,
                 recipient: v.recipient,
                 parameter,
@@ -376,7 +376,7 @@ export const FillStep: React.FC<{
               type: "token",
               data: mode.data,
               value: {
-                amount: mode.data.getRealAmount(v.amount),
+                amount: mode.data.getRealAmount(v.amount).toString(),
                 sender: v.sender,
                 recipient: v.recipient,
               },
@@ -387,7 +387,7 @@ export const FillStep: React.FC<{
               type: "token",
               data: mode.data,
               value: {
-                amount: mode.data.getRealAmount(v.amount),
+                amount: mode.data.getRealAmount(v.amount).toString(),
                 sender: v.sender,
                 recipient: v.recipient,
               },

--- a/src/components/sendForm/steps/SubmitStep.tsx
+++ b/src/components/sendForm/steps/SubmitStep.tsx
@@ -61,7 +61,7 @@ const makeTransfer = async (
     case "tez":
       return await transferMutez(
         operation.value.recipient,
-        operation.value.amount,
+        parseInt(operation.value.amount),
         config,
         operation.value.parameter
       );
@@ -127,7 +127,7 @@ const BatchRecap = ({ transfer }: { transfer: OperationValue[] }) => {
   return (
     <>
       <TransactionsAmount amount={transfer.length} />
-      <Subtotal mutez={getBatchSubtotal(transfer)} />
+      <Subtotal mutez={getBatchSubtotal(transfer).toString()} />
     </>
   );
 };
@@ -138,7 +138,7 @@ const getSubTotal = (t: OperationValue[] | OperationValue): BigNumber => {
   }
 
   if (t.type === "tez") {
-    return t.value.amount;
+    return new BigNumber(t.value.amount);
   }
 
   return new BigNumber(0);
@@ -149,6 +149,7 @@ export const RecapDisplay: React.FC<{
   recap: EstimatedOperation;
   onSucces: (hash: string) => void;
 }> = ({ recap: { fee, operation: transfer }, network, onSucces }) => {
+  const feeNum = new BigNumber(fee);
   const renderAccountTile = useRenderAccountSmallTile();
   const getAccount = useGetOwnedAccount();
 
@@ -184,7 +185,7 @@ export const RecapDisplay: React.FC<{
     setIsLoading(false);
   };
 
-  const total = fee.plus(getSubTotal(transfer));
+  const total = feeNum.plus(getSubTotal(transfer));
 
   return (
     <ModalContent bg="umami.gray.900" data-testid="bar">
@@ -208,7 +209,7 @@ export const RecapDisplay: React.FC<{
             <Fee mutez={fee} />
           </Box>
           <Divider mb={2} mt={2} />
-          <Total mutez={total} />
+          <Total mutez={total.toString()} />
         </ModalBody>
         <ModalFooter justifyContent={"center"}>
           <SignButton

--- a/src/components/sendForm/types.ts
+++ b/src/components/sendForm/types.ts
@@ -1,7 +1,6 @@
 import { TransferParams } from "@taquito/taquito";
 import { Asset } from "../../types/Asset";
 import { Batch } from "../../utils/store/assetsSlice";
-import type { BigNumber } from "bignumber.js";
 
 type TezMode = { type: "tez" };
 
@@ -28,7 +27,7 @@ export type SendFormMode = TezMode | TokenMode | DelegationMode | BatchMode;
 export type OperationValue =
   | (TezMode & {
       value: {
-        amount: BigNumber;
+        amount: string;
         sender: string;
         recipient: string;
         parameter?: TransferParams["parameter"];
@@ -36,7 +35,7 @@ export type OperationValue =
     })
   | (TokenMode & {
       value: {
-        amount: BigNumber;
+        amount: string;
         sender: string;
         recipient: string;
       };
@@ -50,5 +49,5 @@ export type OperationValue =
 
 export type EstimatedOperation = {
   operation: OperationValue | OperationValue[];
-  fee: BigNumber;
+  fee: string;
 };

--- a/src/integration/tezos.integration.test.ts
+++ b/src/integration/tezos.integration.test.ts
@@ -14,7 +14,6 @@ import {
   estimateFA2transfer,
   operationValuesToBatchParams,
 } from "../utils/tezos";
-import { BigNumber } from "bignumber.js";
 
 const pk1 = publicKeys1.pk;
 const pkh1 = publicKeys1.pkh;
@@ -27,7 +26,7 @@ describe("Tezos utils", () => {
         {
           type: "tez",
           value: {
-            amount: new BigNumber(3),
+            amount: "3",
             sender: pkh1,
             recipient: pkh2,
           },
@@ -36,7 +35,7 @@ describe("Tezos utils", () => {
           type: "tez",
 
           value: {
-            amount: new BigNumber(2),
+            amount: "2",
             sender: pkh1,
             recipient: pkh2,
             parameter: {
@@ -61,7 +60,7 @@ describe("Tezos utils", () => {
           value: {
             sender: pkh1,
             recipient: pkh2,
-            amount: new BigNumber(1),
+            amount: "1",
           },
         },
         {
@@ -70,7 +69,7 @@ describe("Tezos utils", () => {
           value: {
             sender: pkh1,
             recipient: pkh2,
-            amount: new BigNumber(1),
+            amount: "1",
           },
         },
         {
@@ -79,7 +78,7 @@ describe("Tezos utils", () => {
           value: {
             sender: pkh1,
             recipient: pkh2,
-            amount: new BigNumber(2),
+            amount: "2",
           },
         },
       ];
@@ -214,7 +213,7 @@ describe("Tezos utils", () => {
       test("FA2 estimation returns the right value on ghostnet", async () => {
         const result = await estimateFA2transfer(
           {
-            amount: new BigNumber(1),
+            amount: "1",
             contract: ghostTezzard.contract,
             recipient: pkh2,
             sender: pkh1,
@@ -230,7 +229,7 @@ describe("Tezos utils", () => {
       test("FA12 estimation returns the right value on ghostnet", async () => {
         const result = await estimateFA12transfer(
           {
-            amount: new BigNumber(1),
+            amount: "1",
             contract: ghostFA12WithOwner.contract,
             recipient: pkh2,
             sender: ghostFA12WithOwner.owner,
@@ -248,7 +247,7 @@ describe("Tezos utils", () => {
             {
               type: "tez",
               value: {
-                amount: new BigNumber(1),
+                amount: "1",
                 sender: pkh1,
                 recipient: pkh2,
               },
@@ -259,7 +258,7 @@ describe("Tezos utils", () => {
               value: {
                 sender: pkh1,
                 recipient: pkh2,
-                amount: new BigNumber(1),
+                amount: "1",
               },
             },
             {
@@ -268,7 +267,7 @@ describe("Tezos utils", () => {
               value: {
                 sender: pkh1,
                 recipient: pkh2,
-                amount: new BigNumber(1),
+                amount: "1",
               },
             },
             {
@@ -277,7 +276,7 @@ describe("Tezos utils", () => {
               value: {
                 sender: pkh1,
                 recipient: pkh2,
-                amount: new BigNumber(1),
+                amount: "1",
               },
             },
           ],
@@ -297,7 +296,7 @@ describe("Tezos utils", () => {
             {
               type: "tez",
               value: {
-                amount: new BigNumber(100),
+                amount: "100",
                 sender: pkh1,
                 recipient: pkh2,
               },
@@ -305,7 +304,7 @@ describe("Tezos utils", () => {
             {
               type: "tez",
               value: {
-                amount: new BigNumber(200),
+                amount: "200",
                 sender: pkh1,
                 recipient: pkh2,
               },
@@ -350,7 +349,7 @@ describe("Tezos utils", () => {
             {
               type: "tez",
               value: {
-                amount: new BigNumber(9999999),
+                amount: "9999999",
                 sender: pkh1,
                 recipient: pkh2,
               },
@@ -378,7 +377,7 @@ describe("Tezos utils", () => {
     test("FA2 estimation returns the right value on ghostnet", async () => {
       const result = await estimateFA2transfer(
         {
-          amount: new BigNumber(1),
+          amount: "1",
           contract: ghostTezzard.contract,
           recipient: pkh2,
           sender: pkh1,

--- a/src/mocks/factories.ts
+++ b/src/mocks/factories.ts
@@ -1,5 +1,4 @@
 import { DelegationOperation } from "@tzkt/sdk-api";
-import { BigNumber } from "bignumber.js";
 import { OperationValue } from "../components/sendForm/types";
 import {
   Account,
@@ -266,7 +265,7 @@ export const mockTezTransfer = (index: number): OperationValue => {
   return {
     type: "tez",
     value: {
-      amount: new BigNumber(index),
+      amount: String(index),
       sender: mockPkh(index),
       recipient: mockPkh(index + 1),
     },
@@ -278,7 +277,7 @@ export const mockNftTransfer = (index: number): OperationValue => {
     type: "token",
     data: {} as NFT,
     value: {
-      amount: new BigNumber(index),
+      amount: String(index),
       sender: mockPkh(index),
       recipient: mockPkh(index + 1),
     },

--- a/src/utils/assetsReducer.test.ts
+++ b/src/utils/assetsReducer.test.ts
@@ -3,7 +3,6 @@ import { store } from "./store/store";
 
 import { TezosNetwork } from "@airgap/tezos";
 import { waitFor } from "@testing-library/react";
-import BigNumber from "bignumber.js";
 import {
   mockDelegationTransfer,
   mockNftTransfer,
@@ -55,12 +54,12 @@ describe("Assets reducer", () => {
   });
 
   test("tez balances are added", () => {
-    store.dispatch(update([{ pkh: "foo", tez: new BigNumber(43) }]));
+    store.dispatch(update([{ pkh: "foo", tez: "43" }]));
 
     expect(store.getState().assets).toEqual({
       balances: {
         tez: {
-          foo: new BigNumber(43),
+          foo: "43",
         },
         tokens: {},
       },
@@ -75,17 +74,17 @@ describe("Assets reducer", () => {
 
     store.dispatch(
       update([
-        { pkh: "bar", tez: new BigNumber(44) },
-        { pkh: "baz", tez: new BigNumber(55) },
+        { pkh: "bar", tez: "44" },
+        { pkh: "baz", tez: "55" },
       ])
     );
 
     expect(store.getState().assets).toEqual({
       balances: {
         tez: {
-          foo: new BigNumber(43),
-          bar: new BigNumber(44),
-          baz: new BigNumber(55),
+          foo: "43",
+          bar: "44",
+          baz: "55",
         },
         tokens: {},
       },
@@ -102,8 +101,8 @@ describe("Assets reducer", () => {
   test("tez balances are updated", () => {
     store.dispatch(
       update([
-        { pkh: "bar", tez: new BigNumber(44) },
-        { pkh: "baz", tez: new BigNumber(55) },
+        { pkh: "bar", tez: "44" },
+        { pkh: "baz", tez: "55" },
       ])
     );
 
@@ -111,14 +110,14 @@ describe("Assets reducer", () => {
       update([
         {
           pkh: "baz",
-          tez: new BigNumber(66),
+          tez: "66",
         },
       ])
     );
 
     expect(store.getState().assets).toEqual({
       balances: {
-        tez: { bar: new BigNumber(44), baz: new BigNumber(66) },
+        tez: { bar: "44", baz: "66" },
         tokens: {},
       },
       conversionRate: null,
@@ -134,8 +133,8 @@ describe("Assets reducer", () => {
   test("token balances are updated", () => {
     store.dispatch(
       update([
-        { pkh: "bar", tez: new BigNumber(44) },
-        { pkh: "baz", tez: new BigNumber(55) },
+        { pkh: "bar", tez: "44" },
+        { pkh: "baz", tez: "55" },
       ])
     );
 
@@ -150,7 +149,7 @@ describe("Assets reducer", () => {
 
     expect(store.getState().assets).toEqual({
       balances: {
-        tez: { bar: new BigNumber("44"), baz: new BigNumber("55") },
+        tez: { bar: "44", baz: "55" },
         tokens: { baz: [{}, {}] },
       },
       conversionRate: null,
@@ -166,8 +165,8 @@ describe("Assets reducer", () => {
   test("updating network resets operations and balances", () => {
     store.dispatch(
       update([
-        { pkh: "bar", tez: new BigNumber(44) },
-        { pkh: "baz", tez: new BigNumber(55) },
+        { pkh: "bar", tez: "44" },
+        { pkh: "baz", tez: "55" },
       ])
     );
 
@@ -182,7 +181,7 @@ describe("Assets reducer", () => {
 
     expect(store.getState().assets).toEqual({
       balances: {
-        tez: { bar: new BigNumber("44"), baz: new BigNumber("55") },
+        tez: { bar: "44", baz: "55" },
         tokens: { foo: [{}, {}] },
       },
       conversionRate: null,
@@ -211,8 +210,8 @@ describe("Assets reducer", () => {
   test("reseting accounts resets assetsState", () => {
     store.dispatch(
       update([
-        { pkh: "bar", tez: new BigNumber(44) },
-        { pkh: "baz", tez: new BigNumber(55) },
+        { pkh: "bar", tez: "44" },
+        { pkh: "baz", tez: "55" },
       ])
     );
 
@@ -227,7 +226,7 @@ describe("Assets reducer", () => {
 
     expect(store.getState().assets).toEqual({
       balances: {
-        tez: { bar: new BigNumber("44"), baz: new BigNumber("55") },
+        tez: { bar: "44", baz: "55" },
         tokens: { foo: [{}, {}] },
       },
       conversionRate: null,
@@ -389,9 +388,9 @@ describe("Assets reducer", () => {
   describe("Batch", () => {
     test("Adding operations to batch starts an estimation and updates the given account's batch with the result", async () => {
       const mockEstimations = [
-        { suggestedFeeMutez: new BigNumber(323) },
-        { suggestedFeeMutez: new BigNumber(423) },
-        { suggestedFeeMutez: new BigNumber(523) },
+        { suggestedFeeMutez: "323" },
+        { suggestedFeeMutez: "423" },
+        { suggestedFeeMutez: "523" },
       ];
 
       estimateBatchMock.mockResolvedValueOnce(mockEstimations);
@@ -440,7 +439,7 @@ describe("Assets reducer", () => {
     });
 
     test("Batches can be cleared for a given account", async () => {
-      const mockEstimations = [{ suggestedFeeMutez: new BigNumber(323) }];
+      const mockEstimations = [{ suggestedFeeMutez: "323" }];
 
       estimateBatchMock.mockResolvedValueOnce(mockEstimations);
 
@@ -499,9 +498,9 @@ describe("Assets reducer", () => {
 
     test("Running a concurrent estimation for a given account is not possible", async () => {
       const mockEstimations = [
-        { suggestedFeeMutez: new BigNumber(323) },
-        { suggestedFeeMutez: new BigNumber(423) },
-        { suggestedFeeMutez: new BigNumber(523) },
+        { suggestedFeeMutez: "323" },
+        { suggestedFeeMutez: "423" },
+        { suggestedFeeMutez: "523" },
       ];
 
       estimateBatchMock.mockResolvedValueOnce(mockEstimations);
@@ -550,9 +549,9 @@ describe("Assets reducer", () => {
 
     test("You can't add an empty list of operations to a batch", async () => {
       const mockEstimations = [
-        { suggestedFeeMutez: new BigNumber(323) },
-        { suggestedFeeMutez: new BigNumber(423) },
-        { suggestedFeeMutez: new BigNumber(523) },
+        { suggestedFeeMutez: "323" },
+        { suggestedFeeMutez: "423" },
+        { suggestedFeeMutez: "523" },
       ];
 
       estimateBatchMock.mockResolvedValueOnce(mockEstimations);
@@ -575,9 +574,9 @@ describe("Assets reducer", () => {
 
     test("Batch can't be cleared for a given account if simulation is ongoing for a given account", async () => {
       const mockEstimations = [
-        { suggestedFeeMutez: new BigNumber(323) },
-        { suggestedFeeMutez: new BigNumber(423) },
-        { suggestedFeeMutez: new BigNumber(523) },
+        { suggestedFeeMutez: "323" },
+        { suggestedFeeMutez: "423" },
+        { suggestedFeeMutez: "523" },
       ];
 
       estimateBatchMock.mockResolvedValueOnce(mockEstimations);
@@ -586,7 +585,7 @@ describe("Assets reducer", () => {
       store.dispatch(
         updateBatch({
           pkh: mockPkh(1),
-          items: [{ fee: new BigNumber(3), operation: mockTezTransfer(3) }],
+          items: [{ fee: "3", operation: mockTezTransfer(3) }],
         })
       );
       const transfers = [
@@ -610,7 +609,7 @@ describe("Assets reducer", () => {
           isSimulating: false,
           items: [
             {
-              fee: new BigNumber(3),
+              fee: "3",
               operation: mockTezTransfer(3),
             },
             {

--- a/src/utils/beacon/BeaconNotification/BeaconRequestNotification.tsx
+++ b/src/utils/beacon/BeaconNotification/BeaconRequestNotification.tsx
@@ -14,7 +14,6 @@ import { walletClient } from "../beacon";
 import BeaconErrorPannel from "./pannels/BeaconErrorPannel";
 import PermissionRequestPannel from "./pannels/PermissionRequestPannel";
 import SignPayloadRequestPannel from "./pannels/SignPayloadRequestPannel";
-import { BigNumber } from "bignumber.js";
 
 export const BeaconNotification: React.FC<{
   message: BeaconRequestOutputMessage;
@@ -70,7 +69,7 @@ export const BeaconNotification: React.FC<{
             mode={{ type: transfer.type }}
             recipient={transfer.value.recipient}
             sender={transfer.value.sender}
-            amount={transfer.value.amount.toString()}
+            amount={transfer.value.amount}
             parameter={transfer.value.parameter}
           />
         );
@@ -107,7 +106,7 @@ const buildTransfer = (o: OperationRequestOutput) => {
     const result: OperationValue = {
       type: "tez",
       value: {
-        amount: new BigNumber(operation.amount),
+        amount: operation.amount,
         sender: o.sourceAddress,
         recipient: operation.destination,
         parameter: operation.parameters,

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -12,7 +12,8 @@ export const truncate = (name: string, len: number) => {
 export const tezToMutez = (tez: string): BigNumber =>
   format("tz", "mutez", tez) as BigNumber;
 
-export const mutezToTez = (m: BigNumber) => format("mutez", "tz", m) as string;
+export const mutezToTez = (m: BigNumber | string) =>
+  format("mutez", "tz", m) as string;
 
-export const prettyTezAmount = (a: BigNumber, isTez = false) =>
+export const prettyTezAmount = (a: BigNumber | string, isTez = false) =>
   `${String(isTez ? a : format("mutez", "tz", a))} ꜩ`;

--- a/src/utils/hooks/accountUtils.test.ts
+++ b/src/utils/hooks/accountUtils.test.ts
@@ -4,9 +4,9 @@ import { getTotalBalance } from "./accountUtils";
 describe("getTotalBalance", () => {
   test("getTotalBalance returns the right value", () => {
     const result = getTotalBalance({
-      foo: new BigNumber(40),
+      foo: "40",
       bar: null,
-      baz: new BigNumber(60),
+      baz: "60",
     });
 
     expect(result).toEqual(new BigNumber(100));

--- a/src/utils/hooks/accountUtils.ts
+++ b/src/utils/hooks/accountUtils.ts
@@ -4,14 +4,16 @@ import { decrypt } from "../aes";
 import { deriveSkFromMnemonic } from "../restoreAccounts";
 import { useAppSelector } from "../store/hooks";
 
-export const getTotalBalance = (balances: Record<string, BigNumber | null>) => {
-  const totalMutez = Object.values(balances).reduce((acc, curr) => {
-    if (acc === null) {
-      return curr;
-    } else {
-      return curr === null ? acc : BigNumber.sum(curr, acc);
-    }
-  }, null);
+export const getTotalBalance = (balances: Record<string, string | null>) => {
+  const totalMutez = Object.values(balances)
+    .map((b) => b && new BigNumber(b))
+    .reduce((acc, curr) => {
+      if (acc === null) {
+        return curr;
+      } else {
+        return curr === null ? acc : BigNumber.sum(curr, acc);
+      }
+    }, null);
 
   return totalMutez;
 };

--- a/src/utils/store/assetsSlice.ts
+++ b/src/utils/store/assetsSlice.ts
@@ -2,14 +2,13 @@ import { TezosNetwork } from "@airgap/tezos";
 import { createSlice } from "@reduxjs/toolkit";
 import { DelegationOperation } from "@tzkt/sdk-api";
 
-import BigNumber from "bignumber.js";
 import { OperationValue } from "../../components/sendForm/types";
 import { Baker } from "../../types/Baker";
 import { TezTransfer, TokenTransfer } from "../../types/Operation";
 import { Token } from "../../types/Token";
 import accountsSlice from "./accountsSlice";
 
-export type BatchItem = { operation: OperationValue; fee: BigNumber };
+export type BatchItem = { operation: OperationValue; fee: string };
 export type Batch = {
   isSimulating: boolean;
   items: Array<BatchItem>;
@@ -24,7 +23,7 @@ type State = {
   network: TezosNetwork;
   blockLevel: number | null;
   balances: {
-    tez: Record<string, BigNumber | null>;
+    tez: Record<string, string | null>;
     tokens: Record<string, Token[]>;
   };
   operations: {
@@ -37,7 +36,7 @@ type State = {
   batches: Record<string, Batch | undefined>;
 };
 
-export type TezBalancePayload = { pkh: string; tez: BigNumber };
+export type TezBalancePayload = { pkh: string; tez: string };
 export type TokenBalancePayload = { pkh: string; tokens: Token[] };
 export type TezTransfersPayload = {
   pkh: string;

--- a/src/utils/store/store.ts
+++ b/src/utils/store/store.ts
@@ -30,7 +30,6 @@ export const store = configureStore({
   // https://stackoverflow.com/a/71955602/6797267
   middleware: (getDefaultMiddleware) =>
     getDefaultMiddleware({
-      serializableCheck: false,
       thunk: {
         extraArgument,
       },

--- a/src/utils/store/thunks/estimateAndupdateBatch.ts
+++ b/src/utils/store/thunks/estimateAndupdateBatch.ts
@@ -5,7 +5,6 @@ import { zip } from "../../helpers";
 import { estimateBatch } from "../../tezos";
 import assetsSlice, { BatchItem } from "../assetsSlice";
 import { RootState } from "../store";
-import { BigNumber } from "bignumber.js";
 
 const {
   updateBatch: addToBatch,
@@ -34,7 +33,7 @@ export const estimateAndUpdateBatch = (
       const estimations = await estimateBatch(operations, pkh, pk, network);
       const items: BatchItem[] = zip(operations, estimations).map(([o, e]) => {
         return {
-          fee: new BigNumber(e.suggestedFeeMutez),
+          fee: String(e.suggestedFeeMutez),
           operation: o,
         };
       });

--- a/src/utils/tezos/operations.ts
+++ b/src/utils/tezos/operations.ts
@@ -13,7 +13,6 @@ import {
 import { SignerConfig } from "../../types/SignerConfig";
 import { operationValuesToWalletParams } from "./params";
 import { FA12TransferMethodArgs, FA2TransferMethodArgs } from "./types";
-import { BigNumber } from "bignumber.js";
 
 export const delegate = async (
   senderPkh: string,
@@ -47,14 +46,14 @@ export const transferFA12Token = async (
 
 export const transferMutez = async (
   recipient: string,
-  amount: BigNumber,
+  amount: number,
   config: SignerConfig,
   parameter?: TransferParams["parameter"]
 ): Promise<TransactionOperation> => {
   const Tezos = await makeToolkitWithSigner(config);
   return Tezos.contract.transfer({
     to: recipient,
-    amount: amount.toNumber(),
+    amount: amount,
     parameter,
     mutez: true,
   });

--- a/src/utils/tezos/params.ts
+++ b/src/utils/tezos/params.ts
@@ -34,7 +34,7 @@ export const operationValuesToParams = async (
         result.push({
           kind: OpKind.TRANSACTION,
           to: operation.value.recipient,
-          amount: operation.value.amount.toNumber(),
+          amount: parseInt(operation.value.amount),
           parameter: operation.value.parameter,
           mutez: true,
         });

--- a/src/utils/tezos/types.ts
+++ b/src/utils/tezos/types.ts
@@ -1,11 +1,9 @@
-import type { BigNumber } from "bignumber.js";
-
 export type FA2TransferMethodArgs = {
   sender: string;
   recipient: string;
   contract: string;
   tokenId: string;
-  amount: BigNumber;
+  amount: string;
 };
 
 export type FA12TransferMethodArgs = Omit<FA2TransferMethodArgs, "tokenId">;

--- a/src/utils/useAssetsPolling.ts
+++ b/src/utils/useAssetsPolling.ts
@@ -32,7 +32,7 @@ const getBalancePayload = async (
   network: TezosNetwork
 ): Promise<TezBalancePayload> => {
   const tez = await getBalance(pkh, network);
-  return { pkh, tez };
+  return { pkh, tez: tez.toString() };
 };
 
 const getTokensPayload = async (

--- a/src/views/batch/BatchDisplay.tsx
+++ b/src/views/batch/BatchDisplay.tsx
@@ -44,7 +44,7 @@ const renderAmount = (operation: OperationValue) => {
         operation.data instanceof NFT
           ? operation.data.balance
           : formatTokenAmount(
-              `${operation.value.amount}`,
+              operation.value.amount,
               operation.data.metadata?.decimals
             );
       return (
@@ -85,12 +85,12 @@ const RightPanel = ({
   return (
     <Flex bg="umami.gray.800" w={292} p={4} flexDirection="column">
       <Box flex={1}>
-        <Subtotal mutez={subTotal} marginY={4} />
-        <Fee mutez={fee} />
+        <Subtotal mutez={subTotal.toString()} marginY={4} />
+        <Fee mutez={fee.toString()} />
       </Box>
       <Box>
         <Divider />
-        <Total mutez={total} paddingY={3} />
+        <Total mutez={total.toString()} paddingY={3} />
 
         <Flex justifyContent={"space-between"}>
           <Button

--- a/src/views/batch/BatchView.test.tsx
+++ b/src/views/batch/BatchView.test.tsx
@@ -22,7 +22,6 @@ import { store } from "../../utils/store/store";
 import { estimateAndUpdateBatch } from "../../utils/store/thunks/estimateAndupdateBatch";
 import { estimateBatch, submitBatch } from "../../utils/tezos";
 import BatchView from "./BatchView";
-import { BigNumber } from "bignumber.js";
 
 // TODO refactor mocks
 jest.mock("react-router-dom");
@@ -123,7 +122,7 @@ const addItemsToBatchViaStore = async () => {
           value: {
             sender: mockAccount(1).pkh,
             recipient: mockPkh(1),
-            amount: new BigNumber(1000000),
+            amount: "1000000",
           },
         },
         {
@@ -131,7 +130,7 @@ const addItemsToBatchViaStore = async () => {
           value: {
             sender: mockAccount(1).pkh,
             recipient: mockPkh(2),
-            amount: new BigNumber(2000000),
+            amount: "2000000",
           },
         },
         {
@@ -139,7 +138,7 @@ const addItemsToBatchViaStore = async () => {
           value: {
             sender: mockAccount(1).pkh,
             recipient: mockPkh(3),
-            amount: new BigNumber(3000000),
+            amount: "3000000",
           },
         },
       ],
@@ -158,7 +157,7 @@ const addItemsToBatchViaStore = async () => {
           value: {
             sender: mockAccount(2).pkh,
             recipient: mockPkh(9),
-            amount: new BigNumber(4),
+            amount: "4",
           },
         },
         {
@@ -166,7 +165,7 @@ const addItemsToBatchViaStore = async () => {
           value: {
             sender: mockAccount(2).pkh,
             recipient: mockPkh(4),
-            amount: new BigNumber(5),
+            amount: "5",
           },
         },
         {
@@ -174,7 +173,7 @@ const addItemsToBatchViaStore = async () => {
           value: {
             sender: mockAccount(2).pkh,
             recipient: mockPkh(5),
-            amount: new BigNumber(6),
+            amount: "6",
           },
         },
       ],
@@ -294,7 +293,7 @@ describe("<BatchView />", () => {
           {
             type: "tez",
             value: {
-              amount: new BigNumber(1000000),
+              amount: "1000000",
               recipient: mockPkh(1),
               sender: mockPkh(1),
             },
@@ -302,7 +301,7 @@ describe("<BatchView />", () => {
           {
             type: "tez",
             value: {
-              amount: new BigNumber(2000000),
+              amount: "2000000",
               recipient: mockPkh(2),
               sender: mockPkh(1),
             },
@@ -310,7 +309,7 @@ describe("<BatchView />", () => {
           {
             type: "tez",
             value: {
-              amount: new BigNumber(3000000),
+              amount: "3000000",
               recipient: mockPkh(3),
               sender: mockPkh(1),
             },

--- a/src/views/batch/batchUtils.ts
+++ b/src/views/batch/batchUtils.ts
@@ -14,7 +14,7 @@ export const getBatchSubtotal = (ops: OperationValue[]) => {
   const subTotal = ops.reduce((acc, curr) => {
     switch (curr.type) {
       case "tez":
-        return acc.plus(curr.value.amount);
+        return acc.plus(new BigNumber(curr.value.amount));
       default:
         return acc;
     }

--- a/src/views/home/AccountsList.tsx
+++ b/src/views/home/AccountsList.tsx
@@ -7,7 +7,6 @@ import {
   useDisclosure,
   useToast,
 } from "@chakra-ui/react";
-import BigNumber from "bignumber.js";
 import { useRef, useState } from "react";
 import { BsWindowPlus } from "react-icons/bs";
 import AccountTile from "../../components/AccountTile";
@@ -49,7 +48,7 @@ const Header = () => {
 const AccountGroup: React.FC<{
   accounts: AccountsOfSameType;
   groupLabel: string;
-  balances: Record<string, BigNumber | null>;
+  balances: Record<string, string | null>;
   onSelect: (pkh: string) => void;
   selected: string | null;
   onDelete?: () => void;


### PR DESCRIPTION
## Proposed changes

Since we cannot store any classes in localStorage we must not have them in our state variables. I enabled the check that will scream at us if we try to pass in any class instances.
That means that we cannot store BigNumber's in any state related variables. So I replaced them with their string representations. But anywhere where we need to calculate anything we should convert them back to BigNumber.

## Types of changes

_Put an `x` in the boxes that apply_

- [x] Bugfix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation Update