### PR TITLE
Remove selectedAccount from accountSlice

### DIFF
--- a/src/components/AccountCard/AccountCard.test.tsx
+++ b/src/components/AccountCard/AccountCard.test.tsx
@@ -14,7 +14,7 @@ import { uUSD } from "../../mocks/fa2Tokens";
 import { render, screen, within } from "../../mocks/testUtils";
 import { hedgeHoge, tzBtsc } from "../../mocks/fa12Tokens";
 const { updateAssets } = assetsSlice.actions;
-const { add, setSelected } = accountsSlice.actions;
+const { add } = accountsSlice.actions;
 
 const tezBalance = "33200000000";
 
@@ -23,7 +23,6 @@ const pkh = account.pkh;
 const mockNft = mockNFTToken(0, pkh);
 beforeAll(() => {
   store.dispatch(add([account]));
-  store.dispatch(setSelected(pkh));
   store.dispatch(updateAssets([{ pkh: pkh, tez: tezBalance }]));
   store.dispatch(
     updateAssets([

--- a/src/utils/accountsReducer.test.ts
+++ b/src/utils/accountsReducer.test.ts
@@ -11,7 +11,7 @@ import { deriveAccount, restoreFromMnemonic } from "./store/thunks/restoreMnemon
 import { getFingerPrint } from "./tezos";
 
 const {
-  actions: { add, reset, setSelected, removeSecret },
+  actions: { add, reset, removeSecret },
 } = accountsSlice;
 
 jest.mock("./aes");
@@ -33,7 +33,6 @@ describe("Accounts reducer", () => {
   test("store should initialize with empty state", () => {
     expect(store.getState().accounts).toEqual({
       items: [],
-      selected: null,
       seedPhrases: {},
     });
   });
@@ -42,14 +41,12 @@ describe("Accounts reducer", () => {
     store.dispatch(add(mockImplicitAccount(1)));
     expect(store.getState().accounts).toEqual({
       items: [mockImplicitAccount(1)],
-      selected: null,
       seedPhrases: {},
     });
 
     store.dispatch(add([mockImplicitAccount(2), mockImplicitAccount(3)]));
     expect(store.getState().accounts).toEqual({
       items: [mockImplicitAccount(1), mockImplicitAccount(2), mockImplicitAccount(3)],
-      selected: null,
       seedPhrases: {},
     });
   });
@@ -63,48 +60,6 @@ describe("Accounts reducer", () => {
 
     expect(store.getState().accounts).toEqual({
       items: [mockImplicitAccount(1), mockImplicitAccount(2), mockImplicitAccount(3)],
-      selected: null,
-      seedPhrases: {},
-    });
-  });
-
-  test("should allow setting an existing account as selected", () => {
-    store.dispatch(add([mockImplicitAccount(1), mockImplicitAccount(2), mockImplicitAccount(3)]));
-    store.dispatch(setSelected(mockImplicitAccount(2).pkh));
-
-    expect(store.getState().accounts).toEqual({
-      items: [mockImplicitAccount(1), mockImplicitAccount(2), mockImplicitAccount(3)],
-      selected: mockImplicitAccount(2).pkh,
-      seedPhrases: {},
-    });
-  });
-
-  test("should ignore setting a non existing account as selected", () => {
-    store.dispatch(add([mockImplicitAccount(1), mockImplicitAccount(2), mockImplicitAccount(3)]));
-    store.dispatch(setSelected(mockImplicitAccount(4).pkh));
-
-    expect(store.getState().accounts).toEqual({
-      items: [mockImplicitAccount(1), mockImplicitAccount(2), mockImplicitAccount(3)],
-      selected: null,
-      seedPhrases: {},
-    });
-  });
-
-  test("should allow settings selected account to null", () => {
-    store.dispatch(add([mockImplicitAccount(1), mockImplicitAccount(2), mockImplicitAccount(3)]));
-    store.dispatch(setSelected(mockImplicitAccount(2).pkh));
-
-    expect(store.getState().accounts).toEqual({
-      items: [mockImplicitAccount(1), mockImplicitAccount(2), mockImplicitAccount(3)],
-      selected: mockImplicitAccount(2).pkh,
-      seedPhrases: {},
-    });
-
-    store.dispatch(setSelected(null));
-
-    expect(store.getState().accounts).toEqual({
-      items: [mockImplicitAccount(1), mockImplicitAccount(2), mockImplicitAccount(3)],
-      selected: null,
       seedPhrases: {},
     });
   });
@@ -134,7 +89,6 @@ describe("Accounts reducer", () => {
         mockImplicitAccount(2, undefined, "mockPrint2"),
       ],
       seedPhrases: { mockPrint1: {}, mockPrint2: {} },
-      selected: null,
     });
 
     store.dispatch(removeSecret({ fingerPrint: "mockPrint1" }));
@@ -142,7 +96,6 @@ describe("Accounts reducer", () => {
     expect(store.getState().accounts).toEqual({
       items: [mockImplicitAccount(2, undefined, "mockPrint2")],
       seedPhrases: { mockPrint2: {} },
-      selected: null,
     });
   });
 

--- a/src/utils/store/accountsSlice.ts
+++ b/src/utils/store/accountsSlice.ts
@@ -5,13 +5,11 @@ import { deriveAccount, restoreFromMnemonic } from "./thunks/restoreMnemonicAcco
 
 type State = {
   items: ImplicitAccount[];
-  selected: null | string;
   seedPhrases: Record<string, UmamiEncrypted | undefined>;
 };
 
 const initialState: State = {
   items: [],
-  selected: null,
   seedPhrases: {},
 };
 
@@ -44,11 +42,6 @@ const accountsSlice = createSlice({
       const accounts = Array.isArray(payload) ? payload : [payload];
 
       state.items = concatUnique(state.items, accounts);
-    },
-    setSelected: (state, { payload }: { type: string; payload: string | null }) => {
-      if (state.items.some(a => a.pkh === payload || payload === null)) {
-        state.selected = payload;
-      }
     },
   },
 });


### PR DESCRIPTION
## Proposed changes

I remove `selectedAccount` from the accountsSlice because it's not used anywhere 

## Types of changes

_Put an `x` in the boxes that apply_

- [ ] Bugfix
- [ ] New feature
- [x] Refactor
- [ ] Breaking change
- [ ] Documentation Update
