### PR TITLE
Add simulate step on batch

### DIFF
--- a/src/components/AccountSelector/AccountSelector.tsx
+++ b/src/components/AccountSelector/AccountSelector.tsx
@@ -3,10 +3,10 @@ import { Button, Menu, MenuButton, MenuItem, MenuList } from "@chakra-ui/react";
 import React from "react";
 import { Account } from "../../types/Account";
 import { useAccounts } from "../../utils/hooks/accountHooks";
-import { AccountSmallTile } from "./AccountSmallTile";
+import { AccountSmallTileDisplay } from "./AccountSmallTile";
 
 const renderAccount = (account: Account) => (
-  <AccountSmallTile pkh={account.pkh} label={account.label} />
+  <AccountSmallTileDisplay pkh={account.pkh} label={account.label} />
 );
 
 export const ConnectedAccountSelector: React.FC<{

--- a/src/components/AccountSelector/AccountSmallTile.tsx
+++ b/src/components/AccountSelector/AccountSmallTile.tsx
@@ -3,7 +3,7 @@ import { formatPkh } from "../../utils/format";
 import { useAccounts } from "../../utils/hooks/accountHooks";
 import { Identicon } from "../Identicon";
 
-export const AccountSmallTile = ({
+export const AccountSmallTileDisplay = ({
   pkh,
   label,
   ...flexProps
@@ -22,13 +22,10 @@ export const AccountSmallTile = ({
   );
 };
 
-export const useRenderAccountSmallTile = () => {
+export const AccountSmallTile = ({ pkh }: { pkh: string }) => {
   const accounts = useAccounts();
-
-  return (pkh: string) => {
-    const account = accounts.find((a) => a.pkh === pkh);
-    return account ? (
-      <AccountSmallTile pkh={account.pkh} label={account.label} />
-    ) : null;
-  };
+  const account = accounts.find((a) => a.pkh === pkh);
+  return account ? (
+    <AccountSmallTileDisplay pkh={account.pkh} label={account.label} />
+  ) : null;
 };

--- a/src/components/sendForm/components/SignButton.tsx
+++ b/src/components/sendForm/components/SignButton.tsx
@@ -22,6 +22,8 @@ const SignButton: React.FC<{
 
   const getSk = useGetSk();
   const isValid = formState.isValid;
+  const isDirty = formState.isDirty;
+  const isError = isDirty && !isValid;
 
   const type = signerAccount.type;
   const isGoogleSSO = type === AccountType.SOCIAL;
@@ -74,7 +76,7 @@ const SignButton: React.FC<{
   return (
     <Box>
       {isMnemonic ? (
-        <FormControl isInvalid={!isValid} mt={4}>
+        <FormControl isInvalid={isError} mt={4}>
           <FormLabel>Password</FormLabel>
           <Input
             type="password"

--- a/src/components/sendForm/steps/BatchRecap.tsx
+++ b/src/components/sendForm/steps/BatchRecap.tsx
@@ -1,0 +1,12 @@
+import { getBatchSubtotal } from "../../../views/batch/batchUtils";
+import { Subtotal, TransactionsAmount } from "../components/TezAmountRecaps";
+import { OperationValue } from "../types";
+
+export const BatchRecap = ({ transfer }: { transfer: OperationValue[] }) => {
+  return (
+    <>
+      <TransactionsAmount amount={transfer.length} />
+      <Subtotal mutez={getBatchSubtotal(transfer).toString()} />
+    </>
+  );
+};

--- a/src/components/sendForm/steps/FillStep.tsx
+++ b/src/components/sendForm/steps/FillStep.tsx
@@ -1,9 +1,12 @@
 import {
   Box,
   Button,
+  Divider,
+  Flex,
   FormControl,
   FormErrorMessage,
   FormLabel,
+  Heading,
   Input,
   InputGroup,
   InputRightAddon,
@@ -24,9 +27,11 @@ import { tezToMutez } from "../../../utils/format";
 import { useBatchIsSimulating } from "../../../utils/hooks/assetsHooks";
 import { BakerSelector } from "../../../views/delegations/BakerSelector";
 import { ConnectedAccountSelector } from "../../AccountSelector/AccountSelector";
+import { AccountSmallTile } from "../../AccountSelector/AccountSmallTile";
 import { RecipentAutoComplete } from "../../RecipientAutoComplete/RecipientAutoComplete";
 import { SendNFTRecapTile } from "../components/SendNFTRecapTile";
 import { OperationValue, SendFormMode } from "../types";
+import { BatchRecap } from "./BatchRecap";
 
 export const DelegateForm = ({
   onSubmit,
@@ -123,6 +128,50 @@ const getAmountSymbol = (asset?: Asset) => {
   }
 
   return tokenSymbol(asset);
+};
+
+export const FillBatchForm: React.FC<{
+  transfer: OperationValue[];
+  onSubmit: () => void;
+  isLoading?: boolean;
+}> = ({ transfer, onSubmit, isLoading = false }) => {
+  return (
+    <ModalContent bg="umami.gray.900" data-testid="bar">
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          onSubmit();
+        }}
+      >
+        <ModalCloseButton />
+        <ModalHeader textAlign={"center"}>Recap</ModalHeader>
+        <Text textAlign={"center"}>Transaction details</Text>
+        <ModalBody mt={4}>
+          <Box>
+            <Flex mb={4}>
+              <Heading size="md" width={20}>
+                From:
+              </Heading>
+              <AccountSmallTile pkh={transfer[0].value.sender} />
+            </Flex>
+            <BatchRecap transfer={transfer} />
+          </Box>
+          <Divider mb={2} mt={2} />
+        </ModalBody>
+        <ModalFooter justifyContent={"center"}>
+          <Button
+            type="submit"
+            width={"100%"}
+            isLoading={isLoading}
+            variant="ghost"
+            mb={2}
+          >
+            Preview
+          </Button>
+        </ModalFooter>
+      </form>
+    </ModalContent>
+  );
 };
 
 export const SendTezOrNFTForm = ({
@@ -292,7 +341,7 @@ export const SendTezOrNFTForm = ({
 };
 
 export const FillStep: React.FC<{
-  onSubmit: (v: OperationValue) => void;
+  onSubmit: (v: OperationValue | OperationValue[]) => void;
   onSubmitBatch: (v: OperationValue) => void;
   isLoading: boolean;
   sender?: string;
@@ -401,7 +450,15 @@ export const FillStep: React.FC<{
     }
 
     case "batch": {
-      throw new Error("Batches are not editable");
+      return (
+        <FillBatchForm
+          isLoading={isLoading}
+          transfer={mode.data.batch}
+          onSubmit={() => {
+            onSubmit(mode.data.batch);
+          }}
+        />
+      );
     }
   }
 };

--- a/src/components/sendForm/steps/SubmitStep.tsx
+++ b/src/components/sendForm/steps/SubmitStep.tsx
@@ -12,6 +12,7 @@ import {
   Text,
   useToast,
 } from "@chakra-ui/react";
+import BigNumber from "bignumber.js";
 import { useState } from "react";
 import { AccountType } from "../../../types/Account";
 import { SignerConfig } from "../../../types/SignerConfig";
@@ -26,17 +27,12 @@ import {
 } from "../../../utils/tezos";
 import { getBatchSubtotal } from "../../../views/batch/batchUtils";
 import { useRenderBakerSmallTile } from "../../../views/delegations/BakerSmallTile";
-import { useRenderAccountSmallTile } from "../../AccountSelector/AccountSmallTile";
+import { AccountSmallTile } from "../../AccountSelector/AccountSmallTile";
 import { SendNFTRecapTile } from "../components/SendNFTRecapTile";
 import SignButton from "../components/SignButton";
-import {
-  Fee,
-  Subtotal,
-  Total,
-  TransactionsAmount,
-} from "../components/TezAmountRecaps";
+import { Fee, Subtotal, Total } from "../components/TezAmountRecaps";
 import { EstimatedOperation, OperationValue } from "../types";
-import BigNumber from "bignumber.js";
+import { BatchRecap } from "./BatchRecap";
 
 const makeTransfer = async (
   operation: OperationValue | OperationValue[],
@@ -95,7 +91,6 @@ const NonBatchRecap = ({ transfer }: { transfer: OperationValue }) => {
   const isDelegation = transfer.type === "delegation";
   const token = transfer.type === "token" ? transfer.data : undefined;
 
-  const renderAccountTile = useRenderAccountSmallTile();
   const renderBakerTile = useRenderBakerSmallTile();
 
   return (
@@ -105,9 +100,11 @@ const NonBatchRecap = ({ transfer }: { transfer: OperationValue }) => {
           <Heading size="md" width={20}>
             To:
           </Heading>
-          {isDelegation
-            ? renderBakerTile(transfer.value.recipient)
-            : renderAccountTile(transfer.value.recipient)}
+          {isDelegation ? (
+            renderBakerTile(transfer.value.recipient)
+          ) : (
+            <AccountSmallTile pkh={transfer.value.recipient} />
+          )}
         </Flex>
       )}
       {token?.type === "nft" && (
@@ -118,15 +115,6 @@ const NonBatchRecap = ({ transfer }: { transfer: OperationValue }) => {
       {transfer.type === "tez" ? (
         <Subtotal mutez={transfer.value.amount} />
       ) : null}
-    </>
-  );
-};
-
-const BatchRecap = ({ transfer }: { transfer: OperationValue[] }) => {
-  return (
-    <>
-      <TransactionsAmount amount={transfer.length} />
-      <Subtotal mutez={getBatchSubtotal(transfer).toString()} />
     </>
   );
 };
@@ -149,7 +137,6 @@ export const RecapDisplay: React.FC<{
   onSucces: (hash: string) => void;
 }> = ({ recap: { fee, operation: transfer }, network, onSucces }) => {
   const feeNum = new BigNumber(fee);
-  const renderAccountTile = useRenderAccountSmallTile();
   const getAccount = useGetOwnedAccount();
 
   const toast = useToast();
@@ -198,7 +185,7 @@ export const RecapDisplay: React.FC<{
               <Heading size="md" width={20}>
                 From:
               </Heading>
-              {renderAccountTile(signerAccount.pkh)}
+              <AccountSmallTile pkh={signerAccount.pkh} />
             </Flex>
             {Array.isArray(transfer) ? (
               <BatchRecap transfer={transfer} />

--- a/src/components/sendForm/types.ts
+++ b/src/components/sendForm/types.ts
@@ -1,6 +1,5 @@
 import { TransferParams } from "@taquito/taquito";
 import { Asset } from "../../types/Asset";
-import { Batch } from "../../utils/store/assetsSlice";
 
 type TezMode = { type: "tez" };
 
@@ -19,7 +18,7 @@ type DelegationMode = {
 type BatchMode = {
   type: "batch";
   data: {
-    batch: Batch;
+    batch: OperationValue[];
   };
 };
 export type SendFormMode = TezMode | TokenMode | DelegationMode | BatchMode;

--- a/src/views/batch/BatchDisplay.tsx
+++ b/src/views/batch/BatchDisplay.tsx
@@ -19,7 +19,7 @@ import React from "react";
 import { BsTrash } from "react-icons/bs";
 import { FiExternalLink } from "react-icons/fi";
 import AccountOrContactTile from "../../components/AccountOrContactTile";
-import { AccountSmallTile } from "../../components/AccountSelector/AccountSmallTile";
+import { AccountSmallTileDisplay } from "../../components/AccountSelector/AccountSmallTile";
 import {
   Fee,
   Subtotal,
@@ -128,7 +128,11 @@ export const BatchDisplay: React.FC<{
     <Flex data-testid="batch-table" mb={4}>
       <Box flex={1} bg="umami.gray.900" p={4}>
         <Flex justifyContent="space-between" ml={2} mr={2} mb={4}>
-          <AccountSmallTile ml={2} pkh={account.pkh} label={account.label} />
+          <AccountSmallTileDisplay
+            ml={2}
+            pkh={account.pkh}
+            label={account.label}
+          />
           <Text color={"umami.gray.400"}>
             {`${items.length} transaction${items.length > 1 ? "s" : ""}`}
           </Text>

--- a/src/views/batch/BatchView.test.tsx
+++ b/src/views/batch/BatchView.test.tsx
@@ -242,28 +242,31 @@ describe("<BatchView />", () => {
       fireEvent.click(submitBatchBtn);
     };
 
-    test("clicking submit batch button displays 'recap and submit' form", () => {
+    test("clicking submit batch button displays 'preview' form", () => {
       render(fixture());
       clickSubmitOnFirstBatch();
       const modal = screen.getByRole("dialog");
       const { getByText, getByLabelText } = within(modal);
       expect(getByText(/transaction details/i)).toBeInTheDocument();
 
-      const txsAmount = getByLabelText(/^transactions-amount$/i);
+      const txsAmount = getByLabelText(/transactions-amount/i);
       expect(txsAmount).toHaveTextContent("3");
-      const fee = getByLabelText(/^fee$/i);
-      expect(fee).toHaveTextContent("0.00003 ꜩ");
-      const subTotal = getByLabelText(/^sub-total$/i);
+
+      const subTotal = getByLabelText(/sub-total/i);
       expect(subTotal).toHaveTextContent("6 ꜩ");
-      const total = getByLabelText(/^total$/i);
-      expect(total).toHaveTextContent("6.00003 ꜩ");
+      expect(
+        screen.getByRole("button", { name: /preview/i })
+      ).toBeInTheDocument();
     });
 
-    test("submiting a batch executes the batch of transactions and empties it after successfull submition", async () => {
+    test("estimating and submiting a batch executes the batch of transactions and empties it after successfull submition", async () => {
       render(fixture());
       clickSubmitOnFirstBatch();
 
-      const passwordInput = screen.getByLabelText(/password/i);
+      const previewBtn = screen.getByRole("button", { name: /preview/i });
+      fireEvent.click(previewBtn);
+
+      const passwordInput = await screen.findByLabelText(/password/i);
       fireEvent.change(passwordInput, { target: { value: "mockPass" } });
 
       const submit = screen.getByRole("button", {

--- a/src/views/batch/BatchView.tsx
+++ b/src/views/batch/BatchView.tsx
@@ -59,7 +59,12 @@ const BatchView = () => {
     return account && batch && batch.items.length > 0 ? (
       <BatchDisplay
         onSend={() =>
-          openSendForm({ mode: { type: "batch", data: { batch } } })
+          openSendForm({
+            mode: {
+              type: "batch",
+              data: { batch: batch.items.map((i) => i.operation) },
+            },
+          })
         }
         onDelete={() =>
           onOpen({

--- a/src/views/batch/batchUtils.ts
+++ b/src/views/batch/batchUtils.ts
@@ -1,6 +1,7 @@
 import { OperationValue } from "../../components/sendForm/types";
 import { BatchItem } from "../../utils/store/assetsSlice";
 import { BigNumber } from "bignumber.js";
+import { Estimate } from "@taquito/taquito";
 
 export const getTotalFee = (items: BatchItem[]): BigNumber => {
   const fee = items.reduce((acc, curr) => {
@@ -20,4 +21,12 @@ export const getBatchSubtotal = (ops: OperationValue[]) => {
     }
   }, new BigNumber(0));
   return subTotal;
+};
+
+export const sumEstimations = (es: Estimate[]) => {
+  return es
+    .reduce((acc, curr) => {
+      return acc.plus(curr.suggestedFeeMutez);
+    }, new BigNumber(0))
+    .toNumber();
 };

--- a/src/views/delegations/DelegationsView.tsx
+++ b/src/views/delegations/DelegationsView.tsx
@@ -11,15 +11,18 @@ import {
   Tr,
 } from "@chakra-ui/react";
 import { formatRelative } from "date-fns";
+import { compact } from "lodash";
 import React from "react";
+import { CiCircleRemove } from "react-icons/ci";
+import { MdOutlineModeEdit } from "react-icons/md";
 import { TbFilter } from "react-icons/tb";
 import { VscWand } from "react-icons/vsc";
 import { useQuery } from "react-query";
-import { useRenderAccountSmallTile } from "../../components/AccountSelector/AccountSmallTile";
+import { AccountSmallTile } from "../../components/AccountSelector/AccountSmallTile";
 import { IconAndTextBtn } from "../../components/IconAndTextBtn";
 import { TopBar } from "../../components/TopBar";
 import { Delegation, makeDelegation } from "../../types/Delegation";
-import { compact } from "lodash";
+import { prettyTezAmount } from "../../utils/format";
 import {
   useAllDelegations,
   useGetAccountBalance,
@@ -29,9 +32,6 @@ import { useAppDispatch } from "../../utils/store/hooks";
 import { getBakers } from "../../utils/tezos";
 import { useSendFormModal } from "../home/useSendFormModal";
 import { useRenderBakerSmallTile } from "./BakerSmallTile";
-import { CiCircleRemove } from "react-icons/ci";
-import { MdOutlineModeEdit } from "react-icons/md";
-import { prettyTezAmount } from "../../utils/format";
 
 const DelegationsTable = ({
   delegations,
@@ -43,7 +43,6 @@ const DelegationsTable = ({
   onChangeDelegate: (pkh: string, baker: string) => void;
 }) => {
   const now = new Date();
-  const renderAccountTile = useRenderAccountSmallTile();
   const renderBakerTile = useRenderBakerSmallTile();
 
   const getAccountBalance = useGetAccountBalance();
@@ -75,7 +74,9 @@ const DelegationsTable = ({
             const balance = getAccountBalance(d.sender);
             return (
               <Tr key={d.id} data-testid={`delegation-row`}>
-                <Td>{renderAccountTile(d.sender)}</Td>
+                <Td>
+                  <AccountSmallTile pkh={d.sender} />
+                </Td>
                 <Td>{d.amount && prettyTezAmount(d.amount)}</Td>
                 <Td>{balance && prettyTezAmount(balance)}</Td>
                 <Td>


### PR DESCRIPTION
## Proposed changes



https://github.com/trilitech/umami-v2/assets/19576344/30af4417-3954-4a5e-80ef-8b0db73b2653


For batch transactions, we add a step with "preview" like for all other transactions.
This allows the batch transaction flow to fit seamlessly with Beacon batch transaction requests.

## Types of changes

_Put an `x` in the boxes that apply_

- [ ] Bugfix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation Update

## Steps to reproduce

- step one
- step two
- step three

## Screenshots

Add the screenshots of how the app used to look like and how it looks now

| Before | Now    |
| ------ | ------ |
| Image1 | Image2 |
| Image3 | Image4 |

## Checklist

- [ ] Tests that prove my fix is effective or that my feature works have been added
- [ ] Documentation has been added (if appropriate)
- [ ] Screenshots are added (if any UI changes have been made)
- [ ] All TODOs have a corresponding task created (and the link is attached to it)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
