### PR TITLE
Remove error never hack

### DIFF
--- a/src/GoogleAuth.tsx
+++ b/src/GoogleAuth.tsx
@@ -49,18 +49,14 @@ export type GoogleAuthProps = {
 
 export const DEFAULT_BTN_TEXT = "Connect with Google";
 
-const toTorusNetwork = (n: TezosNetwork): TORUS_NETWORK_TYPE => {
-  if (n === TezosNetwork.MAINNET) {
-    return "mainnet";
+const toTorusNetwork = (network: TezosNetwork): TORUS_NETWORK_TYPE => {
+  switch (network) {
+    case TezosNetwork.MAINNET:
+      return "mainnet";
+    // Testnet not working
+    case TezosNetwork.GHOSTNET:
+      return "testnet";
   }
-
-  // Testnet not working
-  if (n === TezosNetwork.GHOSTNET) {
-    return "testnet";
-  }
-
-  const error: never = n;
-  throw new Error(error);
 };
 
 export const GoogleAuth: React.FC<GoogleAuthProps> = ({


### PR DESCRIPTION
## Proposed changes

1st commit removes the hacky way to make typescript check the if-else/switch-case exhaustiveness. It is covered by the [linter rule](https://typescript-eslint.io/rules/switch-exhaustiveness-check/) without the need in the hack.
2nd commit converts TemporaryAccountConfig classes into types because `instanceof` doesn't really work with the aforementioned check (neither `error: never` nor the linter rule).


## Types of changes

_Put an `x` in the boxes that apply_

- [x] Bugfix
- [ ] New feature
- [x] Refactor
- [ ] Breaking change
- [ ] Documentation Update
