### PR TITLE
Remove inactive bigmaps

### DIFF
--- a/src/mocks/factories.ts
+++ b/src/mocks/factories.ts
@@ -19,7 +19,7 @@ import {
 } from "../utils/account/derivationPathUtils";
 import {
   MultisigOperation,
-  MultisigWithOperations,
+  MultisigWithPendingOperations,
 } from "../utils/multisig/types";
 
 export const mockTezTransaction = (id: number) => {
@@ -161,11 +161,11 @@ export const mockMultisigWithOperations = (
   signers: string[] = [],
   balance = "0",
   threshold = 3
-): MultisigWithOperations => {
+): MultisigWithPendingOperations => {
   return {
     address: mockContract(index),
     balance,
-    operations,
+    pendingOperations: operations,
     signers,
     threshold,
   };

--- a/src/utils/hooks/accountHooks.ts
+++ b/src/utils/hooks/accountHooks.ts
@@ -7,7 +7,7 @@ import {
   SocialAccount,
 } from "../../types/Account";
 import { decrypt } from "../aes";
-import { MultisigWithOperations } from "../multisig/types";
+import { MultisigWithPendingOperations } from "../multisig/types";
 import accountsSlice from "../store/accountsSlice";
 import { useAppDispatch, useAppSelector } from "../store/hooks";
 import { restoreFromMnemonic } from "../store/thunks/restoreMnemonicAccounts";
@@ -132,7 +132,7 @@ export const useRemoveMnemonic = () => {
 };
 
 export const useMultisigAccounts = (): MultisigAccount[] => {
-  const multisigs: MultisigWithOperations[] = useAppSelector(
+  const multisigs: MultisigWithPendingOperations[] = useAppSelector(
     (s) => s.multisigs.items
   );
 
@@ -143,7 +143,7 @@ export const useMultisigAccounts = (): MultisigAccount[] => {
     threshold: m.threshold,
     signers: m.signers,
     balance: m.balance,
-    operations: m.operations,
+    operations: m.pendingOperations,
   }));
 };
 

--- a/src/utils/multisig/helper.test.ts
+++ b/src/utils/multisig/helper.test.ts
@@ -8,7 +8,7 @@ import {
   getRelevantMultisigContracts,
 } from "./helpers";
 import { tzktGetSameMultisigsResponse } from "../../mocks/tzktResponse";
-import { MultisigWithOperations } from "./types";
+import { MultisigWithPendingOperations } from "./types";
 jest.mock("axios");
 
 const mockedAxios = axios as jest.Mocked<typeof axios>;
@@ -16,20 +16,20 @@ const mockedAxios = axios as jest.Mocked<typeof axios>;
 describe("multisig helpers", () => {
   test("buildAccountToMultisigsMap", async () => {
     const accounts = new Set([mockPkh(0), mockPkh(1), mockPkh(2)]);
-    const multisigs: MultisigWithOperations[] = [
+    const multisigs: MultisigWithPendingOperations[] = [
       {
         balance: "1",
         address: mockContract(0),
         signers: [mockPkh(0)],
         threshold: 1,
-        operations: [],
+        pendingOperations: [],
       },
       {
         balance: "0",
         address: mockContract(1),
         signers: [mockPkh(0), mockPkh(1), mockPkh(3)],
         threshold: 3,
-        operations: [],
+        pendingOperations: [],
       },
     ];
     const result = buildAccountToMultisigsMap(multisigs, accounts);
@@ -38,7 +38,7 @@ describe("multisig helpers", () => {
         {
           address: mockContract(1),
           balance: "0",
-          operations: [],
+          pendingOperations: [],
           signers: [mockPkh(0), mockPkh(1), mockPkh(3)],
           threshold: 3,
         },
@@ -47,14 +47,14 @@ describe("multisig helpers", () => {
         {
           address: mockContract(0),
           balance: "1",
-          operations: [],
+          pendingOperations: [],
           signers: [mockPkh(0)],
           threshold: 1,
         },
         {
           address: mockContract(1),
           balance: "0",
-          operations: [],
+          pendingOperations: [],
           signers: [mockPkh(0), mockPkh(1), mockPkh(3)],
           threshold: 3,
         },
@@ -121,7 +121,7 @@ describe("multisig helpers", () => {
       {
         address: mockContract(0),
         balance: "0",
-        operations: [
+        pendingOperations: [
           {
             approvals: [mockPkh(1)],
             key: "1",
@@ -134,7 +134,7 @@ describe("multisig helpers", () => {
       {
         address: mockContract(10),
         balance: "10",
-        operations: [
+        pendingOperations: [
           {
             approvals: [mockPkh(1)],
             key: "1",

--- a/src/utils/multisig/helpers.ts
+++ b/src/utils/multisig/helpers.ts
@@ -4,12 +4,12 @@ import { tzktGetSameMultisigsResponseType } from "../tzkt/types";
 import { getAllMultiSigContracts, getPendingOperations } from "./fetch";
 import {
   WalletAccountPkh,
-  MultisigWithOperations,
+  MultisigWithPendingOperations,
   AccountToMultisigs,
 } from "./types";
 
 export const buildAccountToMultisigsMap = (
-  multisigs: MultisigWithOperations[],
+  multisigs: MultisigWithPendingOperations[],
   accountPkhs: Set<WalletAccountPkh>
 ): AccountToMultisigs =>
   multisigs.reduce((acc: AccountToMultisigs, cur) => {
@@ -37,7 +37,7 @@ export const getRelevantMultisigContracts = async (
 export const getOperationsForMultisigs = async (
   network: TezosNetwork,
   multisigs: tzktGetSameMultisigsResponseType
-): Promise<MultisigWithOperations[]> => {
+): Promise<MultisigWithPendingOperations[]> => {
   const multisigsWithOperations = await Promise.all(
     multisigs.map(
       async ({
@@ -65,7 +65,7 @@ export const getOperationsForMultisigs = async (
           threshold: Number(threshold),
           signers,
           balance: balance.toString(),
-          operations: compact(operations),
+          pendingOperations: compact(operations),
         };
       }
     )

--- a/src/utils/multisig/types.ts
+++ b/src/utils/multisig/types.ts
@@ -8,15 +8,15 @@ export type MultisigOperation = {
   approvals: WalletAccountPkh[];
 };
 
-export type MultisigWithOperations = {
+export type MultisigWithPendingOperations = {
   address: MultisigAddress;
   threshold: number;
   signers: WalletAccountPkh[];
   balance: string;
-  operations: MultisigOperation[];
+  pendingOperations: MultisigOperation[];
 };
 
 export type AccountToMultisigs = Record<
   WalletAccountPkh,
-  MultisigWithOperations[] | undefined
+  MultisigWithPendingOperations[] | undefined
 >;

--- a/src/utils/multisigsReducer.test.ts
+++ b/src/utils/multisigsReducer.test.ts
@@ -1,4 +1,4 @@
-import { MultisigWithOperations } from "./multisig/types";
+import { MultisigWithPendingOperations } from "./multisig/types";
 import { multisigActions } from "./store/multisigsSlice";
 import { store } from "./store/store";
 
@@ -12,10 +12,10 @@ describe("Contacts reducer", () => {
   });
 
   test("should set new multisigs", () => {
-    const multisig: MultisigWithOperations = {
+    const multisig: MultisigWithPendingOperations = {
       address: "mockKt1",
       balance: "44",
-      operations: [],
+      pendingOperations: [],
       signers: [],
       threshold: 8,
     };

--- a/src/utils/store/multisigsSlice.ts
+++ b/src/utils/store/multisigsSlice.ts
@@ -1,8 +1,8 @@
 import { createSlice } from "@reduxjs/toolkit";
-import { MultisigWithOperations } from "../multisig/types";
+import { MultisigWithPendingOperations } from "../multisig/types";
 
 type State = {
-  items: MultisigWithOperations[];
+  items: MultisigWithPendingOperations[];
 };
 
 const initialState: State = { items: [] };
@@ -12,7 +12,7 @@ const multisigsSlice = createSlice({
   initialState,
   reducers: {
     reset: () => initialState,
-    set: (state, { payload }: { payload: MultisigWithOperations[] }) => {
+    set: (state, { payload }: { payload: MultisigWithPendingOperations[] }) => {
       state.items = payload;
     },
   },


### PR DESCRIPTION
## Proposed changes

[Task link](https://please-paste-here-the-task.url)

<!-- if that's a rewrite from the V1 add a corresponding link to code on gitlab
[Original implementation](https://gitlab.com/link)
 -->

Remove the inactive bigmpas(pending operations) for multisigs and rename from `operations` to `pendingOperations` as the bigmap only stores pending operations.

## Types of changes

_Put an `x` in the boxes that apply_

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation Update

## Steps to reproduce

- step one
- step two
- step three

## Screenshots

Add the screenshots of how the app used to look like and how it looks now

| Before | Now    |
| ------ | ------ |
| Image1 | Image2 |
| Image3 | Image4 |

## Checklist

- [x] Tests that prove my fix is effective or that my feature works have been added
- [ ] Documentation has been added (if appropriate)
- [ ] Screenshots are added (if any UI changes have been made)
- [ ] All TODOs have a corresponding task created (and the link is attached to it)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
