### PR TITLE
Convert Asset class to plain objects

### DIFF
--- a/src/components/AccountCard.tsx/AssetsPannel/TokenTile.tsx
+++ b/src/components/AccountCard.tsx/AssetsPannel/TokenTile.tsx
@@ -1,16 +1,24 @@
 import { Box, Flex, Heading, Icon, Image, Text } from "@chakra-ui/react";
 import { MdGeneratingTokens } from "react-icons/md";
-import { FA12Token, FA2Token } from "../../../types/Asset";
+import {
+  FA12Token,
+  FA2Token,
+  httpIconUri,
+  tokenName,
+  tokenPrettyBalance,
+  tokenSymbol,
+} from "../../../types/Asset";
 
 const TokenTile = ({ token }: { token: FA12Token | FA2Token }) => {
-  const name = token.name();
-  const symbol = token.symbol();
-  const prettyAmount = token.prettyBalance({ showSymbol: false });
+  const name = tokenName(token);
+  const symbol = tokenSymbol(token);
+  const iconUri = httpIconUri(token);
+  const prettyAmount = tokenPrettyBalance(token, { showSymbol: false });
   return (
     <Flex justifyContent={"space-around"} mb={2} data-testid="token-tile">
       <Flex flex={1}>
-        {token.iconUri() ? (
-          <Image src={token.iconUri()} w={8} h={8} />
+        {iconUri ? (
+          <Image src={iconUri} w={8} h={8} />
         ) : (
           <Icon h={8} w={8} as={MdGeneratingTokens} />
         )}

--- a/src/components/CSVFileUploader/utils.test.ts
+++ b/src/components/CSVFileUploader/utils.test.ts
@@ -2,7 +2,7 @@ import { mockContract, mockPkh } from "../../mocks/factories";
 import { csvRowToOperationValue, parseToCSVRow } from "./utils";
 import { CSVRow } from "./types";
 import { ghostFA12, ghostFA2, ghostTezzard } from "../../mocks/tokens";
-import { FA12Token, FA2Token, NFT } from "../../types/Asset";
+import type { NFT } from "../../types/Asset";
 
 describe("csv utils", () => {
   test("parse valid csv rows", async () => {
@@ -97,7 +97,7 @@ describe("csv utils", () => {
     });
     expect(res).toEqual({
       type: "token",
-      data: new FA12Token(ghostFA12.contract, ghostFA12.balance),
+      data: ghostFA12,
       value: {
         amount: "100000000",
         recipient: mockPkh(1),
@@ -119,12 +119,7 @@ describe("csv utils", () => {
     });
     expect(res).toEqual({
       type: "token",
-      data: new FA2Token(
-        ghostFA2.contract,
-        ghostFA2.tokenId,
-        ghostFA2.balance,
-        ghostFA2.metadata
-      ),
+      data: ghostFA2,
       value: {
         amount: "100000",
         recipient: mockPkh(1),
@@ -135,7 +130,7 @@ describe("csv utils", () => {
 
   test("converts NFT CSVFA2TransferRow to OperationValue", () => {
     const ghostTezzard1 = ghostTezzard;
-    const ghostTezzard2 = { ...ghostTezzard, tokenId: "8" } as NFT;
+    const ghostTezzard2: NFT = { ...ghostTezzard, tokenId: "8" };
     const mockCSVFA2TransferRow = {
       type: "fa2",
       recipient: mockPkh(1),
@@ -148,13 +143,10 @@ describe("csv utils", () => {
     });
     expect(res).toEqual({
       type: "token",
-      data: new NFT(
-        ghostTezzard1.contract,
-        ghostTezzard1.tokenId,
-        ghostTezzard1.balance,
-        ghostTezzard1.owner,
-        ghostTezzard1.metadata
-      ),
+      data: {
+        ...ghostTezzard1,
+        type: "nft",
+      },
       value: {
         amount: "1",
         recipient: mockPkh(1),

--- a/src/components/CSVFileUploader/utils.ts
+++ b/src/components/CSVFileUploader/utils.ts
@@ -1,5 +1,5 @@
 import { validateAddress, ValidationResult } from "@taquito/utils";
-import { Asset, FA12Token, FA2Token } from "../../types/Asset";
+import { Asset, getRealAmount } from "../../types/Asset";
 import { tezToMutez } from "../../utils/format";
 import { validateNonNegativeNumber } from "../../utils/helpers";
 import { OperationValue } from "../sendForm/types";
@@ -71,8 +71,7 @@ export const csvRowToOperationValue = (
       ? assets[0]
       : assets.find(
           (asset) =>
-            !(asset instanceof FA12Token) &&
-            (asset as FA2Token).tokenId === `${csvRow.tokenId}`
+            !(asset.type === "fa1.2") && asset.tokenId === `${csvRow.tokenId}`
         );
 
   if (!asset) {
@@ -81,7 +80,7 @@ export const csvRowToOperationValue = (
 
   if (
     csvRow.contract !== asset.contract ||
-    (asset instanceof FA12Token && csvRow.type !== "fa1.2")
+    (asset.type === "fa1.2" && csvRow.type !== "fa1.2")
   ) {
     throw new Error(`Inconsistent csv value for token ${csvRow.contract}`);
   }
@@ -91,7 +90,7 @@ export const csvRowToOperationValue = (
     value: {
       sender,
       recipient,
-      amount: asset.getRealAmount(csvRow.prettyAmount).toString(),
+      amount: getRealAmount(asset, csvRow.prettyAmount).toString(),
     },
   };
 };

--- a/src/components/sendForm/SendForm.test.tsx
+++ b/src/components/sendForm/SendForm.test.tsx
@@ -278,10 +278,16 @@ describe("<SendForm />", () => {
     const MOCK_TOKEN_SYMBOL = "FOO";
     const MOCK_TOKEN_ID = "7";
     const MOCK_FEE = 3122;
-    const mockFA2 = new FA2Token(mockContract(2), MOCK_TOKEN_ID, "14760000", {
-      symbol: MOCK_TOKEN_SYMBOL,
-      decimals: "5",
-    });
+    const mockFA2: FA2Token = {
+      type: "fa2",
+      contract: mockContract(2),
+      tokenId: MOCK_TOKEN_ID,
+      balance: "14760000",
+      metadata: {
+        symbol: MOCK_TOKEN_SYMBOL,
+        decimals: "5",
+      },
+    };
     it("should display token name in amount input", () => {
       render(
         fixture(undefined, {
@@ -376,10 +382,15 @@ describe("<SendForm />", () => {
     const MOCK_TOKEN_SYMBOL = "FA1FOO";
     const MOCK_FEE = 4122;
 
-    const mockFa1 = new FA12Token(mockContract(2), "3", {
-      symbol: MOCK_TOKEN_SYMBOL,
-      decimals: "8",
-    });
+    const mockFa1: FA12Token = {
+      type: "fa1.2",
+      contract: mockContract(2),
+      balance: "3",
+      metadata: {
+        symbol: MOCK_TOKEN_SYMBOL,
+        decimals: "8",
+      },
+    };
     it("should display token name in amount input", () => {
       render(
         fixture(undefined, {

--- a/src/components/sendForm/SendForm.tsx
+++ b/src/components/sendForm/SendForm.tsx
@@ -18,7 +18,6 @@ import { RecapDisplay } from "./steps/SubmitStep";
 import { SuccessStep } from "./steps/SuccessStep";
 import { EstimatedOperation, SendFormMode, OperationValue } from "./types";
 import { BigNumber } from "bignumber.js";
-import { FA12Token, FA2Token } from "../../types/Asset";
 
 const makeSimulation = (
   operation: OperationValue,
@@ -41,14 +40,14 @@ const makeSimulation = (
         contract: operation.data.contract,
       };
 
-      if (operation.data instanceof FA12Token) {
+      if (operation.data.type === "fa1.2") {
         return estimateFA12transfer(base, pk, network);
       }
 
       return estimateFA2transfer(
         {
           ...base,
-          tokenId: (operation.data as FA2Token).tokenId,
+          tokenId: operation.data.tokenId,
         },
         pk,
         network

--- a/src/components/sendForm/steps/FillStep.tsx
+++ b/src/components/sendForm/steps/FillStep.tsx
@@ -19,7 +19,7 @@ import { TransferParams } from "@taquito/taquito";
 import { validateAddress, ValidationResult } from "@taquito/utils";
 import React from "react";
 import { Controller, useForm } from "react-hook-form";
-import { Asset, NFT } from "../../../types/Asset";
+import { Asset, getRealAmount, tokenSymbol } from "../../../types/Asset";
 import { tezToMutez } from "../../../utils/format";
 import { useBatchIsSimulating } from "../../../utils/hooks/assetsHooks";
 import { BakerSelector } from "../../../views/delegations/BakerSelector";
@@ -118,11 +118,11 @@ const getAmountSymbol = (asset?: Asset) => {
   if (!asset) {
     return "tez";
   }
-  if (asset instanceof NFT) {
+  if (asset.type === "nft") {
     return "editions";
   }
 
-  return asset.symbol();
+  return tokenSymbol(asset);
 };
 
 export const SendTezOrNFTForm = ({
@@ -150,7 +150,7 @@ export const SendTezOrNFTForm = ({
   amount?: string;
   parameter?: TransferParams["parameter"];
 }) => {
-  const isNFT = token instanceof NFT;
+  const isNFT = token?.type === "nft";
   const mandatoryNftSender = isNFT ? token?.owner : undefined;
   const getBatchIsSimulating = useBatchIsSimulating();
 
@@ -229,7 +229,7 @@ export const SendTezOrNFTForm = ({
             )}
           </FormControl>
 
-          {token instanceof NFT ? <SendNFTRecapTile nft={token} /> : null}
+          {isNFT ? <SendNFTRecapTile nft={token} /> : null}
 
           <FormControl mb={2} mt={2}>
             <FormLabel>Amount</FormLabel>
@@ -378,7 +378,7 @@ export const FillStep: React.FC<{
               type: "token",
               data: mode.data,
               value: {
-                amount: mode.data.getRealAmount(v.amount).toString(),
+                amount: getRealAmount(mode.data, v.amount).toString(),
                 sender: v.sender,
                 recipient: v.recipient,
               },
@@ -389,7 +389,7 @@ export const FillStep: React.FC<{
               type: "token",
               data: mode.data,
               value: {
-                amount: mode.data.getRealAmount(v.amount).toString(),
+                amount: getRealAmount(mode.data, v.amount).toString(),
                 sender: v.sender,
                 recipient: v.recipient,
               },

--- a/src/components/sendForm/steps/SubmitStep.tsx
+++ b/src/components/sendForm/steps/SubmitStep.tsx
@@ -36,8 +36,7 @@ import {
   TransactionsAmount,
 } from "../components/TezAmountRecaps";
 import { EstimatedOperation, OperationValue } from "../types";
-import { FA12Token, FA2Token, NFT } from "../../../types/Asset";
-import { BigNumber } from "bignumber.js";
+import BigNumber from "bignumber.js";
 
 const makeTransfer = async (
   operation: OperationValue | OperationValue[],
@@ -67,7 +66,7 @@ const makeTransfer = async (
       );
     case "token": {
       const token = operation.data;
-      if (token instanceof FA12Token) {
+      if (token.type === "fa1.2") {
         return await transferFA12Token(
           {
             amount: operation.value.amount,
@@ -84,7 +83,7 @@ const makeTransfer = async (
           contract: token.contract,
           recipient: operation.value.recipient,
           sender: operation.value.sender,
-          tokenId: (token as FA2Token).tokenId,
+          tokenId: token.tokenId,
         },
         config
       );
@@ -111,7 +110,7 @@ const NonBatchRecap = ({ transfer }: { transfer: OperationValue }) => {
             : renderAccountTile(transfer.value.recipient)}
         </Flex>
       )}
-      {token instanceof NFT && (
+      {token?.type === "nft" && (
         <Box mb={4}>
           <SendNFTRecapTile nft={token} />
         </Box>

--- a/src/mocks/factories.ts
+++ b/src/mocks/factories.ts
@@ -239,19 +239,20 @@ export const mockFA1Token = (
   };
 };
 
-export const mockNFT = (index: number, balance = "1") => {
-  return new NFT(
-    mockContract(index),
-    "mockId" + index,
+export const mockNFT = (index: number, balance = "1"): NFT => {
+  return {
+    type: "nft",
     balance,
-    mockPkh(index),
-    {
+    contract: mockContract(index),
+    tokenId: "mockId" + index,
+    owner: mockPkh(index),
+    metadata: {
       displayUri:
         "ipfs://zdj7Wk92xWxpzGqT6sE4cx7umUyWaX2Ck8MrSEmPAR31sNWG" + index,
       name: "Tezzardz #" + index,
       symbol: "FKR" + index,
-    }
-  );
+    },
+  };
 };
 
 export const mockBaker = (index: number) =>

--- a/src/mocks/tokens.ts
+++ b/src/mocks/tokens.ts
@@ -1,39 +1,42 @@
-import { FA12Token, FA2Token, NFT } from "../types/Asset";
+import type { FA12Token, FA2Token, NFT } from "../types/Asset";
 import { publicKeys1 } from "./publicKeys";
 
-export const ghostTezzard = new NFT(
-  "KT1GVhG7dQNjPAt4FNBNmc9P9zpiQex4Mxob",
-  "6",
-  "1",
-  publicKeys1.pkh,
-  {
+export const ghostTezzard: NFT = {
+  type: "nft",
+  contract: "KT1GVhG7dQNjPAt4FNBNmc9P9zpiQex4Mxob",
+  tokenId: "6",
+  balance: "1",
+  owner: publicKeys1.pkh,
+  metadata: {
     displayUri:
       "https://ipfs.io/ipfs/zdj7WWXMC8RpzC6RkR2DXtD2zcfLc2QWu6tu7f6vnkeeUvSoh",
     name: "Tezzardz #24",
     symbol: "FKR",
-  }
-);
+  },
+};
 
-export const ghostFA12 = new FA12Token(
-  "KT1UCPcXExqEYRnfoXWYvBkkn5uPjn8TBTEe",
-  "1"
-);
+export const ghostFA12: FA12Token = {
+  type: "fa1.2",
+  contract: "KT1UCPcXExqEYRnfoXWYvBkkn5uPjn8TBTEe",
+  balance: "1",
+};
 
 export const ghostFA12WithOwner = {
   ...ghostFA12,
   owner: publicKeys1.pkh,
 };
 
-export const ghostFA2 = new FA2Token(
-  "KT1XZoJ3PAidWVWRiKWESmPj64eKN7CEHuWZ",
-  "1",
-  "1",
-  {
+export const ghostFA2: FA2Token = {
+  type: "fa2",
+  contract: "KT1XZoJ3PAidWVWRiKWESmPj64eKN7CEHuWZ",
+  tokenId: "1",
+  balance: "1",
+  metadata: {
     name: "Klondike3",
     symbol: "KL3",
     decimals: "5",
-  }
-);
+  },
+};
 
 export const ghostFA2WithOwner = {
   ...ghostFA2,

--- a/src/types/Asset.test.tsx
+++ b/src/types/Asset.test.tsx
@@ -1,55 +1,68 @@
 import { tzBtsc, hedgeHoge } from "../mocks/fa12Tokens";
 import { uUSD } from "../mocks/fa2Tokens";
 import { fa1Token, fa2Token, nft } from "../mocks/tzktResponse";
-import { Asset, FA12Token, FA2Token, NFT } from "../types/Asset";
+import {
+  FA12Token,
+  FA2Token,
+  fromToken,
+  httpIconUri,
+  tokenName,
+  tokenSymbol,
+} from "../types/Asset";
 import type { TokenMetadata } from "./Token";
 
-describe("Asset.from", () => {
+describe("fromToken", () => {
   test("case fa1.2 valid", () => {
-    const result = Asset.from(fa1Token);
-    const expected = new FA12Token(
-      "KT1UCPcXExqEYRnfoXWYvBkkn5uPjn8TBTEe",
-      "443870"
-    );
+    const result = fromToken(fa1Token);
+    const expected = {
+      type: "fa1.2",
+      contract: "KT1UCPcXExqEYRnfoXWYvBkkn5uPjn8TBTEe",
+      balance: "443870",
+    };
     expect(result).toEqual(expected);
   });
 
-  test("case fa1.2 invalid (missing balance)", () => {
-    const result = Asset.from({ ...fa1Token, balance: null });
+  test("case fa1.2 with no balance", () => {
+    const result = fromToken({ ...fa1Token, balance: null });
     expect(result).toEqual(null);
   });
 
   test("case valid fa2 token", () => {
-    const result = Asset.from(fa2Token);
-    expect(result).toEqual(
-      new FA2Token("KT1XZoJ3PAidWVWRiKWESmPj64eKN7CEHuWZ", "1", "409412200", {
+    const result = fromToken(fa2Token);
+    expect(result).toEqual({
+      type: "fa2",
+      contract: "KT1XZoJ3PAidWVWRiKWESmPj64eKN7CEHuWZ",
+      tokenId: "1",
+      balance: "409412200",
+      metadata: {
         decimals: "5",
         name: "Klondike3",
         symbol: "KL3",
-      })
-    );
+      },
+    });
   });
 
   test("case invalid fa2 token (missing tokenId)", () => {
-    const result = Asset.from({ ...fa2Token, token: { tokenId: undefined } });
+    const result = fromToken({ ...fa2Token, token: { tokenId: undefined } });
 
     expect(result).toEqual(null);
   });
 
   test("case valid nft", () => {
-    const result = Asset.from(nft);
-    const expected = new NFT(
-      "KT1GVhG7dQNjPAt4FNBNmc9P9zpiQex4Mxob",
-      "3",
-      "0",
-      "tz1UNer1ijeE9ndjzSszRduR3CzX49hoBUB3",
-      nft.token?.metadata as TokenMetadata
-    );
+    const result = fromToken(nft);
+    const expected = {
+      type: "nft",
+      contract: "KT1GVhG7dQNjPAt4FNBNmc9P9zpiQex4Mxob",
+      tokenId: "3",
+      balance: "0",
+      owner: "tz1UNer1ijeE9ndjzSszRduR3CzX49hoBUB3",
+      metadata: nft.token?.metadata as TokenMetadata,
+    };
     expect(result).toEqual(expected);
   });
 
   test("case invalid nft (missing contract address)", () => {
-    const result = Asset.from({
+    const result = fromToken({
       ...nft,
       token: { contract: { address: null } },
     });
@@ -58,238 +71,157 @@ describe("Asset.from", () => {
   });
 
   test("case fa1 token with name symbol and decimals (tzBTC)", () => {
-    const result = Asset.from(tzBtsc);
+    const result = fromToken(tzBtsc);
 
-    const expected = new FA12Token(
-      "KT1PWx2mnDueood7fEmfbBDKx1D9BAnnXitn",
-      "2205",
-      {
+    const expected = {
+      type: "fa1.2",
+      contract: "KT1PWx2mnDueood7fEmfbBDKx1D9BAnnXitn",
+      balance: "2205",
+      metadata: {
         decimals: "8",
         name: "tzBTC",
         symbol: "tzBTC",
-      }
-    );
+      },
+    };
     expect(result).toEqual(expected);
   });
 
   test("case fa1 token with name symbol decimals and icon (hedgeHoge)", () => {
-    const result = Asset.from(hedgeHoge);
+    const result = fromToken(hedgeHoge);
 
-    const expected = new FA12Token(
-      "KT1G1cCRNBgQ48mVDjopHjEmTN5Sbtar8nn9",
-      "10000000000",
-      {
+    const expected = {
+      type: "fa1.2",
+      contract: "KT1G1cCRNBgQ48mVDjopHjEmTN5Sbtar8nn9",
+      balance: "10000000000",
+      metadata: {
         decimals: "6",
         name: "Hedgehoge",
         symbol: "HEH",
         icon: "ipfs://QmXL3FZ5kcwXC8mdwkS1iCHS2qVoyg69ugBhU2ap8z1zcs",
-      }
-    );
+      },
+    };
     expect(result).toEqual(expected);
-    expect(result?.iconUri).toEqual(expected.iconUri);
   });
 
   test("case fa2 token with thumbnailUri (uUSD)", () => {
-    const result = Asset.from(uUSD);
-    const expected = new FA2Token(
-      "KT1QTcAXeefhJ3iXLurRt81WRKdv7YqyYFmo",
-      "0",
-      "19218750000",
-      {
+    const result = fromToken(uUSD);
+    const expected = {
+      type: "fa2",
+      contract: "KT1QTcAXeefhJ3iXLurRt81WRKdv7YqyYFmo",
+      tokenId: "0",
+      balance: "19218750000",
+      metadata: {
         decimals: "12",
         name: "youves uUSD",
         symbol: "uUSD",
         shouldPreferSymbol: true,
         thumbnailUri: "ipfs://QmbvhanNCxydZEbGu1RdqkG3LcpNGv7XYsCHgzWBXnmxRd",
-      }
-    );
+      },
+    };
 
     expect(result).toEqual(expected);
-    expect(result?.iconUri()).toEqual(
-      "https://ipfs.io/ipfs/QmbvhanNCxydZEbGu1RdqkG3LcpNGv7XYsCHgzWBXnmxRd"
-    );
   });
 });
 
-describe("FA12Token", () => {
-  describe("name", () => {
-    test("when metadata.name exists", () => {
-      const token = new FA12Token("KT1QTcAXeefhJ3iXLurRt81WRKdv7YqyYFmo", "1", {
+describe("tokenName", () => {
+  test("when metadata.name exists", () => {
+    const fa1token: FA12Token = {
+      type: "fa1.2",
+      contract: "KT1QTcAXeefhJ3iXLurRt81WRKdv7YqyYFmo",
+      balance: "1",
+    };
+    expect(tokenName(fa1token)).toEqual("FA1.2 token");
+    const fa1tokenWithName = {
+      ...fa1token,
+      metadata: {
         name: "some token name",
-      });
-      expect(token.name()).toEqual("some token name");
-    });
-    test("when metadata.name is empty we use the default name", () => {
-      const token = new FA12Token("KT1QTcAXeefhJ3iXLurRt81WRKdv7YqyYFmo", "1");
-      expect(token.name()).toEqual("FA1.2 token");
-    });
-  });
+      },
+    };
+    expect(tokenName(fa1tokenWithName)).toEqual("some token name");
 
-  describe("symbol", () => {
-    test("when metadata.symbol exists", () => {
-      const token = new FA12Token("KT1QTcAXeefhJ3iXLurRt81WRKdv7YqyYFmo", "1", {
+    const fa2token: FA2Token = {
+      type: "fa2",
+      contract: "KT1QTcAXeefhJ3iXLurRt81WRKdv7YqyYFmo",
+      balance: "1",
+      tokenId: "123",
+    };
+    expect(tokenName(fa2token)).toEqual("FA2 token");
+    const fa2tokenWithName = {
+      ...fa2token,
+      metadata: {
+        name: "some token name",
+      },
+    };
+    expect(tokenName(fa2tokenWithName)).toEqual("some token name");
+  });
+});
+
+describe("tokenSymbol", () => {
+  test("when metadata.symbol exists", () => {
+    const fa1token: FA12Token = {
+      type: "fa1.2",
+      contract: "KT1QTcAXeefhJ3iXLurRt81WRKdv7YqyYFmo",
+      balance: "1",
+    };
+    expect(tokenSymbol(fa1token)).toEqual("FA1.2");
+    const fa1tokenWithSymbol = {
+      ...fa1token,
+      metadata: {
         symbol: "some token symbol",
-      });
-      expect(token.symbol()).toEqual("some token symbol");
-    });
-    test("when metadata.symbol is empty we use the default symbol", () => {
-      const token = new FA12Token("KT1QTcAXeefhJ3iXLurRt81WRKdv7YqyYFmo", "1");
-      expect(token.symbol()).toEqual("FA1.2");
-    });
-  });
+      },
+    };
+    expect(tokenSymbol(fa1tokenWithSymbol)).toEqual("some token symbol");
 
-  describe("iconUri", () => {
-    test("when metadata.icon is not set it returns undefined", () => {
-      const token = new FA12Token("KT1QTcAXeefhJ3iXLurRt81WRKdv7YqyYFmo", "1");
-      expect(token.iconUri()).toBeUndefined();
-    });
-
-    test("when metadata.icon is set it returns modified ipfs link", () => {
-      const token = new FA12Token("KT1QTcAXeefhJ3iXLurRt81WRKdv7YqyYFmo", "1", {
-        icon: "ipfs://QmbvhanNCxydZEbGu1RdqkG3LcpNGv7XYsCHgzWBXnmxRd",
-      });
-      expect(token.iconUri()).toEqual(
-        "https://ipfs.io/ipfs/QmbvhanNCxydZEbGu1RdqkG3LcpNGv7XYsCHgzWBXnmxRd"
-      );
-    });
+    const fa2token: FA2Token = {
+      type: "fa2",
+      contract: "KT1QTcAXeefhJ3iXLurRt81WRKdv7YqyYFmo",
+      balance: "1",
+      tokenId: "123",
+    };
+    expect(tokenSymbol(fa2token)).toEqual("FA2");
+    const fa2tokenWithSymbol = {
+      ...fa2token,
+      metadata: {
+        symbol: "some token symbol",
+      },
+    };
+    expect(tokenSymbol(fa2tokenWithSymbol)).toEqual("some token symbol");
   });
 });
 
-describe("FA2Token", () => {
-  describe("name", () => {
-    test("when metadata.name exists", () => {
-      const token = new FA2Token(
-        "KT1QTcAXeefhJ3iXLurRt81WRKdv7YqyYFmo",
-        "1",
-        "1",
-        {
-          name: "some token name",
-        }
-      );
-      expect(token.name()).toEqual("some token name");
-    });
-    test("when metadata.name is empty we use the default name", () => {
-      const token = new FA2Token(
-        "KT1QTcAXeefhJ3iXLurRt81WRKdv7YqyYFmo",
-        "1",
-        "1",
-        {}
-      );
-      expect(token.name()).toEqual("FA2 token");
-    });
-  });
+describe("httpIconUri", () => {
+  test("when metadata.symbol exists", () => {
+    const fa1token: FA12Token = {
+      type: "fa1.2",
+      contract: "KT1QTcAXeefhJ3iXLurRt81WRKdv7YqyYFmo",
+      balance: "1",
+    };
+    expect(httpIconUri(fa1token)).toEqual(undefined);
+    const fa1tokenWithIcon = {
+      ...fa1token,
+      metadata: {
+        icon: "ipfs://QmXL3FZ5kcwXC8mdwkS1iCHS2qVoyg69ugBhU2ap8z1zcs",
+      },
+    };
+    expect(httpIconUri(fa1tokenWithIcon)).toEqual(
+      "https://ipfs.io/ipfs/QmXL3FZ5kcwXC8mdwkS1iCHS2qVoyg69ugBhU2ap8z1zcs"
+    );
 
-  describe("symbol", () => {
-    test("when metadata.symbol exists", () => {
-      const token = new FA2Token(
-        "KT1QTcAXeefhJ3iXLurRt81WRKdv7YqyYFmo",
-        "1",
-        "1",
-        {
-          symbol: "some token symbol",
-        }
-      );
-      expect(token.symbol()).toEqual("some token symbol");
-    });
-    test("when metadata.symbol is empty we use the default symbol", () => {
-      const token = new FA2Token(
-        "KT1QTcAXeefhJ3iXLurRt81WRKdv7YqyYFmo",
-        "1",
-        "1",
-        {}
-      );
-      expect(token.symbol()).toEqual("FA2");
-    });
-  });
-
-  describe("iconUri", () => {
-    test("when metadata.thumbnailUri is not set it returns undefined", () => {
-      const token = new FA2Token(
-        "KT1QTcAXeefhJ3iXLurRt81WRKdv7YqyYFmo",
-        "1",
-        "2",
-        {}
-      );
-      expect(token.iconUri()).toBeUndefined();
-    });
-
-    test("when metadata.thumbnailUri is set it returns modified ipfs link", () => {
-      const token = new FA2Token(
-        "KT1QTcAXeefhJ3iXLurRt81WRKdv7YqyYFmo",
-        "1",
-        "2",
-        {
-          thumbnailUri: "ipfs://QmbvhanNCxydZEbGu1RdqkG3LcpNGv7XYsCHgzWBXnmxRd",
-        }
-      );
-      expect(token.iconUri()).toEqual(
-        "https://ipfs.io/ipfs/QmbvhanNCxydZEbGu1RdqkG3LcpNGv7XYsCHgzWBXnmxRd"
-      );
-    });
-  });
-});
-
-describe("NFT", () => {
-  describe("name", () => {
-    test("when metadata.name exists", () => {
-      const token = new NFT(
-        "KT1QTcAXeefhJ3iXLurRt81WRKdv7YqyYFmo",
-        "1",
-        "1",
-        "tz1UNer1ijeE9ndjzSszRduR3CzX49hoBUB3",
-        {
-          name: "some token name",
-        }
-      );
-      expect(token.name()).toEqual("some token name");
-    });
-    test("when metadata.name is empty we use the default name", () => {
-      const token = new NFT(
-        "KT1QTcAXeefhJ3iXLurRt81WRKdv7YqyYFmo",
-        "1",
-        "1",
-        "tz1UNer1ijeE9ndjzSszRduR3CzX49hoBUB3",
-        {}
-      );
-      expect(() => token.name()).toThrowError();
-    });
-  });
-
-  describe("symbol", () => {
-    test("when metadata.symbol exists", () => {
-      const token = new NFT(
-        "KT1QTcAXeefhJ3iXLurRt81WRKdv7YqyYFmo",
-        "1",
-        "1",
-        "tz1UNer1ijeE9ndjzSszRduR3CzX49hoBUB3",
-        {
-          symbol: "some token symbol",
-        }
-      );
-      expect(token.symbol()).toEqual("some token symbol");
-    });
-    test("when metadata.symbol is empty we use the default symbol", () => {
-      const token = new NFT(
-        "KT1QTcAXeefhJ3iXLurRt81WRKdv7YqyYFmo",
-        "1",
-        "1",
-        "tz1UNer1ijeE9ndjzSszRduR3CzX49hoBUB3",
-        {}
-      );
-      expect(() => token.name()).toThrowError();
-    });
-  });
-
-  describe("iconUri", () => {
-    test("it always returns undefined as it's not used for NFT", () => {
-      const token = new NFT(
-        "KT1QTcAXeefhJ3iXLurRt81WRKdv7YqyYFmo",
-        "1",
-        "1",
-        "tz1UNer1ijeE9ndjzSszRduR3CzX49hoBUB3",
-        {}
-      );
-      expect(token.iconUri()).toBeUndefined();
-    });
+    const fa2token: FA2Token = {
+      type: "fa2",
+      contract: "KT1QTcAXeefhJ3iXLurRt81WRKdv7YqyYFmo",
+      balance: "1",
+      tokenId: "123",
+    };
+    expect(httpIconUri(fa2token)).toEqual(undefined);
+    const fa2tokenWithIcon = {
+      ...fa2token,
+      metadata: {
+        thumbnailUri: "ipfs://QmXL3FZ5kcwXC8mdwkS1iCHS2qVoyg69ugBhU2ap8z1zcs",
+      },
+    };
+    expect(httpIconUri(fa2tokenWithIcon)).toEqual(
+      "https://ipfs.io/ipfs/QmXL3FZ5kcwXC8mdwkS1iCHS2qVoyg69ugBhU2ap8z1zcs"
+    );
   });
 });

--- a/src/utils/hooks/assetsHooks.ts
+++ b/src/utils/hooks/assetsHooks.ts
@@ -1,5 +1,11 @@
 import { compact } from "lodash";
-import { Asset, keepFA1s, keepFA2s, keepNFTs } from "../../types/Asset";
+import {
+  Asset,
+  fromToken,
+  keepFA1s,
+  keepFA2s,
+  keepNFTs,
+} from "../../types/Asset";
 import { OperationDisplay } from "../../types/Operation";
 import { getOperationDisplays } from "../../views/operations/operationsUtils";
 import { objectMap } from "../helpers";
@@ -28,7 +34,7 @@ export const useAllNfts = () => {
   const allTokens = useAppSelector((s) => s.assets.balances.tokens);
 
   return objectMap(allTokens, (tokens) =>
-    keepNFTs(compact(tokens.map(Asset.from)).filter((t) => t.balance !== "0"))
+    keepNFTs(compact(tokens.map(fromToken)).filter((t) => t.balance !== "0"))
   );
 };
 
@@ -36,7 +42,7 @@ export const useAccountAssets = () => {
   const allTokens = useAppSelector((s) => s.assets.balances.tokens);
 
   return objectMap(allTokens, (tokens) =>
-    compact(tokens.map(Asset.from)).filter((t) => t.balance !== "0")
+    compact(tokens.map(fromToken)).filter((t) => t.balance !== "0")
   );
 };
 
@@ -44,7 +50,7 @@ export const useGetAccountAssets = () => {
   const allTokens = useAppSelector((s) => s.assets.balances.tokens);
 
   return (pkh: string) => {
-    return compact((allTokens[pkh] ?? []).map(Asset.from));
+    return compact((allTokens[pkh] ?? []).map(fromToken));
   };
 };
 

--- a/src/utils/tezos/params.ts
+++ b/src/utils/tezos/params.ts
@@ -7,7 +7,6 @@ import {
   WalletParamsWithKind,
 } from "@taquito/taquito";
 import { OperationValue } from "../../components/sendForm/types";
-import { FA12Token, FA2Token } from "../../types/Asset";
 import {
   makeFA12TransferMethod,
   makeFA2TransferMethod,
@@ -76,12 +75,9 @@ const makeTokenTransferParams = async (
   const { contract } = asset;
   const args = { ...operation.value, contract };
   const transferMethod =
-    asset instanceof FA12Token
+    asset.type === "fa1.2"
       ? makeFA12TransferMethod(args, signer)
-      : makeFA2TransferMethod(
-          { ...args, tokenId: (asset as FA2Token).tokenId },
-          signer
-        );
+      : makeFA2TransferMethod({ ...args, tokenId: asset.tokenId }, signer);
 
   return (await transferMethod).toTransferParams();
 };

--- a/src/views/batch/BatchDisplay.tsx
+++ b/src/views/batch/BatchDisplay.tsx
@@ -28,7 +28,7 @@ import {
 import { OperationValue } from "../../components/sendForm/types";
 import { TextAndIconBtn } from "../../components/TextAndIconBtn";
 import { Account } from "../../types/Account";
-import { formatTokenAmount, NFT } from "../../types/Asset";
+import { formatTokenAmount, tokenSymbol } from "../../types/Asset";
 import { formatPkh, prettyTezAmount } from "../../utils/format";
 import { navigateToExternalLink } from "../../utils/helpers";
 import { useSelectedNetwork } from "../../utils/hooks/assetsHooks";
@@ -41,7 +41,7 @@ const renderAmount = (operation: OperationValue) => {
   switch (operation.type) {
     case "token": {
       const amount =
-        operation.data instanceof NFT
+        operation.data.type === "nft"
           ? operation.data.balance
           : formatTokenAmount(
               operation.value.amount,
@@ -51,12 +51,12 @@ const renderAmount = (operation: OperationValue) => {
         <Flex>
           <Text mr={1}>{amount} </Text>
 
-          {operation.data instanceof NFT ? (
+          {operation.data.type === "nft" ? (
             <AspectRatio ml={2} height={6} width={6} ratio={4 / 4}>
               <Image src={getIPFSurl(operation.data.metadata.displayUri)} />
             </AspectRatio>
           ) : (
-            <Text>{operation.data.symbol()}</Text>
+            <Text>{tokenSymbol(operation.data)}</Text>
           )}
         </Flex>
       );

--- a/src/views/operations/operationsUtils.ts
+++ b/src/views/operations/operationsUtils.ts
@@ -1,14 +1,14 @@
 import { TezosNetwork } from "@airgap/tezos";
 import { formatRelative } from "date-fns";
 import { z } from "zod";
-import { NFT } from "../../types/Asset";
+import { tokenPrettyBalance } from "../../types/Asset";
 import {
   OperationDisplay,
   TezTransfer,
   TokenTransfer,
 } from "../../types/Operation";
 import { Token } from "../../types/Token";
-import { Asset } from "../../types/Asset";
+import { fromToken } from "../../types/Asset";
 import { compact } from "lodash";
 import { getIPFSurl } from "../../utils/token/nftUtils";
 import { BigNumber } from "bignumber.js";
@@ -17,10 +17,10 @@ import { prettyTezAmount } from "../../utils/format";
 export const classifyTokenTransfer = (transfer: TokenTransfer) => {
   const token: Token = {
     balance: transfer.amount,
-    token: transfer.token === null ? undefined : transfer.token, // XD
+    token: transfer.token === null ? undefined : transfer.token,
   };
 
-  return Asset.from(token);
+  return fromToken(token);
 };
 
 export const getHashUrl = (hash: string, network: TezosNetwork) => {
@@ -136,10 +136,10 @@ export const getTokenOperationDisplay = (
   );
 
   let prettyAmount: string;
-  if (asset instanceof NFT) {
+  if (asset.type === "nft") {
     prettyAmount = asset.balance;
   } else {
-    prettyAmount = asset.prettyBalance({ showSymbol: true });
+    prettyAmount = tokenPrettyBalance(asset, { showSymbol: true });
   }
 
   const result: OperationDisplay = {

--- a/src/views/tokens/AccountTokensTile.tsx
+++ b/src/views/tokens/AccountTokensTile.tsx
@@ -30,6 +30,7 @@ import { Options } from "../home/useSendFormModal";
 import { FiExternalLink } from "react-icons/fi";
 import { tzktExplorer } from "../../utils/tezos/consts";
 import { navigateToExternalLink } from "../../utils/helpers";
+import { httpIconUri, tokenName, tokenPrettyBalance } from "../../types/Asset";
 
 const AccountTokensTileHeader: React.FC<{
   pkh: string;
@@ -81,18 +82,19 @@ const AccountTokensTile: React.FC<{
           </Thead>
           <Tbody>
             {tokens.map((token, i) => {
+              const iconUri = httpIconUri(token);
               return (
                 <Tr key={`${token.contract}${i}`}>
                   <Td w="15%">
                     <Flex alignItems="cnenter">
-                      {token.iconUri() ? (
-                        <Image src={token.iconUri()} w={8} h={8} />
+                      {iconUri ? (
+                        <Image src={iconUri} w={8} h={8} />
                       ) : (
                         <Icon h={8} w={8} as={MdGeneratingTokens} />
                       )}
 
                       <Heading size="sm" p={2} marginX={2}>
-                        {token.name()}
+                        {tokenName(token)}
                       </Heading>
                     </Flex>
                   </Td>
@@ -107,7 +109,9 @@ const AccountTokensTile: React.FC<{
                       }}
                     />
                   </Td>
-                  <Td w="15%">{token.prettyBalance({ showSymbol: false })}</Td>
+                  <Td w="15%">
+                    {tokenPrettyBalance(token, { showSymbol: false })}
+                  </Td>
                   <Td>
                     <Flex
                       alignItems="center"


### PR DESCRIPTION
## Proposed changes

to prevent assets from being serialized we have to convert them back to simple JS objects 😿 

## Types of changes

_Put an `x` in the boxes that apply_

- [x] Bugfix
- [ ] New feature
- [x] Refactor
- [ ] Breaking change
- [ ] Documentation Update
