### PR TITLE
Implement support for delegations with Beacon

### DIFF
--- a/src/components/sendForm/steps/FillStep.tsx
+++ b/src/components/sendForm/steps/FillStep.tsx
@@ -34,12 +34,14 @@ export const DelegateForm = ({
   undelegate = false,
   sender,
   recipient,
+  disabled = false,
 }: {
   isLoading: boolean;
   onSubmit: (a: { sender: string; baker?: string }) => void;
   undelegate?: boolean;
   sender?: string;
   recipient?: string;
+  disabled?: boolean;
 }) => {
   const { formState, control, handleSubmit } = useForm<{
     sender: string;
@@ -65,7 +67,7 @@ export const DelegateForm = ({
               name="sender"
               render={({ field: { onChange, onBlur, value, ref } }) => (
                 <ConnectedAccountSelector
-                  isDisabled={undelegate}
+                  isDisabled={undelegate || disabled}
                   selected={value}
                   onSelect={(a) => {
                     onChange(a.pkh);
@@ -82,12 +84,11 @@ export const DelegateForm = ({
                 rules={{ required: true }}
                 control={control}
                 name="baker"
-                render={({ field: { onChange, onBlur, value, ref } }) => (
+                render={({ field: { onChange, value } }) => (
                   <BakerSelector
+                    disabled={disabled}
                     selected={value}
-                    onSelect={(bakerAddress) => {
-                      onChange(bakerAddress);
-                    }}
+                    onSelect={onChange}
                   />
                 )}
               />
@@ -315,6 +316,7 @@ export const FillStep: React.FC<{
     case "delegation":
       return (
         <DelegateForm
+          disabled={disabled}
           sender={sender}
           recipient={recipient}
           undelegate={mode.data?.undelegate}

--- a/src/components/sendForm/types.ts
+++ b/src/components/sendForm/types.ts
@@ -24,28 +24,34 @@ type BatchMode = {
 };
 export type SendFormMode = TezMode | TokenMode | DelegationMode | BatchMode;
 
+type TezOperation = TezMode & {
+  value: {
+    amount: string;
+    sender: string;
+    recipient: string;
+    parameter?: TransferParams["parameter"];
+  };
+};
+
+type TokenOperation = TokenMode & {
+  value: {
+    amount: string;
+    sender: string;
+    recipient: string;
+  };
+};
+
+type DelegationOperation = DelegationMode & {
+  value: {
+    sender: string;
+    recipient?: string;
+  };
+};
+
 export type OperationValue =
-  | (TezMode & {
-      value: {
-        amount: string;
-        sender: string;
-        recipient: string;
-        parameter?: TransferParams["parameter"];
-      };
-    })
-  | (TokenMode & {
-      value: {
-        amount: string;
-        sender: string;
-        recipient: string;
-      };
-    })
-  | (DelegationMode & {
-      value: {
-        sender: string;
-        recipient?: string;
-      };
-    });
+  | TezOperation
+  | TokenOperation
+  | DelegationOperation;
 
 export type EstimatedOperation = {
   operation: OperationValue | OperationValue[];

--- a/src/mocks/beacon.ts
+++ b/src/mocks/beacon.ts
@@ -30,3 +30,27 @@ export const objectOperationRequest: OperationRequestOutput = {
   ],
   sourceAddress: "tz1Te4MXuNYxyyuPqmAQdnKwkD8ZgSF9M7d6",
 };
+
+export const mockBeaconDelegate = "KT1WvzYHCNBvDSdwafTHv7nJ1dWmZ8GCYuuC";
+export const objectOperationDelegationRequest: OperationRequestOutput = {
+  appMetadata: {
+    senderId: "id1",
+    name: "some baker",
+    icon: "http://mock",
+  },
+  id: "id2",
+  version: "2",
+  senderId: "id3",
+  type: BeaconMessageType.OperationRequest,
+  network: { type: NetworkType.MAINNET },
+  operationDetails: [
+    {
+      kind: TezosOperationType.DELEGATION,
+      storage_limit: "350",
+      delegate: mockBeaconDelegate,
+      fee: "3",
+      gas_limit: "33",
+    },
+  ],
+  sourceAddress: "tz1Te4MXuNYxyyuPqmAQdnKwkD8ZgSF9M7d6",
+};

--- a/src/views/delegations/BakerSelector.tsx
+++ b/src/views/delegations/BakerSelector.tsx
@@ -5,7 +5,7 @@ import { Baker } from "../../types/Baker";
 import { useAppSelector } from "../../utils/store/hooks";
 import { BakerSmallTile } from "./BakerSmallTile";
 
-const renderBaker = (baker: Baker) => (
+const renderBakerTile = (baker: Baker) => (
   <BakerSmallTile
     pkh={baker.address}
     label={baker.name}
@@ -13,19 +13,27 @@ const renderBaker = (baker: Baker) => (
   />
 );
 
+const renderBaker = (bakers: Baker[], selected: string) => {
+  const referencedBaker = bakers.find((b) => b.address === selected);
+
+  if (!referencedBaker) {
+    return <BakerSmallTile pkh={selected} />;
+  }
+
+  return renderBakerTile(referencedBaker);
+};
+
 export const BakerSelector: React.FC<{
   onSelect: (a: string) => void;
   selected?: string;
-  isDisabled?: boolean;
-}> = ({ onSelect = () => {}, selected, isDisabled }) => {
+  disabled?: boolean;
+}> = ({ onSelect = () => {}, selected, disabled }) => {
   const bakers = useAppSelector((s) => s.assets.bakers);
-
-  const selectedBaker = bakers.find((b) => b.address === selected);
 
   return (
     <Menu>
       <MenuButton
-        isDisabled={isDisabled}
+        isDisabled={disabled}
         data-testid="baker-selector"
         w={"100%"}
         textAlign="left"
@@ -33,7 +41,9 @@ export const BakerSelector: React.FC<{
         rightIcon={<ChevronDownIcon />}
         h={16}
       >
-        {selectedBaker ? renderBaker(selectedBaker) : "Select a baker"}
+        {selected === undefined
+          ? "Select a Baker"
+          : renderBaker(bakers, selected)}
       </MenuButton>
       <MenuList bg={"umami.gray.900"} maxH={40} overflow={"scroll"}>
         {bakers.map((baker) => (
@@ -48,7 +58,7 @@ export const BakerSelector: React.FC<{
             // TODO implement hover color that disapeared
             bg={"umami.gray.900"}
           >
-            {renderBaker(baker)}
+            {renderBakerTile(baker)}
           </MenuItem>
         ))}
       </MenuList>


### PR DESCRIPTION
## Proposed changes

[Task link](https://app.asana.com/0/1204165186238194/1204185495676081/f)

Handle Operation Requests for delegations

We now get a delegation popup when Beacon sends us a delegation operation request.
Everything looks the same as the nominal case for delegations except that inputs are disabled.

## Types of changes

_Put an `x` in the boxes that apply_

- [ ] Bugfix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation Update

## Steps to reproduce

- step one
- step two
- step three



## Checklist

- [x] Tests that prove my fix is effective or that my feature works have been added
- [ ] Documentation has been added (if appropriate)
- [ ] Screenshots are added (if any UI changes have been made)
- [ ] All TODOs have a corresponding task created (and the link is attached to it)
