### PR TITLE
Add tags section to the NFT Drawer

### DIFF
--- a/src/mocks/factories.ts
+++ b/src/mocks/factories.ts
@@ -240,15 +240,17 @@ export const mockFA1Token = (
 };
 
 export const mockNFT = (index: number, balance = "1"): NFT => {
+  const displayUri =
+    "ipfs://zdj7Wk92xWxpzGqT6sE4cx7umUyWaX2Ck8MrSEmPAR31sNWG" + index;
   return {
     type: "nft",
     balance,
+    displayUri,
     contract: mockContract(index),
     tokenId: "mockId" + index,
     owner: mockPkh(index),
     metadata: {
-      displayUri:
-        "ipfs://zdj7Wk92xWxpzGqT6sE4cx7umUyWaX2Ck8MrSEmPAR31sNWG" + index,
+      displayUri: displayUri,
       name: "Tezzardz #" + index,
       symbol: "FKR" + index,
     },

--- a/src/mocks/tokens.ts
+++ b/src/mocks/tokens.ts
@@ -1,4 +1,5 @@
 import type { FA12Token, FA2Token, NFT } from "../types/Asset";
+import { nftDisplayUri } from "../utils/tezos/consts";
 import { publicKeys1 } from "./publicKeys";
 
 export const ghostTezzard: NFT = {
@@ -7,9 +8,9 @@ export const ghostTezzard: NFT = {
   tokenId: "6",
   balance: "1",
   owner: publicKeys1.pkh,
+  displayUri: nftDisplayUri,
   metadata: {
-    displayUri:
-      "https://ipfs.io/ipfs/zdj7WWXMC8RpzC6RkR2DXtD2zcfLc2QWu6tu7f6vnkeeUvSoh",
+    displayUri: nftDisplayUri,
     name: "Tezzardz #24",
     symbol: "FKR",
   },

--- a/src/types/Asset.test.tsx
+++ b/src/types/Asset.test.tsx
@@ -12,7 +12,7 @@ import {
 import type { TokenMetadata } from "./Token";
 
 describe("fromToken", () => {
-  test("case fa1.2 valid", () => {
+  test("fa1.2 valid", () => {
     const result = fromToken(fa1Token);
     const expected = {
       type: "fa1.2",
@@ -22,12 +22,12 @@ describe("fromToken", () => {
     expect(result).toEqual(expected);
   });
 
-  test("case fa1.2 with no balance", () => {
+  test("fa1.2 with no balance", () => {
     const result = fromToken({ ...fa1Token, balance: null });
     expect(result).toEqual(null);
   });
 
-  test("case valid fa2 token", () => {
+  test("valid fa2 token", () => {
     const result = fromToken(fa2Token);
     expect(result).toEqual({
       type: "fa2",
@@ -42,13 +42,13 @@ describe("fromToken", () => {
     });
   });
 
-  test("case invalid fa2 token (missing tokenId)", () => {
+  test("invalid fa2 token (missing tokenId)", () => {
     const result = fromToken({ ...fa2Token, token: { tokenId: undefined } });
 
     expect(result).toEqual(null);
   });
 
-  test("case valid nft", () => {
+  test("valid nft", () => {
     const result = fromToken(nft);
     const expected = {
       type: "nft",
@@ -56,12 +56,13 @@ describe("fromToken", () => {
       tokenId: "3",
       balance: "0",
       owner: "tz1UNer1ijeE9ndjzSszRduR3CzX49hoBUB3",
+      displayUri: "ipfs://zdj7Wk92xWxpzGqT6sE4cx7umUyWaX2Ck8MrSEmPAR31sNWGz",
       metadata: nft.token?.metadata as TokenMetadata,
     };
     expect(result).toEqual(expected);
   });
 
-  test("case invalid nft (missing contract address)", () => {
+  test("invalid nft (missing contract address)", () => {
     const result = fromToken({
       ...nft,
       token: { contract: { address: null } },
@@ -70,7 +71,7 @@ describe("fromToken", () => {
     expect(result).toEqual(null);
   });
 
-  test("case fa1 token with name symbol and decimals (tzBTC)", () => {
+  test("fa1 token with name symbol and decimals (tzBTC)", () => {
     const result = fromToken(tzBtsc);
 
     const expected = {
@@ -86,7 +87,7 @@ describe("fromToken", () => {
     expect(result).toEqual(expected);
   });
 
-  test("case fa1 token with name symbol decimals and icon (hedgeHoge)", () => {
+  test("fa1 token with name symbol decimals and icon (hedgeHoge)", () => {
     const result = fromToken(hedgeHoge);
 
     const expected = {
@@ -103,7 +104,7 @@ describe("fromToken", () => {
     expect(result).toEqual(expected);
   });
 
-  test("case fa2 token with thumbnailUri (uUSD)", () => {
+  test("fa2 token with thumbnailUri (uUSD)", () => {
     const result = fromToken(uUSD);
     const expected = {
       type: "fa2",

--- a/src/types/Asset.ts
+++ b/src/types/Asset.ts
@@ -70,6 +70,7 @@ export const fromToken = (raw: Token): Asset | null => {
       tokenId: nftResult.data.token.tokenId,
       balance: nftResult.data.balance,
       owner: nftResult.data.account.address,
+      displayUri: nftResult.data.token.metadata.displayUri,
     };
   }
 
@@ -165,6 +166,7 @@ export type NFT = {
   balance: string;
   owner: string;
   metadata: TokenMetadata;
+  displayUri: string;
 };
 
 export const keepNFTs = (assets: Asset[]) => {

--- a/src/utils/tezos/consts.ts
+++ b/src/utils/tezos/consts.ts
@@ -22,3 +22,6 @@ export const wertUrls = {
 export const coincapUrl = "https://api.coincap.io/v2/assets";
 
 export const bakersUrl = "https://api.baking-bad.org/v2/bakers";
+
+export const nftDisplayUri =
+  "ipfs://zdj7WWXMC8RpzC6RkR2DXtD2zcfLc2QWu6tu7f6vnkeeUvSoh";

--- a/src/views/nfts/NFTDrawerCard.tsx
+++ b/src/views/nfts/NFTDrawerCard.tsx
@@ -1,0 +1,52 @@
+import {
+  AspectRatio,
+  Box,
+  Button,
+  Card,
+  CardBody,
+  Heading,
+  Image,
+} from "@chakra-ui/react";
+import { NFT } from "../../types/Asset";
+import { useSendFormModal } from "../home/useSendFormModal";
+import { getIPFSurl } from "../../utils/token/nftUtils";
+import TagsSection from "./drawer/TagsSection";
+
+const NFTDrawerCard = ({ nft }: { nft: NFT }) => {
+  const { modalElement, onOpen } = useSendFormModal();
+  return (
+    <Box>
+      <Card bg="umami.gray.800">
+        <CardBody>
+          <AspectRatio width={"100%"} ratio={1}>
+            <Image width="100%" src={getIPFSurl(nft.displayUri)} />
+          </AspectRatio>
+        </CardBody>
+      </Card>
+
+      <TagsSection nft={nft} />
+
+      <Heading mt={4} size="lg">
+        {nft.metadata.name}
+      </Heading>
+
+      <Button
+        mt={4}
+        bg="umami.blue"
+        onClick={(_) => {
+          onOpen({
+            mode: {
+              type: "token",
+              data: nft,
+            },
+          });
+        }}
+      >
+        Send
+      </Button>
+      {modalElement}
+    </Box>
+  );
+};
+
+export default NFTDrawerCard;

--- a/src/views/nfts/NftsView.tsx
+++ b/src/views/nfts/NftsView.tsx
@@ -1,14 +1,10 @@
 import {
-  AspectRatio,
   Box,
-  Button,
   Drawer,
   DrawerBody,
   DrawerContent,
   DrawerOverlay,
   Flex,
-  Heading,
-  Image,
   useDisclosure,
 } from "@chakra-ui/react";
 import React, { useState } from "react";
@@ -20,9 +16,8 @@ import { TopBar } from "../../components/TopBar";
 import { NFT } from "../../types/Asset";
 import { useAllNfts } from "../../utils/hooks/assetsHooks";
 import { DrawerTopButtons } from "../home/DrawerTopButtons";
-import { useSendFormModal } from "../home/useSendFormModal";
+import NFTDrawerCard from "./NFTDrawerCard";
 import NFTGallery from "./NFTGallery";
-import { getIPFSurl } from "../../utils/token/nftUtils";
 
 export const FilterController: React.FC = () => {
   return (
@@ -34,35 +29,6 @@ export const FilterController: React.FC = () => {
   );
 };
 
-const NFTDrawerCard = ({ nft }: { nft: NFT }) => {
-  const { modalElement, onOpen } = useSendFormModal();
-  return (
-    <Box>
-      <AspectRatio width={"100%"} ratio={4 / 4}>
-        <Image width="100%" src={getIPFSurl(nft.metadata.displayUri)} />
-      </AspectRatio>
-      <Heading mt={4} size="lg">
-        {nft.metadata.name}
-      </Heading>
-
-      <Button
-        mt={4}
-        bg="umami.blue"
-        onClick={(_) => {
-          onOpen({
-            mode: {
-              type: "token",
-              data: nft,
-            },
-          });
-        }}
-      >
-        Send
-      </Button>
-      {modalElement}
-    </Box>
-  );
-};
 const NFTsViewBase = () => {
   const nfts = useAllNfts();
 

--- a/src/views/nfts/drawer/TagsSection.test.tsx
+++ b/src/views/nfts/drawer/TagsSection.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from "@testing-library/react";
+import { mockNFT } from "../../../mocks/factories";
+import TagsSection from "./TagsSection";
+
+describe("TagsSection", () => {
+  it("shows nothing if there are no tags", () => {
+    const nft = mockNFT(0);
+    render(<TagsSection nft={nft} />);
+
+    expect(screen.queryByTestId("tags-section")).toBeNull();
+  });
+
+  it("renders all tags", () => {
+    const nft = mockNFT(0);
+    nft.metadata.tags = ["tag1", "tag2", "tag3"];
+    render(<TagsSection nft={nft} />);
+
+    const tagElements = screen.getAllByTestId("nft-tag");
+    expect(tagElements).toHaveLength(3);
+    expect(tagElements[0]).toHaveTextContent("tag1");
+    expect(tagElements[1]).toHaveTextContent("tag2");
+    expect(tagElements[2]).toHaveTextContent("tag3");
+  });
+});

--- a/src/views/nfts/drawer/TagsSection.tsx
+++ b/src/views/nfts/drawer/TagsSection.tsx
@@ -1,0 +1,29 @@
+import { Wrap, WrapItem, Text } from "@chakra-ui/react";
+import { NFT } from "../../../types/Asset";
+
+const TagsSection = ({ nft }: { nft: NFT }) => {
+  const tags = nft.metadata.tags;
+  if (!tags || tags.length === 0) {
+    return null;
+  }
+  return (
+    <Wrap mt="3" data-testid="tags-section">
+      {tags.map((tag) => {
+        return (
+          <WrapItem
+            key={tag}
+            borderRadius="100px"
+            padding="3px 8px"
+            bg="umami.gray.600"
+          >
+            <Text data-testid="nft-tag" color="umami.gray.400">
+              {tag}
+            </Text>
+          </WrapItem>
+        );
+      })}
+    </Wrap>
+  );
+};
+
+export default TagsSection;


### PR DESCRIPTION
## Proposed changes

[Task link](https://app.asana.com/0/0/1204721073861935/f)

NFT now has a border
Tags section is added

I duplicated the displayUri in the root of an NFT object because it's a required field in order to call an FA2 token an NFT.

## Types of changes

_Put an `x` in the boxes that apply_

- [ ] Bugfix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation Update

## Screenshots

<img width="491" alt="Screenshot 2023-06-01 at 08 56 16" src="https://github.com/trilitech/umami-v2/assets/129749432/679662e3-b972-46a8-b791-817786e8e7f3">
<img width="485" alt="Screenshot 2023-06-01 at 08 56 20" src="https://github.com/trilitech/umami-v2/assets/129749432/c6d5d615-6edf-4f20-9161-4e3348684ada">

## Checklist

- [x] Tests that prove my fix is effective or that my feature works have been added
- [ ] Documentation has been added (if appropriate)
- [x] Screenshots are added (if any UI changes have been made)
- [ ] All TODOs have a corresponding task created (and the link is attached to it)
