### PR TITLE
Add nft drawer properties section part3

### DIFF
--- a/src/components/TruncatedTextWithTooltip.test.tsx
+++ b/src/components/TruncatedTextWithTooltip.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from "@testing-library/react";
+import { TruncatedTextWithTooltip } from "./TruncatedTextWithTooltip";
+
+describe("TruncatedTextWithTooltip", () => {
+  it("renders just text if the input is short enough", () => {
+    render(<TruncatedTextWithTooltip text={"123"} maxLength={10} />);
+    expect(screen.getByTestId("truncated-text")).toHaveTextContent("123");
+    expect(screen.getByTestId("truncated-text")).not.toHaveTextContent("...");
+  });
+
+  it("renders shortened text and a tooltip if the input large", () => {
+    render(<TruncatedTextWithTooltip text={"some text"} maxLength={5} />);
+    expect(screen.getByTestId("truncated-text")).toHaveTextContent("so...");
+  });
+});

--- a/src/components/TruncatedTextWithTooltip.tsx
+++ b/src/components/TruncatedTextWithTooltip.tsx
@@ -1,0 +1,17 @@
+import { Text, Tooltip } from "@chakra-ui/react";
+import React from "react";
+import { truncate } from "../utils/format";
+
+export const TruncatedTextWithTooltip: React.FC<{
+  text: string;
+  maxLength: number;
+}> = ({ text, maxLength }) => {
+  if (text.length <= maxLength) {
+    return <Text data-testid="truncated-text">{text}</Text>;
+  }
+  return (
+    <Tooltip label={text}>
+      <Text data-testid="truncated-text">{truncate(text, maxLength)}</Text>
+    </Tooltip>
+  );
+};

--- a/src/utils/format.test.ts
+++ b/src/utils/format.test.ts
@@ -1,0 +1,11 @@
+import { truncate } from "./format";
+
+describe("truncate", () => {
+  it("should leave the text untouched if it's shorter than the limit", () => {
+    expect(truncate("some text", 20)).toEqual("some text");
+  });
+
+  it("should shrink the text to fit into the limit", () => {
+    expect(truncate("some text", 5)).toEqual("so...");
+  });
+});

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -6,7 +6,7 @@ export const formatPkh = (pkh: string) => {
 };
 
 export const truncate = (name: string, len: number) => {
-  return name.length > len ? name.slice(0, len) + "..." : name;
+  return name.length > len ? name.slice(0, len - 3) + "..." : name;
 };
 
 export const tezToMutez = (tez: string): BigNumber =>

--- a/src/views/nfts/NFTDrawerCard.test.tsx
+++ b/src/views/nfts/NFTDrawerCard.test.tsx
@@ -61,7 +61,7 @@ describe("NFTDrawerCard", () => {
   describe("owned counter", () => {
     it("doesn't render if I own only one nft", () => {
       const nft = mockNFT(0);
-      nft.balance = '1';
+      nft.balance = "1";
       render(fixture(nft));
 
       expect(screen.queryByTestId("nft-owned-count")).toBeNull();
@@ -69,7 +69,7 @@ describe("NFTDrawerCard", () => {
 
     it("renders the number of owned NFT instances", () => {
       const nft = mockNFT(0);
-      nft.balance = '123';
+      nft.balance = "123";
       render(fixture(nft));
 
       expect(screen.getByTestId("nft-owned-count")).toHaveTextContent("x123");

--- a/src/views/nfts/NFTDrawerCard.tsx
+++ b/src/views/nfts/NFTDrawerCard.tsx
@@ -49,7 +49,9 @@ const NFTDrawerCard = ({ nft }: { nft: NFT }) => {
               position="absolute"
               marginTop="-40px"
               marginLeft="10px"
-            >{"x" + nft.balance}</Text>
+            >
+              {"x" + nft.balance}
+            </Text>
           )}
         </CardBody>
       </Card>

--- a/src/views/nfts/drawer/PropertiesAccordionItem.tsx
+++ b/src/views/nfts/drawer/PropertiesAccordionItem.tsx
@@ -12,9 +12,9 @@ import {
 } from "@chakra-ui/react";
 import { CSSProperties } from "react";
 import { CopyableAddress } from "../../../components/CopyableText";
+import { TruncatedTextWithTooltip } from "../../../components/TruncatedTextWithTooltip";
 import { TzktLink } from "../../../components/TzktLink";
 import { metadataUri, mimeType, NFT, royalties } from "../../../types/Asset";
-import { truncate } from "../../../utils/format";
 import { useSelectedNetwork } from "../../../utils/hooks/assetsHooks";
 
 export const creatorElement = (nft: NFT) => {
@@ -25,7 +25,7 @@ export const creatorElement = (nft: NFT) => {
   if (firstCreator.startsWith("tz")) {
     return <CopyableAddress pkh={firstCreator} />;
   }
-  return truncate(firstCreator, 15);
+  return <TruncatedTextWithTooltip text={firstCreator} maxLength={15} />;
 };
 
 const PropertiesAccordionItem = ({
@@ -179,9 +179,11 @@ const PropertiesAccordionItem = ({
                 <Td padding="16px 0 16px 15px" color="umami.gray.400">
                   License:
                 </Td>
-                {/* TODO: truncate it with a tooltip https://app.asana.com/0/0/1204749792730548/f */}
                 <Td padding="16px 0 16px 5px" w="30%">
-                  {truncate(nft.metadata.rights || "-", 15)}
+                  <TruncatedTextWithTooltip
+                    text={nft.metadata.rights || "-"}
+                    maxLength={15}
+                  />
                 </Td>
               </Tr>
             </Tbody>


### PR DESCRIPTION
## Proposed changes

[task link](https://app.asana.com/0/1204165186238194/1204289597673385/f)
[subtask link](https://app.asana.com/0/0/1204721073861944/f)


Added a tooltip to a a couple of fields in properties, and if a user ones a few NFTs of the same type then there is a count on the image

## Types of changes

_Put an `x` in the boxes that apply_

- [ ] Bugfix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation Update

## Steps to reproduce

open NFT drawer

## Screenshots

<img width="586" alt="Screenshot 2023-06-05 at 17 01 01" src="https://github.com/trilitech/umami-v2/assets/129749432/7c8bb9c4-43cf-4cf6-84fa-d32bcc80c93d">
<img width="581" alt="Screenshot 2023-06-05 at 17 01 06" src="https://github.com/trilitech/umami-v2/assets/129749432/aa57dd31-bd38-4694-9c58-941f5750b266">
<img width="367" alt="Screenshot 2023-06-05 at 17 10 42" src="https://github.com/trilitech/umami-v2/assets/129749432/f2bd7ef8-6c55-42af-a040-6e8c1d992e5a">
<img width="565" alt="Screenshot 2023-06-05 at 17 11 54" src="https://github.com/trilitech/umami-v2/assets/129749432/0183137c-545b-43bc-8859-23c6c4efcdb6">


## Checklist

- [x] Tests that prove my fix is effective or that my feature works have been added
- [ ] Documentation has been added (if appropriate)
- [x] Screenshots are added (if any UI changes have been made)
- [ ] All TODOs have a corresponding task created (and the link is attached to it)
