### PR TITLE
Introduce Address type

### DIFF
--- a/src/components/AccountCard/AccountCard.test.tsx
+++ b/src/components/AccountCard/AccountCard.test.tsx
@@ -19,7 +19,7 @@ const { add } = accountsSlice.actions;
 const tezBalance = "33200000000";
 
 const account = mockImplicitAccount(0);
-const pkh = account.pkh;
+const pkh = account.address.pkh;
 const mockNft = mockNFTToken(0, pkh);
 beforeAll(() => {
   store.dispatch(add([account]));
@@ -27,7 +27,7 @@ beforeAll(() => {
   store.dispatch(
     updateAssets([
       {
-        pkh: mockImplicitAccount(0).pkh,
+        pkh: mockImplicitAccount(0).address.pkh,
         tokens: [hedgeHoge, tzBtsc, uUSD, mockFA1Token(1, mockPkh(1), 123), mockNft],
       },
     ])

--- a/src/components/AccountCard/AccountCardDisplay.tsx
+++ b/src/components/AccountCard/AccountCardDisplay.tsx
@@ -9,7 +9,7 @@ import { Identicon } from "../Identicon";
 import { TezRecapDisplay } from "../TezRecapDisplay";
 import { AssetsPannel } from "./AssetsPannel/AssetsPannel";
 import type { BigNumber } from "bignumber.js";
-import { AccountType, AllAccount } from "../../types/Account";
+import { AccountType, Account } from "../../types/Account";
 import MultisigApprovers from "./MultisigApprovers";
 
 type Props = {
@@ -23,7 +23,7 @@ type Props = {
   dollarBalance: BigNumber | null;
   tokens: Array<FA12Token | FA2Token>;
   nfts: Array<NFT>;
-  account: AllAccount;
+  account: Account;
 };
 
 const RoundButton: React.FC<{

--- a/src/components/AccountCard/AssetsPannel/AssetsPannel.tsx
+++ b/src/components/AccountCard/AssetsPannel/AssetsPannel.tsx
@@ -1,6 +1,6 @@
 import { Box, Tab, TabList, TabPanel, TabPanels, Tabs, UnorderedList } from "@chakra-ui/react";
 import React from "react";
-import { AccountType, AllAccount } from "../../../types/Account";
+import { AccountType, Account } from "../../../types/Account";
 import { FA12Token, FA2Token, NFT } from "../../../types/Asset";
 import MultisigPendingList from "./MultisigPendingList";
 import { NFTsGrid } from "./NFTsGrid";
@@ -9,7 +9,7 @@ import TokenTile from "./TokenTile";
 export const AssetsPannel: React.FC<{
   tokens: Array<FA12Token | FA2Token>;
   nfts: Array<NFT>;
-  account: AllAccount;
+  account: Account;
 }> = ({ tokens, nfts, account }) => {
   const isMultisig = account.type === AccountType.MULTISIG;
   return (

--- a/src/components/AccountCard/AssetsPannel/MultisigActionButton.test.tsx
+++ b/src/components/AccountCard/AssetsPannel/MultisigActionButton.test.tsx
@@ -12,14 +12,14 @@ describe("<ActionButton/>", () => {
   it("should display execute for non-pending operation with signer included in the owned account", () => {
     const account = mockImplicitAccount(0);
     store.dispatch(add([account]));
-    render(<MultisigActionButton signer={account.pkh} approvers={[]} pendingApprovals={0} />);
+    render(<MultisigActionButton signer={account.address} approvers={[]} pendingApprovals={0} />);
     expect(screen.getByTestId("multisig-signer-button")).toHaveTextContent("Execute");
   });
 
   it("should display approve for pending operation with signer included in the owned account", () => {
     const account = mockImplicitAccount(0);
     store.dispatch(add([account]));
-    render(<MultisigActionButton signer={account.pkh} approvers={[]} pendingApprovals={1} />);
+    render(<MultisigActionButton signer={account.address} approvers={[]} pendingApprovals={1} />);
     expect(screen.getByTestId("multisig-signer-button")).toHaveTextContent("Approve");
   });
 
@@ -27,7 +27,11 @@ describe("<ActionButton/>", () => {
     const account = mockImplicitAccount(0);
     store.dispatch(add([account]));
     render(
-      <MultisigActionButton signer={account.pkh} approvers={[account.pkh]} pendingApprovals={1} />
+      <MultisigActionButton
+        signer={account.address}
+        approvers={[account.address]}
+        pendingApprovals={1}
+      />
     );
     expect(screen.getByTestId("multisig-signer-approved")).toHaveTextContent("Approved");
   });
@@ -35,14 +39,18 @@ describe("<ActionButton/>", () => {
   it("should show approved for operation with signers not in the account", () => {
     const account = mockImplicitAccount(0);
     render(
-      <MultisigActionButton signer={account.pkh} approvers={[account.pkh]} pendingApprovals={1} />
+      <MultisigActionButton
+        signer={account.address}
+        approvers={[account.address]}
+        pendingApprovals={1}
+      />
     );
     expect(screen.getByTestId("multisig-signer-approved-or-waiting")).toHaveTextContent("Approved");
   });
 
   it("should show Awaiting approval for operation with signers not owned by the user account that hasn't approved", () => {
     const account = mockImplicitAccount(0);
-    render(<MultisigActionButton signer={account.pkh} approvers={[]} pendingApprovals={1} />);
+    render(<MultisigActionButton signer={account.address} approvers={[]} pendingApprovals={1} />);
     expect(screen.getByTestId("multisig-signer-approved-or-waiting")).toHaveTextContent(
       "Awaiting Approval"
     );

--- a/src/components/AccountCard/AssetsPannel/MultisigActionButton.tsx
+++ b/src/components/AccountCard/AssetsPannel/MultisigActionButton.tsx
@@ -3,19 +3,19 @@ import React from "react";
 import { CgSandClock } from "react-icons/cg";
 import { RxCheckCircled } from "react-icons/rx";
 import colors from "../../../style/colors";
+import { ImplicitAddress } from "../../../types/Address";
 import { useGetImplicitAccount } from "../../../utils/hooks/accountHooks";
-import { WalletAccountPkh } from "../../../utils/multisig/types";
 import { IconAndTextBtn } from "../../IconAndTextBtn";
 
 export const MultisigActionButton: React.FC<{
-  signer: WalletAccountPkh;
-  approvers: WalletAccountPkh[];
+  signer: ImplicitAddress;
+  approvers: ImplicitAddress[];
   pendingApprovals: number;
 }> = ({ signer, approvers, pendingApprovals }) => {
   const getImplicitAccount = useGetImplicitAccount();
 
-  const signerInOwnedAccounts = getImplicitAccount(signer) !== undefined;
-  const approvedBySigner = approvers.find(approver => approver === signer) !== undefined;
+  const signerInOwnedAccounts = getImplicitAccount(signer.pkh) !== undefined;
+  const approvedBySigner = approvers.find(approver => approver.pkh === signer.pkh) !== undefined;
   const operationIsExecutable = pendingApprovals === 0;
 
   if (!signerInOwnedAccounts) {

--- a/src/components/AccountCard/AssetsPannel/MultisigPendingCard.test.tsx
+++ b/src/components/AccountCard/AssetsPannel/MultisigPendingCard.test.tsx
@@ -12,10 +12,14 @@ describe("<MultisigPendingCard/>", () => {
         operation={{
           key: "1",
           rawActions: "action",
-          approvals: [pkh0],
+          approvals: [{ type: "implicit", pkh: pkh0 }],
         }}
         threshold={3}
-        signers={[pkh0, pkh1, pkh2]}
+        signers={[
+          { type: "implicit", pkh: pkh0 },
+          { type: "implicit", pkh: pkh1 },
+          { type: "implicit", pkh: pkh2 },
+        ]}
       />
     );
 
@@ -31,10 +35,18 @@ describe("<MultisigPendingCard/>", () => {
         operation={{
           key: "1",
           rawActions: "action",
-          approvals: [pkh0, pkh1, pkh2],
+          approvals: [
+            { type: "implicit", pkh: pkh0 },
+            { type: "implicit", pkh: pkh1 },
+            { type: "implicit", pkh: pkh2 },
+          ],
         }}
         threshold={2}
-        signers={[pkh0, pkh1, pkh2]}
+        signers={[
+          { type: "implicit", pkh: pkh0 },
+          { type: "implicit", pkh: pkh1 },
+          { type: "implicit", pkh: pkh2 },
+        ]}
       />
     );
 

--- a/src/components/AccountCard/AssetsPannel/MultisigPendingCard.tsx
+++ b/src/components/AccountCard/AssetsPannel/MultisigPendingCard.tsx
@@ -2,12 +2,13 @@ import { Box, Flex, Text, Heading, Icon, useDisclosure } from "@chakra-ui/react"
 import React from "react";
 import { IoIosArrowDown, IoIosArrowUp } from "react-icons/io";
 import colors from "../../../style/colors";
-import { MultisigOperation, WalletAccountPkh } from "../../../utils/multisig/types";
+import { ImplicitAddress } from "../../../types/Address";
+import { MultisigOperation } from "../../../utils/multisig/types";
 import MultisigSignerTile from "./MultisigSignerTile";
 
 export const MultisigPendingCard: React.FC<{
   operation: MultisigOperation;
-  signers: WalletAccountPkh[];
+  signers: ImplicitAddress[];
   threshold: number;
 }> = ({ operation, signers, threshold }) => {
   const { isOpen, getDisclosureProps, getButtonProps } = useDisclosure({
@@ -45,7 +46,7 @@ export const MultisigPendingCard: React.FC<{
         <Box marginY={5}>
           {signers.map(signer => (
             <MultisigSignerTile
-              key={signer}
+              key={signer.pkh}
               signer={signer}
               approvers={operation.approvals}
               pendingApprovals={pendingApprovals}

--- a/src/components/AccountCard/AssetsPannel/MultisigSignerTile.test.tsx
+++ b/src/components/AccountCard/AssetsPannel/MultisigSignerTile.test.tsx
@@ -12,7 +12,7 @@ describe("<MultisigSignerTile/>", () => {
   it("should display a button for non-pending operation with signer included in the account", () => {
     const account = mockImplicitAccount(0);
     store.dispatch(add([account]));
-    render(<MultisigSignerTile signer={account.pkh} approvers={[]} pendingApprovals={0} />);
+    render(<MultisigSignerTile signer={account.address} approvers={[]} pendingApprovals={0} />);
     expect(screen.getByTestId("multisig-signer-button")).toBeInTheDocument();
   });
 
@@ -20,7 +20,11 @@ describe("<MultisigSignerTile/>", () => {
     const account = mockImplicitAccount(0);
     store.dispatch(add([account]));
     render(
-      <MultisigSignerTile signer={account.pkh} approvers={[account.pkh]} pendingApprovals={1} />
+      <MultisigSignerTile
+        signer={account.address}
+        approvers={[account.address]}
+        pendingApprovals={1}
+      />
     );
     expect(screen.queryByTestId("multisig-signer-button")).not.toBeInTheDocument();
   });
@@ -28,7 +32,11 @@ describe("<MultisigSignerTile/>", () => {
   it("should hide button for operation with signers not in the account", () => {
     const account = mockImplicitAccount(0);
     render(
-      <MultisigSignerTile signer={account.pkh} approvers={[account.pkh]} pendingApprovals={1} />
+      <MultisigSignerTile
+        signer={account.address}
+        approvers={[account.address]}
+        pendingApprovals={1}
+      />
     );
     expect(screen.queryByTestId("multisig-signer-button")).not.toBeInTheDocument();
   });

--- a/src/components/AccountCard/AssetsPannel/MultisigSignerTile.tsx
+++ b/src/components/AccountCard/AssetsPannel/MultisigSignerTile.tsx
@@ -1,22 +1,22 @@
 import { Box, Flex, Text, Heading } from "@chakra-ui/react";
 import React from "react";
 import colors from "../../../style/colors";
+import { ImplicitAddress } from "../../../types/Address";
 import { formatPkh } from "../../../utils/format";
 import { useGetImplicitAccount } from "../../../utils/hooks/accountHooks";
 import { useGetContractName } from "../../../utils/hooks/contactsHooks";
-import { WalletAccountPkh } from "../../../utils/multisig/types";
 import { Identicon } from "../../Identicon";
 import MultisigActionButton from "./MultisigActionButton";
 
 const MultisigSignerTile: React.FC<{
-  signer: WalletAccountPkh;
-  approvers: WalletAccountPkh[];
+  signer: ImplicitAddress;
+  approvers: ImplicitAddress[];
   pendingApprovals: number;
 }> = ({ signer, approvers, pendingApprovals }) => {
   const getContactName = useGetContractName();
   const getImplicitAccount = useGetImplicitAccount();
-  const accountLabel = getImplicitAccount(signer)?.label;
-  const label = accountLabel || getContactName(signer);
+  const accountLabel = getImplicitAccount(signer.pkh)?.label;
+  const label = accountLabel || getContactName(signer.pkh);
 
   return (
     <Flex
@@ -28,13 +28,13 @@ const MultisigSignerTile: React.FC<{
       border={`1px solid ${colors.gray[800]}`}
       alignItems="center"
     >
-      <Identicon address={signer} />
+      <Identicon address={signer.pkh} />
       <Flex flex={1} justifyContent="space-between" alignItems="center">
         <Box m={4}>
           {label && <Heading size={"md"}>{label}</Heading>}
           <Flex alignItems={"center"}>
             <Text size={"sm"} color="text.dark">
-              {formatPkh(signer)}
+              {formatPkh(signer.pkh)}
             </Text>
           </Flex>
         </Box>

--- a/src/components/AccountCard/MultisigApprovers.test.tsx
+++ b/src/components/AccountCard/MultisigApprovers.test.tsx
@@ -1,14 +1,15 @@
 import MultisigApprovers from "./MultisigApprovers";
 import { fireEvent, render, screen } from "../../mocks/testUtils";
+import { mockPkh } from "../../mocks/factories";
 describe("<MultisigApprovers/>", () => {
   it("should display approvers by default", () => {
-    render(<MultisigApprovers signers={["singer1"]} />);
+    render(<MultisigApprovers signers={[{ type: "implicit", pkh: mockPkh(0) }]} />);
 
     expect(screen.getByTestId("multisig-tag-section")).toBeInTheDocument();
   });
 
   it("should hide approvers on click", () => {
-    render(<MultisigApprovers signers={["singer1"]} />);
+    render(<MultisigApprovers signers={[{ type: "implicit", pkh: mockPkh(0) }]} />);
     const button = screen.getByTestId("multisig-toggle-button");
     fireEvent.click(button);
     expect(screen.queryByTestId("multisig-tag-section")).toBeFalsy();

--- a/src/components/AccountCard/MultisigApprovers.tsx
+++ b/src/components/AccountCard/MultisigApprovers.tsx
@@ -2,11 +2,11 @@ import { Box, Flex, Heading, Icon, Tag, useDisclosure, Wrap, WrapItem } from "@c
 import React from "react";
 import { IoIosArrowDown, IoIosArrowUp } from "react-icons/io";
 import colors from "../../style/colors";
-import { WalletAccountPkh } from "../../utils/multisig/types";
+import { ImplicitAddress } from "../../types/Address";
 import AccountOrContactTile from "../AccountOrContactTile";
 
 const MultisigApprovers: React.FC<{
-  signers: WalletAccountPkh[];
+  signers: ImplicitAddress[];
 }> = ({ signers }) => {
   const { isOpen, getButtonProps } = useDisclosure({
     defaultIsOpen: true,
@@ -27,11 +27,16 @@ const MultisigApprovers: React.FC<{
       </Flex>
       {isOpen && (
         <Wrap mt="3" data-testid="multisig-tag-section">
-          {signers.map(pkh => {
+          {signers.map(address => {
             return (
-              <WrapItem key={pkh} borderRadius="100px" padding="3px 8px" bg={colors.gray[600]}>
+              <WrapItem
+                key={address.pkh}
+                borderRadius="100px"
+                padding="3px 8px"
+                bg={colors.gray[600]}
+              >
                 <Tag data-testid="multisig-tag" color={colors.gray[400]} borderRadius="full">
-                  <AccountOrContactTile pkh={pkh} />
+                  <AccountOrContactTile pkh={address.pkh} />
                 </Tag>
               </WrapItem>
             );

--- a/src/components/AccountCard/index.tsx
+++ b/src/components/AccountCard/index.tsx
@@ -1,4 +1,4 @@
-import { AllAccount } from "../../types/Account";
+import { Account } from "../../types/Account";
 import { mutezToTez } from "../../utils/format";
 import {
   useGetAccountAllTokens,
@@ -10,7 +10,7 @@ import { useSendFormModal } from "../../views/home/useSendFormModal";
 import { useReceiveModal } from "../ReceiveModal";
 import { AccountCardDisplay } from "./AccountCardDisplay";
 
-export const AccountCard: React.FC<{ account: AllAccount }> = ({ account }) => {
+export const AccountCard: React.FC<{ account: Account }> = ({ account }) => {
   const accountBalance = useGetAccountBalance();
   const getDollarBalance = useGetDollarBalance();
 
@@ -23,27 +23,27 @@ export const AccountCard: React.FC<{ account: AllAccount }> = ({ account }) => {
     return null;
   }
 
-  const balance = accountBalance(account.pkh);
+  const balance = accountBalance(account.address.pkh);
   const tez = balance || null;
-  const dollarBalance = getDollarBalance(account.pkh);
+  const dollarBalance = getDollarBalance(account.address.pkh);
 
-  const tokens = getTokens(account.pkh);
-  const nfts = getNFTs(account.pkh);
+  const tokens = getTokens(account.address.pkh);
+  const nfts = getNFTs(account.address.pkh);
   return (
     <>
       <AccountCardDisplay
         onSend={() =>
           onOpenSend({
             mode: { type: "tez" },
-            sender: account?.pkh,
+            sender: account?.address.pkh,
           })
         }
-        pkh={account.pkh}
+        pkh={account.address.pkh}
         label={account.label || ""}
         tezBalance={tez && mutezToTez(tez)}
         dollarBalance={dollarBalance}
         onReceive={() => {
-          onOpenReceive({ pkh: account.pkh });
+          onOpenReceive({ pkh: account.address.pkh });
         }}
         tokens={tokens}
         nfts={nfts}

--- a/src/components/AccountSelector/AccountSelector.tsx
+++ b/src/components/AccountSelector/AccountSelector.tsx
@@ -6,7 +6,7 @@ import { useImplicitAccounts } from "../../utils/hooks/accountHooks";
 import { AccountSmallTileDisplay } from "./AccountSmallTile";
 
 const renderAccount = (account: ImplicitAccount) => (
-  <AccountSmallTileDisplay pkh={account.pkh} label={account.label} />
+  <AccountSmallTileDisplay pkh={account.address.pkh} label={account.label} />
 );
 
 export const ConnectedAccountSelector: React.FC<{
@@ -15,7 +15,7 @@ export const ConnectedAccountSelector: React.FC<{
   isDisabled?: boolean;
 }> = ({ onSelect = () => {}, selected, isDisabled }) => {
   const accounts = useImplicitAccounts();
-  const selectedAccount = accounts.find(a => a.pkh === selected);
+  const selectedAccount = accounts.find(a => a.address.pkh === selected);
 
   return (
     <Menu>
@@ -33,12 +33,12 @@ export const ConnectedAccountSelector: React.FC<{
       <MenuList bg={"umami.gray.900"}>
         {accounts.map(account => (
           <MenuItem
-            value={account.pkh}
+            value={account.address.pkh}
             aria-label={account.label}
             onClick={e => {
               onSelect(account);
             }}
-            key={account.pkh}
+            key={account.address.pkh}
             minH="48px"
             w="100%"
             // TODO implement hover color that disapeared

--- a/src/components/AccountSelector/AccountSmallTile.tsx
+++ b/src/components/AccountSelector/AccountSmallTile.tsx
@@ -24,6 +24,8 @@ export const AccountSmallTileDisplay = ({
 
 export const AccountSmallTile = ({ pkh }: { pkh: string }) => {
   const accounts = useImplicitAccounts();
-  const account = accounts.find(a => a.pkh === pkh);
-  return account ? <AccountSmallTileDisplay pkh={account.pkh} label={account.label} /> : null;
+  const account = accounts.find(a => a.address.pkh === pkh);
+  return account ? (
+    <AccountSmallTileDisplay pkh={account.address.pkh} label={account.label} />
+  ) : null;
 };

--- a/src/components/AccountToContactTile.test.tsx
+++ b/src/components/AccountToContactTile.test.tsx
@@ -38,7 +38,7 @@ describe("ContactTile", () => {
 describe("AccountOrContactTile", () => {
   it("displays account label if the address is in accounts", () => {
     const account = mockImplicitAccount(0);
-    const pkh = account.pkh;
+    const pkh = account.address.pkh;
     store.dispatch(add(account));
     render(AccountOrContactTileFixture(pkh));
     expect(screen.queryByTestId("account-or-contact-tile")).toHaveTextContent(account.label);

--- a/src/components/BuyTez/BuyTezForm.tsx
+++ b/src/components/BuyTez/BuyTezForm.tsx
@@ -55,7 +55,7 @@ const BuyTezForm = () => {
                   <ConnectedAccountSelector
                     selected={value}
                     onSelect={account => {
-                      onChange(account.pkh);
+                      onChange(account.address.pkh);
                     }}
                   />
                 )}

--- a/src/components/CSVFileUploader/CSVFileUploadForm.tsx
+++ b/src/components/CSVFileUploader/CSVFileUploadForm.tsx
@@ -23,14 +23,12 @@ import {
 import { useAppDispatch } from "../../utils/store/hooks";
 import { estimateAndUpdateBatch } from "../../utils/store/thunks/estimateAndupdateBatch";
 import { ConnectedAccountSelector } from "../AccountSelector/AccountSelector";
-import { useGetPk } from "../sendForm/SendForm";
 import { CSVRow } from "./types";
 import { csvRowToOperationValue, parseToCSVRow } from "./utils";
 
 const CSVFileUploadForm: FC<{ onClose: () => void }> = ({ onClose }) => {
   const network = useSelectedNetwork();
   const toast = useToast();
-  const getPk = useGetPk();
   const getAssetsLookup = useGetAccountAssetsLookup();
   const dispatch = useAppDispatch();
   const isSimulating = useBatchIsSimulating();
@@ -100,7 +98,7 @@ const CSVFileUploadForm: FC<{ onClose: () => void }> = ({ onClose }) => {
         csvRowToOperationValue(sender, csvRow, assetLookup)
       );
 
-      await dispatch(estimateAndUpdateBatch(sender, getPk(sender), operationValues, network));
+      await dispatch(estimateAndUpdateBatch(sender, operationValues, network));
 
       toast({ title: "CSV added to batch!" });
       onClose();
@@ -126,7 +124,7 @@ const CSVFileUploadForm: FC<{ onClose: () => void }> = ({ onClose }) => {
               <ConnectedAccountSelector
                 selected={value}
                 onSelect={account => {
-                  onChange(account.pkh);
+                  onChange(account.address.pkh);
                 }}
               />
             )}

--- a/src/components/Onboarding/masterPassword/MasterPassword.tsx
+++ b/src/components/Onboarding/masterPassword/MasterPassword.tsx
@@ -44,11 +44,11 @@ export const MasterPassword = ({
         if (!config.derivationPath) throw new Error("DerivationPath not set");
         if (!config.pk) throw new Error("Pk not set");
         if (!config.pkh) throw new Error("Pkh not set");
-        await restoreLedger(config.derivationPath, config.pk, config.pkh, config.label);
+        await restoreLedger(config.derivationPath, config.pkh, config.label);
       } else if (config instanceof TemporarySocialAccountConfig) {
         if (!config.pk) throw new Error("Pk not set");
         if (!config.pkh) throw new Error("Pkh not set");
-        await restoreSocial(config.pk, config.pkh, config.label);
+        await restoreSocial(config.pkh, config.label);
       } else {
         const error: never = config;
         throw new Error(error);

--- a/src/components/RecipientAutoComplete/RecipientAutoComplete.tsx
+++ b/src/components/RecipientAutoComplete/RecipientAutoComplete.tsx
@@ -155,9 +155,9 @@ export const RecipientAutoCompleteDisplay: React.FC<BaseProps & { contacts: Cont
 export const RecipentAutoComplete: React.FC<BaseProps> = props => {
   const contacts = Object.values(useAppSelector(s => s.contacts));
 
-  const accounts = useImplicitAccounts().map(a => ({
-    name: a.label,
-    pkh: a.pkh,
+  const accounts = useImplicitAccounts().map(account => ({
+    name: account.label,
+    pkh: account.address.pkh,
   }));
 
   return <RecipientAutoCompleteDisplay {...props} contacts={contacts.concat(accounts)} />;

--- a/src/components/sendForm/SendForm.test.tsx
+++ b/src/components/sendForm/SendForm.test.tsx
@@ -105,16 +105,16 @@ describe("<SendForm />", () => {
     });
 
     test("should render first step with sender prefiled if provided", () => {
-      render(fixture(mockImplicitAccount(1).pkh));
+      render(fixture(mockImplicitAccount(1).address.pkh));
       expect(screen.getByTestId(/account-selector/)).toHaveTextContent(
-        formatPkh(mockImplicitAccount(1).pkh)
+        formatPkh(mockImplicitAccount(1).address.pkh)
       );
     });
 
     const fillForm = async () => {
-      render(fixture(mockImplicitAccount(1).pkh));
+      render(fixture(mockImplicitAccount(1).address.pkh));
       expect(screen.getByTestId(/account-selector/)).toHaveTextContent(
-        formatPkh(mockImplicitAccount(1).pkh)
+        formatPkh(mockImplicitAccount(1).address.pkh)
       );
 
       const amountInput = screen.getByLabelText(/amount/i);
@@ -186,7 +186,7 @@ describe("<SendForm />", () => {
         });
         expect(addToBatchBtn).toBeEnabled();
       });
-      const batch = store.getState().assets.batches[mockImplicitAccount(1).pkh];
+      const batch = store.getState().assets.batches[mockImplicitAccount(1).address.pkh];
       expect(batch).toEqual({
         isSimulating: false,
         items: [
@@ -215,7 +215,7 @@ describe("<SendForm />", () => {
         expect(mockToast).toHaveBeenCalledTimes(2);
       });
 
-      const batch2 = store.getState().assets.batches[mockImplicitAccount(1).pkh];
+      const batch2 = store.getState().assets.batches[mockImplicitAccount(1).address.pkh];
       expect(batch2).toEqual({
         isSimulating: false,
         items: [
@@ -253,7 +253,7 @@ describe("<SendForm />", () => {
       const mockBatchItems = [{} as BatchItem];
       store.dispatch(
         assetsSlice.actions.updateBatch({
-          pkh: mockImplicitAccount(1).pkh,
+          pkh: mockImplicitAccount(1).address.pkh,
           items: mockBatchItems,
         })
       );
@@ -277,7 +277,7 @@ describe("<SendForm />", () => {
       await waitFor(() => {
         expect(screen.getByText(/Operation Submitted/i)).toBeTruthy();
       });
-      expect(store.getState().assets.batches[mockImplicitAccount(1).pkh]?.items).toEqual(
+      expect(store.getState().assets.batches[mockImplicitAccount(1).address.pkh]?.items).toEqual(
         mockBatchItems
       );
     });
@@ -394,7 +394,6 @@ describe("<SendForm />", () => {
           },
         ],
         "tz1ikfEcj3LmsmxpcC1RMZNzBHbEmybCc43D",
-        "edpkuwYWCugiYG7nMnVUdopFmyc3sbMSiLqsJHTQgGtVhtSdLSw6H2",
         "mainnet"
       );
 
@@ -509,7 +508,6 @@ describe("<SendForm />", () => {
           },
         ],
         "tz1ikfEcj3LmsmxpcC1RMZNzBHbEmybCc43D",
-        "edpkuwYWCugiYG7nMnVUdopFmyc3sbMSiLqsJHTQgGtVhtSdLSw6H2",
         "mainnet"
       );
 
@@ -557,7 +555,7 @@ describe("<SendForm />", () => {
     const fillFormAndSimulate = async () => {
       render(fixture(undefined, { type: "token", data: mockNFT(1) }));
       expect(screen.getByTestId(/account-selector/)).toHaveTextContent(
-        formatPkh(mockImplicitAccount(1).pkh)
+        formatPkh(mockImplicitAccount(1).address.pkh)
       );
 
       // const amountInput = screen.getByLabelText(/amount/i);
@@ -675,12 +673,12 @@ describe("<SendForm />", () => {
     //   render(fixture(undefined, { type: "delegation" }));
     //   const senderInput = screen.getByText(/select an account/i);
     //   fireEvent.click(senderInput);
-    //   // userEvent.selectOptions(senderInput, mockAccount(1).pkh);
+    //   // userEvent.selectOptions(senderInput, mockAccount(1).address.pkh);
     // });
   });
   describe("case send tez with Google account", () => {
     const fillForm = async () => {
-      render(fixture(mockImplicitAccount(4, AccountType.SOCIAL).pkh));
+      render(fixture(mockImplicitAccount(4, AccountType.SOCIAL).address.pkh));
 
       const amountInput = screen.getByLabelText(/amount/i);
       fireEvent.change(amountInput, { target: { value: 23 } });
@@ -737,7 +735,7 @@ describe("<SendForm />", () => {
 
   describe("case send tez with Ledger account", () => {
     const fillForm = async () => {
-      render(fixture(mockImplicitAccount(5, AccountType.LEDGER).pkh));
+      render(fixture(mockImplicitAccount(5, AccountType.LEDGER).address.pkh));
 
       const amountInput = screen.getByLabelText(/amount/i);
       fireEvent.change(amountInput, { target: { value: 23 } });

--- a/src/components/sendForm/steps/FillStep.tsx
+++ b/src/components/sendForm/steps/FillStep.tsx
@@ -75,7 +75,7 @@ export const DelegateForm = ({
                   isDisabled={undelegate || disabled}
                   selected={value}
                   onSelect={a => {
-                    onChange(a.pkh);
+                    onChange(a.address.pkh);
                   }}
                 />
               )}
@@ -231,7 +231,7 @@ export const SendTezOrNFTForm = ({
                   isDisabled={isNFT || simulating || disabled}
                   selected={value}
                   onSelect={a => {
-                    onChange(a.pkh);
+                    onChange(a.address.pkh);
                   }}
                 />
               )}

--- a/src/components/sendForm/steps/SubmitStep.tsx
+++ b/src/components/sendForm/steps/SubmitStep.tsx
@@ -86,7 +86,7 @@ export const RecapDisplay: React.FC<{
       const result = await submitBatch(transfer, config);
       if (isBatch) {
         // TODO this will have to me moved in a thunk
-        clearBatch(signerAccount.pkh);
+        clearBatch(signerAccount.address.pkh);
       }
       onSucces(result.opHash);
       toast({ title: "Success", description: result.opHash });
@@ -111,7 +111,7 @@ export const RecapDisplay: React.FC<{
               <Heading size="md" width={20}>
                 From:
               </Heading>
-              <AccountSmallTile pkh={signerAccount.pkh} />
+              <AccountSmallTile pkh={signerAccount.address.pkh} />
             </Flex>
             {isBatch ? (
               <BatchRecap transfer={transfer} />

--- a/src/integration/tezos.integration.test.ts
+++ b/src/integration/tezos.integration.test.ts
@@ -7,7 +7,6 @@ import { estimateBatch, operationValuesToBatchParams } from "../utils/tezos";
 
 jest.unmock("../utils/tezos");
 
-const pk0 = devPublicKeys0.pk;
 const pkh0 = devPublicKeys0.pkh;
 const pkh1 = devPublicKeys1.pkh;
 
@@ -75,7 +74,7 @@ describe("Tezos utils", () => {
         },
       ];
 
-      const result = await operationValuesToBatchParams(input, pk0, TezosNetwork.GHOSTNET);
+      const result = await operationValuesToBatchParams(input, TezosNetwork.GHOSTNET);
       expect(result).toEqual([
         {
           amount: 3,
@@ -238,7 +237,6 @@ describe("Tezos utils", () => {
             },
           ],
           pkh0,
-          pk0,
           TezosNetwork.GHOSTNET
         );
 
@@ -268,7 +266,6 @@ describe("Tezos utils", () => {
             },
           ],
           pkh0,
-          pk0,
           TezosNetwork.MAINNET
         );
 
@@ -291,7 +288,6 @@ describe("Tezos utils", () => {
             },
           ],
           pkh0,
-          pk0,
           TezosNetwork.MAINNET
         );
 
@@ -321,7 +317,6 @@ describe("Tezos utils", () => {
             },
           ],
           pkh0,
-          pk0,
           TezosNetwork.MAINNET
         );
 

--- a/src/mocks/factories.ts
+++ b/src/mocks/factories.ts
@@ -97,14 +97,17 @@ export const mockImplicitAccount = (
   type = AccountType.MNEMONIC,
   fingerPrint = "mockPrint"
 ): ImplicitAccount => {
+  // TODO: convert to switch
   if (type === AccountType.MNEMONIC) {
     const account: MnemonicAccount = {
       curve: "ed25519",
       derivationPath: getDefaultMnemonicDerivationPath(index),
       type,
       label: mockAccountLabel(index),
-      pkh: mockPkh(index),
-      pk: mockPk(index),
+      address: {
+        type: "implicit",
+        pkh: mockPkh(index),
+      },
       seedFingerPrint: `${fingerPrint}`,
     };
     return account;
@@ -114,8 +117,10 @@ export const mockImplicitAccount = (
     const account: SocialAccount = {
       type: AccountType.SOCIAL,
       label: "google " + mockAccountLabel(index),
-      pkh: mockPkh(index),
-      pk: mockPk(index),
+      address: {
+        type: "implicit",
+        pkh: mockPkh(index),
+      },
       idp: "google",
     };
     return account;
@@ -127,8 +132,10 @@ export const mockImplicitAccount = (
       derivationPath: getLedgerDerivationPath(index),
       curve: "ed25519",
       label: mockAccountLabel(index) + " ledger",
-      pkh: mockPkh(index),
-      pk: mockPk(index),
+      address: {
+        type: "implicit",
+        pkh: mockPkh(index),
+      },
     };
     return account;
   }
@@ -139,30 +146,17 @@ export const mockImplicitAccount = (
 export const mockMultisigAccount = (index: number): MultisigAccount => {
   return {
     type: AccountType.MULTISIG,
-    pkh: mockPkh(index),
+    address: {
+      type: "contract",
+      pkh: mockPkh(index),
+    },
     label: "label",
     threshold: 1,
-    signers: ["signers2"],
+    signers: [{ type: "implicit", pkh: mockPkh(index) }],
     balance: "1",
     operations: [],
   };
 };
-
-// Might need this later
-//
-// export const mockMultisigAccount = (
-//   index: number,
-//   proposals: MultisigOperation[] = []
-// ) => {
-//   const account: MultisigAccount = {
-//     proposals: [],
-//     type: AccountType.MULTISIG,
-//     label: "Mulstisig account " + index,
-//     pkh: mockContract(index),
-//   };
-
-//   return account;
-// };
 
 export const mockMultisigWithOperations = (
   index: number,
@@ -172,10 +166,10 @@ export const mockMultisigWithOperations = (
   threshold = 3
 ): MultisigWithPendingOperations => {
   return {
-    address: mockContract(index),
+    address: { type: "contract", pkh: mockContract(index) },
     balance,
     pendingOperations: operations,
-    signers,
+    signers: signers.map(pkh => ({ type: "implicit", pkh })),
     threshold,
   };
 };

--- a/src/multisig/decode/decodeLambda.test.ts
+++ b/src/multisig/decode/decodeLambda.test.ts
@@ -35,7 +35,7 @@ describe("decodeLambda", () => {
     expect(decode(input)).toEqual([
       {
         amount: "910000",
-        recipient: "tz1Te4MXuNYxyyuPqmAQdnKwkD8ZgSF9M7d6",
+        recipient: { type: "implicit", pkh: "tz1Te4MXuNYxyyuPqmAQdnKwkD8ZgSF9M7d6" },
         type: "tez",
       },
     ]);
@@ -70,7 +70,7 @@ describe("decodeLambda", () => {
       {
         type: "tez",
         amount: "5",
-        recipient: "KT1GVhG7dQNjPAt4FNBNmc9P9zpiQex4Mxob",
+        recipient: { type: "contract", pkh: "KT1GVhG7dQNjPAt4FNBNmc9P9zpiQex4Mxob" },
       },
     ]);
   });
@@ -189,9 +189,9 @@ describe("decodeLambda", () => {
     const expected = [
       {
         amount: "1",
-        contract: "KT1GVhG7dQNjPAt4FNBNmc9P9zpiQex4Mxob",
-        recipient: "tz1g7Vk9dxDALJUp4w1UTnC41ssvRa7Q4XyS",
-        sender: "KT1MYis2J1hpjxVcfF92Mf7AfXouzaxsYfKm",
+        contract: { type: "contract", pkh: "KT1GVhG7dQNjPAt4FNBNmc9P9zpiQex4Mxob" },
+        recipient: { type: "implicit", pkh: "tz1g7Vk9dxDALJUp4w1UTnC41ssvRa7Q4XyS" },
+        sender: { type: "contract", pkh: "KT1MYis2J1hpjxVcfF92Mf7AfXouzaxsYfKm" },
         tokenId: "6",
         type: "fa2",
       },
@@ -226,12 +226,12 @@ describe("decodeLambda", () => {
     expect(decode(input)).toEqual([
       {
         amount: "20000",
-        recipient: "tz1Te4MXuNYxyyuPqmAQdnKwkD8ZgSF9M7d6",
+        recipient: { type: "implicit", pkh: "tz1Te4MXuNYxyyuPqmAQdnKwkD8ZgSF9M7d6" },
         type: "tez",
       },
       {
         amount: "33333",
-        recipient: "tz1g7Vk9dxDALJUp4w1UTnC41ssvRa7Q4XyS",
+        recipient: { type: "implicit", pkh: "tz1g7Vk9dxDALJUp4w1UTnC41ssvRa7Q4XyS" },
         type: "tez",
       },
     ]);
@@ -369,20 +369,20 @@ describe("decodeLambda", () => {
     expect(decode(input)).toEqual([
       {
         amount: "600000",
-        recipient: "tz1Te4MXuNYxyyuPqmAQdnKwkD8ZgSF9M7d6",
+        recipient: { type: "implicit", pkh: "tz1Te4MXuNYxyyuPqmAQdnKwkD8ZgSF9M7d6" },
         type: "tez",
       },
       {
         amount: "1",
-        contract: "KT1GVhG7dQNjPAt4FNBNmc9P9zpiQex4Mxob",
-        recipient: "tz1g7Vk9dxDALJUp4w1UTnC41ssvRa7Q4XyS",
-        sender: "KT1MYis2J1hpjxVcfF92Mf7AfXouzaxsYfKm",
+        contract: { type: "contract", pkh: "KT1GVhG7dQNjPAt4FNBNmc9P9zpiQex4Mxob" },
+        recipient: { type: "implicit", pkh: "tz1g7Vk9dxDALJUp4w1UTnC41ssvRa7Q4XyS" },
+        sender: { type: "contract", pkh: "KT1MYis2J1hpjxVcfF92Mf7AfXouzaxsYfKm" },
         tokenId: "6",
         type: "fa2",
       },
       {
         amount: "33333",
-        recipient: "tz1g7Vk9dxDALJUp4w1UTnC41ssvRa7Q4XyS",
+        recipient: { type: "implicit", pkh: "tz1g7Vk9dxDALJUp4w1UTnC41ssvRa7Q4XyS" },
         type: "tez",
       },
     ]);
@@ -461,9 +461,9 @@ describe("decodeLambda", () => {
     expect(decode(input)).toEqual([
       {
         amount: "300",
-        contract: "KT1UCPcXExqEYRnfoXWYvBkkn5uPjn8TBTEe",
-        recipient: "tz1g7Vk9dxDALJUp4w1UTnC41ssvRa7Q4XyS",
-        sender: "KT1MYis2J1hpjxVcfF92Mf7AfXouzaxsYfKm",
+        contract: { type: "contract", pkh: "KT1UCPcXExqEYRnfoXWYvBkkn5uPjn8TBTEe" },
+        recipient: { type: "implicit", pkh: "tz1g7Vk9dxDALJUp4w1UTnC41ssvRa7Q4XyS" },
+        sender: { type: "contract", pkh: "KT1MYis2J1hpjxVcfF92Mf7AfXouzaxsYfKm" },
         type: "fa1.2",
       },
     ]);
@@ -665,26 +665,26 @@ describe("decodeLambda", () => {
     expect(decode(input)).toEqual([
       {
         amount: "100000",
-        recipient: "tz1Te4MXuNYxyyuPqmAQdnKwkD8ZgSF9M7d6",
+        recipient: { type: "implicit", pkh: "tz1Te4MXuNYxyyuPqmAQdnKwkD8ZgSF9M7d6" },
         type: "tez",
       },
       {
         amount: "300",
-        contract: "KT1UCPcXExqEYRnfoXWYvBkkn5uPjn8TBTEe",
-        recipient: "tz1g7Vk9dxDALJUp4w1UTnC41ssvRa7Q4XyS",
-        sender: "KT1MYis2J1hpjxVcfF92Mf7AfXouzaxsYfKm",
+        contract: { type: "contract", pkh: "KT1UCPcXExqEYRnfoXWYvBkkn5uPjn8TBTEe" },
+        recipient: { type: "implicit", pkh: "tz1g7Vk9dxDALJUp4w1UTnC41ssvRa7Q4XyS" },
+        sender: { type: "contract", pkh: "KT1MYis2J1hpjxVcfF92Mf7AfXouzaxsYfKm" },
         type: "fa1.2",
       },
       {
         amount: "33333",
-        recipient: "tz1UNer1ijeE9ndjzSszRduR3CzX49hoBUB3",
+        recipient: { type: "implicit", pkh: "tz1UNer1ijeE9ndjzSszRduR3CzX49hoBUB3" },
         type: "tez",
       },
       {
         amount: "1",
-        contract: "KT1GVhG7dQNjPAt4FNBNmc9P9zpiQex4Mxob",
-        recipient: "tz1g7Vk9dxDALJUp4w1UTnC41ssvRa7Q4XyS",
-        sender: "KT1MYis2J1hpjxVcfF92Mf7AfXouzaxsYfKm",
+        contract: { type: "contract", pkh: "KT1GVhG7dQNjPAt4FNBNmc9P9zpiQex4Mxob" },
+        recipient: { type: "implicit", pkh: "tz1g7Vk9dxDALJUp4w1UTnC41ssvRa7Q4XyS" },
+        sender: { type: "contract", pkh: "KT1MYis2J1hpjxVcfF92Mf7AfXouzaxsYfKm" },
         tokenId: "6",
         type: "fa2",
       },
@@ -750,7 +750,10 @@ describe("decodeLambda", () => {
     ];
 
     expect(decode(input)).toEqual([
-      { type: "delegation", recipient: "tz1RuHDSj9P7mNNhfKxsyLGRDahTX5QD1DdP" },
+      {
+        type: "delegation",
+        recipient: { type: "implicit", pkh: "tz1RuHDSj9P7mNNhfKxsyLGRDahTX5QD1DdP" },
+      },
     ]);
   });
 });

--- a/src/multisig/multisigSandbox.integration.test.ts
+++ b/src/multisig/multisigSandbox.integration.test.ts
@@ -7,6 +7,7 @@ import { ghostTezzard } from "../mocks/tokens";
 import { contract, makeStorageMichelsonJSON } from "./multisigContract";
 import { makeBatchLambda } from "./multisigUtils";
 import { MultisigStorage } from "./types";
+import { parseContractPkh, parsePkh } from "../types/Address";
 
 jest.unmock("../utils/tezos");
 
@@ -98,26 +99,26 @@ describe("multisig Sandbox", () => {
       const keys2 = await makeDefaultDevSignerKeys(2);
       const batch = await makeBatchLambda(
         [
-          { type: "tez", amount: "600000", recipient: keys1.pkh },
+          { type: "tez", amount: "600000", recipient: parsePkh(keys1.pkh) },
           {
             type: "fa1.2",
             amount: "300",
-            recipient: keys2.pkh,
+            recipient: parsePkh(keys2.pkh),
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            contract: ghostnetFA12!.token!.contract!.address!,
-            sender: multisigContract,
+            contract: parseContractPkh(ghostnetFA12!.token!.contract!.address!),
+            sender: parsePkh(multisigContract),
           },
           {
             type: "fa2",
             amount: "1",
-            recipient: keys2.pkh,
+            recipient: parsePkh(keys2.pkh),
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            contract: ghotnetThezard!.token!.contract!.address!,
-            sender: multisigContract,
+            contract: parseContractPkh(ghotnetThezard!.token!.contract!.address!),
+            sender: parsePkh(multisigContract),
             tokenId: ghostTezzard.tokenId,
           },
-          { type: "tez", amount: "910000", recipient: keys1.pkh },
-          { type: "tez", amount: "2000", recipient: keys2.pkh },
+          { type: "tez", amount: "910000", recipient: parsePkh(keys1.pkh) },
+          { type: "tez", amount: "2000", recipient: parsePkh(keys2.pkh) },
         ],
 
         TezosNetwork.GHOSTNET

--- a/src/multisig/multisigSandbox2.integration.test.ts
+++ b/src/multisig/multisigSandbox2.integration.test.ts
@@ -62,21 +62,21 @@ describe("multisig Sandbox", () => {
       [
         {
           type: "tez",
-          recipient: devAccount2Pkh,
+          recipient: { type: "implicit", pkh: devAccount2Pkh },
           amount: tezToMutez(TEZ_TO_SEND.toString()).toString(),
         },
         {
           type: "fa1.2",
-          sender: MULTISIG_GHOSTNET_1,
-          recipient: devAccount2Pkh,
-          contract: FA12_TOKEN_CONTRACT,
+          sender: { type: "implicit", pkh: MULTISIG_GHOSTNET_1 },
+          recipient: { type: "implicit", pkh: devAccount2Pkh },
+          contract: { type: "contract", pkh: FA12_TOKEN_CONTRACT },
           amount: "2",
         },
         {
           type: "fa2",
-          sender: MULTISIG_GHOSTNET_1,
-          recipient: devAccount2Pkh,
-          contract: FA2_KL2_CONTRACT,
+          sender: { type: "implicit", pkh: MULTISIG_GHOSTNET_1 },
+          recipient: { type: "implicit", pkh: devAccount2Pkh },
+          contract: { type: "contract", pkh: FA2_KL2_CONTRACT },
           amount: "3",
           tokenId: "0",
         },
@@ -85,15 +85,14 @@ describe("multisig Sandbox", () => {
     );
 
     const proposeEstimate = await estimateMultisigPropose(
-      { contract: MULTISIG_GHOSTNET_1, lambdaActions },
-      await devAccount0.publicKey(),
+      { contract: { type: "contract", pkh: MULTISIG_GHOSTNET_1 }, lambdaActions },
       await devAccount0.publicKeyHash(),
       TezosNetwork.GHOSTNET
     );
     expect(proposeEstimate).toHaveProperty("suggestedFeeMutez");
 
     const proposeResponse = await proposeMultisigLambda(
-      { contract: MULTISIG_GHOSTNET_1, lambdaActions },
+      { contract: { type: "contract", pkh: MULTISIG_GHOSTNET_1 }, lambdaActions },
       {
         type: SignerType.SK,
         network: TezosNetwork.GHOSTNET,
@@ -118,10 +117,9 @@ describe("multisig Sandbox", () => {
     const approveEstimate = await estimateMultisigApproveOrExecute(
       {
         type: "approve",
-        contract: MULTISIG_GHOSTNET_1,
+        contract: { type: "contract", pkh: MULTISIG_GHOSTNET_1 },
         operationId: pendingOpKey as string,
       },
-      await devAccount1.publicKey(),
       await devAccount1.publicKeyHash(),
       TezosNetwork.GHOSTNET
     );
@@ -130,7 +128,7 @@ describe("multisig Sandbox", () => {
     const approveResponse = await approveOrExecuteMultisigOperation(
       {
         type: "approve",
-        contract: MULTISIG_GHOSTNET_1,
+        contract: { type: "contract", pkh: MULTISIG_GHOSTNET_1 },
         operationId: pendingOpKey as string,
       },
       {
@@ -147,10 +145,9 @@ describe("multisig Sandbox", () => {
     const executeEstimate = await estimateMultisigApproveOrExecute(
       {
         type: "execute",
-        contract: MULTISIG_GHOSTNET_1,
+        contract: { type: "contract", pkh: MULTISIG_GHOSTNET_1 },
         operationId: pendingOpKey as string,
       },
-      await devAccount1.publicKey(),
       await devAccount1.publicKeyHash(),
       TezosNetwork.GHOSTNET
     );
@@ -159,7 +156,7 @@ describe("multisig Sandbox", () => {
     const executeResponse = await approveOrExecuteMultisigOperation(
       {
         type: "execute",
-        contract: MULTISIG_GHOSTNET_1,
+        contract: { type: "contract", pkh: MULTISIG_GHOSTNET_1 },
         operationId: pendingOpKey as string,
       },
       {

--- a/src/multisig/multisigUtils.test.ts
+++ b/src/multisig/multisigUtils.test.ts
@@ -50,7 +50,7 @@ describe("makeLambda", () => {
         {
           type: "tez",
           amount: MUTEZ_AMOUNT,
-          recipient: mockPkh(0),
+          recipient: { type: "implicit", pkh: mockPkh(0) },
         },
         TezosNetwork.GHOSTNET
       );
@@ -68,7 +68,7 @@ describe("makeLambda", () => {
         {
           type: "tez",
           amount: MUTEZ_AMOUNT,
-          recipient: mockContract(0),
+          recipient: { type: "contract", pkh: mockContract(0) },
         },
         TezosNetwork.GHOSTNET
       );
@@ -87,9 +87,9 @@ describe("makeLambda", () => {
       {
         type: "fa1.2",
         amount: AMOUNT,
-        recipient: mockPkh(0),
-        contract: mockContract(0),
-        sender: multisigContract,
+        recipient: { type: "implicit", pkh: mockPkh(0) },
+        contract: { type: "contract", pkh: mockContract(0) },
+        sender: { type: "contract", pkh: multisigContract },
       },
       TezosNetwork.GHOSTNET
     );
@@ -109,9 +109,9 @@ describe("makeLambda", () => {
         {
           type: "fa2",
           amount: AMOUNT,
-          recipient: mockPkh(0),
-          contract: mockContract(0),
-          sender: multisigContract,
+          recipient: { type: "implicit", pkh: mockPkh(0) },
+          contract: { type: "contract", pkh: mockContract(0) },
+          sender: { type: "contract", pkh: multisigContract },
           tokenId: MOCK_TOKEN_ID,
         },
       ],
@@ -130,7 +130,7 @@ describe("makeLambda", () => {
       const result = await makeLambda(
         {
           type: "delegation",
-          recipient: mockPkh(0),
+          recipient: { type: "implicit", pkh: mockPkh(0) },
         },
         TezosNetwork.GHOSTNET
       );
@@ -142,23 +142,9 @@ describe("makeLambda", () => {
     });
 
     it("can unset a delegate", async () => {
-      const emptyStringResult = await makeLambda(
-        {
-          type: "delegation",
-          recipient: "",
-        },
-        TezosNetwork.GHOSTNET
-      );
+      const result = await makeLambda({ type: "delegation" }, TezosNetwork.GHOSTNET);
 
-      expect(emptyStringResult).toEqual([
-        { prim: "DROP" },
-        { args: [{ prim: "operation" }], prim: "NIL" },
-        ...dropDelegationLambda,
-      ]);
-
-      const undefinedResult = await makeLambda({ type: "delegation" }, TezosNetwork.GHOSTNET);
-
-      expect(undefinedResult).toEqual([
+      expect(result).toEqual([
         { prim: "DROP" },
         { args: [{ prim: "operation" }], prim: "NIL" },
         ...dropDelegationLambda,
@@ -176,7 +162,7 @@ describe("makeBatchLambda", () => {
         {
           type: "tez",
           amount: MUTEZ_AMOUNT_1,
-          recipient: mockPkh(0),
+          recipient: { type: "implicit", pkh: mockPkh(0) },
         },
       ],
       TezosNetwork.GHOSTNET
@@ -195,30 +181,30 @@ describe("makeBatchLambda", () => {
     const MOCK_TEZ_AMOUNT2 = "55556";
     const result = await makeBatchLambda(
       [
-        { type: "tez", amount: MOCK_TEZ_AMOUNT, recipient: mockPkh(1) },
+        { type: "tez", amount: MOCK_TEZ_AMOUNT, recipient: { type: "implicit", pkh: mockPkh(1) } },
         {
           type: "tez",
           amount: MOCK_TEZ_AMOUNT2,
-          recipient: mockContract(0),
+          recipient: { type: "contract", pkh: mockContract(0) },
         },
         {
           type: "fa2",
           amount: "1",
-          recipient: mockPkh(0),
-          contract: mockContract(0),
-          sender: multisigContract,
+          recipient: { type: "implicit", pkh: mockPkh(0) },
+          contract: { type: "contract", pkh: mockContract(0) },
+          sender: { type: "contract", pkh: multisigContract },
           tokenId: "123",
         },
         {
           type: "fa1.2",
           amount: "1",
-          recipient: mockPkh(0),
-          contract: mockContract(1),
-          sender: multisigContract,
+          recipient: { type: "implicit", pkh: mockPkh(0) },
+          contract: { type: "contract", pkh: mockContract(1) },
+          sender: { type: "contract", pkh: multisigContract },
         },
         {
           type: "delegation",
-          recipient: mockPkh(1),
+          recipient: { type: "implicit", pkh: mockPkh(1) },
         },
         { type: "delegation" },
       ],

--- a/src/types/Account.ts
+++ b/src/types/Account.ts
@@ -1,5 +1,6 @@
 import { Curves } from "@taquito/signer";
-import { MultisigOperation, WalletAccountPkh } from "../utils/multisig/types";
+import { MultisigOperation } from "../utils/multisig/types";
+import { ContractAddress, ImplicitAddress } from "./Address";
 
 export enum AccountType {
   SOCIAL = "social",
@@ -8,44 +9,40 @@ export enum AccountType {
   MULTISIG = "multisig",
 }
 
-type Base = {
-  pkh: string;
-  pk: string;
-};
-
-export type UnencryptedAccount = Base;
-
-export type SocialAccount = Base & {
+export type SocialAccount = {
   label: string;
   type: AccountType.SOCIAL;
   idp: "google";
+  address: ImplicitAddress;
 };
 
-export type MnemonicAccount = Base & {
+export type MnemonicAccount = {
   label: string;
   curve: "ed25519";
   derivationPath: string;
   type: AccountType.MNEMONIC;
   seedFingerPrint: string;
+  address: ImplicitAddress;
 };
 
-export type LedgerAccount = Base & {
+export type LedgerAccount = {
   label: string;
   curve: Curves;
   derivationPath: string;
   type: AccountType.LEDGER;
+  address: ImplicitAddress;
 };
 
 export type MultisigAccount = {
   type: AccountType.MULTISIG;
-  pkh: string;
+  address: ContractAddress;
   label: string;
   threshold: number;
-  signers: WalletAccountPkh[];
-  balance: string;
-  operations: MultisigOperation[];
+  signers: ImplicitAddress[];
+  balance: string; // TODO remove
+  operations: MultisigOperation[]; // TODO remove
 };
 
 export type ImplicitAccount = MnemonicAccount | SocialAccount | LedgerAccount;
 
-export type AllAccount = ImplicitAccount | MultisigAccount;
+export type Account = ImplicitAccount | MultisigAccount;

--- a/src/types/Address.ts
+++ b/src/types/Address.ts
@@ -1,13 +1,38 @@
-export type Address = string;
+export type ContractAddress = {
+  type: "contract";
+  pkh: string;
+};
 
-export type AddressType = "contract" | "user";
+export type ImplicitAddress = {
+  type: "implicit";
+  pkh: string;
+};
 
-export const addressType = (addressType: string): AddressType => {
-  if (addressType.match(/^tz[1234]/)) {
-    return "user";
+export type Address = ContractAddress | ImplicitAddress;
+
+export const parsePkh = (pkh: string): Address => {
+  if (isValidContractPkh(pkh)) {
+    return parseContractPkh(pkh);
   }
-  if (addressType.startsWith("KT")) {
-    return "contract";
+  if (isValidImplicitPkh(pkh)) {
+    return parseImplicitPkh(pkh);
   }
-  throw new Error(`Unknown address type: ${addressType}`);
+  throw new Error(`Cannot parse address type: ${pkh}`);
+};
+
+const isValidContractPkh = (pkh: string) => pkh.match(/^KT1\w+/);
+const isValidImplicitPkh = (pkh: string) => pkh.match(/^tz[1234]\w+/);
+
+export const parseContractPkh = (pkh: string): ContractAddress => {
+  if (isValidContractPkh(pkh)) {
+    return { type: "contract", pkh };
+  }
+  throw new Error(`Invalid contract address: ${pkh}`);
+};
+
+export const parseImplicitPkh = (pkh: string): ImplicitAddress => {
+  if (isValidImplicitPkh(pkh)) {
+    return { type: "implicit", pkh };
+  }
+  throw new Error(`Invalid implicit address: ${pkh}`);
 };

--- a/src/utils/account/makeMnemonicAccount.ts
+++ b/src/utils/account/makeMnemonicAccount.ts
@@ -1,7 +1,6 @@
 import { AccountType, MnemonicAccount } from "../../types/Account";
 
 export const makeMnemonicAccount = (
-  pk: string,
   pkh: string,
   derivationPath: string,
   seedFingerPrint: string,
@@ -10,8 +9,7 @@ export const makeMnemonicAccount = (
   return {
     curve: "ed25519",
     derivationPath,
-    pk,
-    pkh,
+    address: { type: "implicit", pkh: pkh },
     seedFingerPrint,
     label,
     type: AccountType.MNEMONIC,

--- a/src/utils/accountsReducer.test.ts
+++ b/src/utils/accountsReducer.test.ts
@@ -21,9 +21,9 @@ afterEach(() => {
 });
 
 beforeEach(async () => {
-  const { pk, pkh } = await makeDefaultDevSignerKeys(0);
+  const { pkh } = await makeDefaultDevSignerKeys(0);
   fakeExtraArguments.restoreAccount.mockResolvedValue({
-    pk,
+    type: "implicit",
     pkh,
   });
   fakeExtraArguments.decrypt.mockResolvedValue("unencryptedFingerprint");
@@ -55,7 +55,7 @@ describe("Accounts reducer", () => {
     store.dispatch(add([mockImplicitAccount(1), mockImplicitAccount(2), mockImplicitAccount(3)]));
 
     expect(() => store.dispatch(add(mockImplicitAccount(2)))).toThrowError(
-      `Can't add account ${mockImplicitAccount(2).pkh} in store since it already exists.`
+      `Can't add account ${mockImplicitAccount(2).address.pkh} in store since it already exists.`
     );
 
     expect(store.getState().accounts).toEqual({
@@ -193,8 +193,7 @@ describe("Accounts reducer", () => {
           curve: "ed25519",
           derivationPath: "m/44'/1729'/0'/0'",
           label: "Account 0",
-          pk: "edpkuwYWCugiYG7nMnVUdopFmyc3sbMSiLqsJHTQgGtVhtSdLSw6H0",
-          pkh: "tz1gUNyn3hmnEWqkusWPzxRaon1cs7ndWh7h",
+          address: { type: "implicit", pkh: "tz1gUNyn3hmnEWqkusWPzxRaon1cs7ndWh7h" },
           seedFingerPrint: "mockPrint1",
           type: "mnemonic",
         },
@@ -202,8 +201,7 @@ describe("Accounts reducer", () => {
           curve: "ed25519",
           derivationPath: "m/44'/1729'/1'/0'",
           label: "Account 1",
-          pk: "edpkuwYWCugiYG7nMnVUdopFmyc3sbMSiLqsJHTQgGtVhtSdLSw6H1",
-          pkh: "tz1UZFB9kGauB6F5c2gfJo4hVcvrD8MeJ3Vf",
+          address: { type: "implicit", pkh: "tz1UZFB9kGauB6F5c2gfJo4hVcvrD8MeJ3Vf" },
           seedFingerPrint: "mockPrint1",
           type: "mnemonic",
         },
@@ -211,8 +209,7 @@ describe("Accounts reducer", () => {
           curve: "ed25519",
           derivationPath: "m/44'/1729'/2'/0'",
           label: "my new account",
-          pk: "edpkuwYWCugiYG7nMnVUdopFmyc3sbMSiLqsJHTQgGtVhtSdLSw6HG",
-          pkh: "tz1UNer1ijeE9ndjzSszRduR3CzX49hoBUB3",
+          address: { type: "implicit", pkh: "tz1UNer1ijeE9ndjzSszRduR3CzX49hoBUB3" },
           seedFingerPrint: "mockPrint1",
           type: "mnemonic",
         },

--- a/src/utils/assetsReducer.test.ts
+++ b/src/utils/assetsReducer.test.ts
@@ -6,7 +6,6 @@ import { waitFor } from "@testing-library/react";
 import {
   mockDelegationTransfer,
   mockNftTransfer,
-  mockPk,
   mockPkh,
   mockTezTransaction,
   mockTezTransfer,
@@ -386,7 +385,7 @@ describe("Assets reducer", () => {
   });
 
   describe("Batch", () => {
-    test("Adding operations to batch starts an estimation and updates the given account's batch with the result", async () => {
+    test.only("Adding operations to batch starts an estimation and updates the given account's batch with the result", async () => {
       const mockEstimations = [
         { suggestedFeeMutez: "323" },
         { suggestedFeeMutez: "423" },
@@ -396,15 +395,10 @@ describe("Assets reducer", () => {
       estimateBatchMock.mockResolvedValueOnce(mockEstimations);
 
       const transfers = [mockTezTransfer(1), mockDelegationTransfer(1), mockNftTransfer(1)];
-      const action = estimateAndUpdateBatch(mockPkh(1), mockPk(1), transfers, TezosNetwork.MAINNET);
+      const action = estimateAndUpdateBatch(mockPkh(1), transfers, TezosNetwork.MAINNET);
 
       store.dispatch(action);
-      expect(estimateBatchMock).toHaveBeenCalledWith(
-        transfers,
-        mockPkh(1),
-        mockPk(1),
-        TezosNetwork.MAINNET
-      );
+      expect(estimateBatchMock).toHaveBeenCalledWith(transfers, mockPkh(1), TezosNetwork.MAINNET);
       expect(store.getState().assets.batches[mockPkh(1)]?.isSimulating).toEqual(true);
       await waitFor(() => {
         expect(store.getState().assets.batches[mockPkh(1)]).toEqual({
@@ -433,7 +427,7 @@ describe("Assets reducer", () => {
       estimateBatchMock.mockResolvedValueOnce(mockEstimations);
 
       const transfers = [mockTezTransfer(1)];
-      const action = estimateAndUpdateBatch(mockPkh(1), mockPk(1), transfers, TezosNetwork.MAINNET);
+      const action = estimateAndUpdateBatch(mockPkh(1), transfers, TezosNetwork.MAINNET);
 
       store.dispatch(action);
       await waitFor(() => {
@@ -458,7 +452,7 @@ describe("Assets reducer", () => {
       estimateBatchMock.mockRejectedValueOnce(estimationError);
 
       const transfers = [mockTezTransfer(1), mockDelegationTransfer(1), mockNftTransfer(1)];
-      const action = estimateAndUpdateBatch(mockPkh(1), mockPk(1), transfers, TezosNetwork.MAINNET);
+      const action = estimateAndUpdateBatch(mockPkh(1), transfers, TezosNetwork.MAINNET);
 
       const dispatchResult = store.dispatch(action);
       expect(store.getState().assets.batches[mockPkh(1)]?.isSimulating).toEqual(true);
@@ -481,7 +475,7 @@ describe("Assets reducer", () => {
 
       const transfers = [mockTezTransfer(1), mockDelegationTransfer(1), mockNftTransfer(1)];
 
-      const action = estimateAndUpdateBatch(mockPkh(1), mockPk(1), transfers, TezosNetwork.MAINNET);
+      const action = estimateAndUpdateBatch(mockPkh(1), transfers, TezosNetwork.MAINNET);
 
       store.dispatch(action);
       const concurrentDispatch = store.dispatch(action);
@@ -522,12 +516,7 @@ describe("Assets reducer", () => {
 
       const operations: OperationValue[] = [];
 
-      const action = estimateAndUpdateBatch(
-        mockPkh(1),
-        mockPk(1),
-        operations,
-        TezosNetwork.MAINNET
-      );
+      const action = estimateAndUpdateBatch(mockPkh(1), operations, TezosNetwork.MAINNET);
 
       const dispatch = store.dispatch(action);
 
@@ -552,7 +541,7 @@ describe("Assets reducer", () => {
       );
       const transfers = [mockTezTransfer(1), mockDelegationTransfer(1), mockNftTransfer(1)];
 
-      const action = estimateAndUpdateBatch(mockPkh(1), mockPk(1), transfers, TezosNetwork.MAINNET);
+      const action = estimateAndUpdateBatch(mockPkh(1), transfers, TezosNetwork.MAINNET);
 
       store.dispatch(action);
       store.dispatch(clearBatch({ pkh: mockPkh(1) }));

--- a/src/utils/beacon/BeaconNotification/BeaconRequestNotification.test.tsx
+++ b/src/utils/beacon/BeaconNotification/BeaconRequestNotification.test.tsx
@@ -87,7 +87,7 @@ describe("<BeaconRequestNotification />", () => {
         expect(walletClient.respond).toHaveBeenCalledWith({
           id: MESSAGE_ID,
           network: { type: "mainnet" },
-          publicKey: mockImplicitAccount(2).pk,
+          publicKey: mockImplicitAccount(2).address.pkh,
           scopes: SCOPES,
           type: "permission_response",
         });
@@ -98,7 +98,7 @@ describe("<BeaconRequestNotification />", () => {
   describe("Operation request (case simple tez transaction)", () => {
     const message: OperationRequestOutput = {
       ...objectOperationRequest,
-      sourceAddress: mockImplicitAccount(2).pkh,
+      sourceAddress: mockImplicitAccount(2).address.pkh,
     };
     it("should display operations request with controls disabled and parameter displayed", async () => {
       render(fixture(message, () => {}));
@@ -147,7 +147,7 @@ describe("<BeaconRequestNotification />", () => {
   describe("Operation request (case delegation)", () => {
     const message: OperationRequestOutput = {
       ...objectOperationDelegationRequest,
-      sourceAddress: mockImplicitAccount(2).pkh,
+      sourceAddress: mockImplicitAccount(2).address.pkh,
     };
     it("should display delegation request with controls disabled", async () => {
       render(fixture(message, () => {}));
@@ -192,7 +192,7 @@ describe("<BeaconRequestNotification />", () => {
   test("User previews then submits Batches, and operation hash is sent via Beacon", async () => {
     const message: OperationRequestOutput = {
       ...objectOperationBatchRequest,
-      sourceAddress: mockImplicitAccount(2).pkh,
+      sourceAddress: mockImplicitAccount(2).address.pkh,
     };
     render(fixture(message, () => {}));
     const modal = screen.getByRole("dialog", { name: /recap/i });

--- a/src/utils/beacon/BeaconNotification/pannels/PermissionRequestPannel.tsx
+++ b/src/utils/beacon/BeaconNotification/pannels/PermissionRequestPannel.tsx
@@ -35,7 +35,7 @@ const PermissionRequestPannel: React.FC<{
       network: { type: request.network.type }, // Use the same network that the user requested
       scopes: request.scopes,
       id: request.id,
-      publicKey: account.pk,
+      publicKey: account.address.pkh, // TODO: check if that works
     };
 
     await walletClient.respond(response);
@@ -49,7 +49,7 @@ const PermissionRequestPannel: React.FC<{
       <ModalCloseButton />
       <ModalBody>
         <ConnectedAccountSelector
-          selected={account && account.pkh}
+          selected={account && account.address.pkh}
           onSelect={a => {
             setAccount(a);
           }}

--- a/src/utils/contactsReducer.test.ts
+++ b/src/utils/contactsReducer.test.ts
@@ -75,7 +75,9 @@ describe("Contacts reducer", () => {
   test("should not add contact containing Account info", () => {
     const account = mockImplicitAccount(0);
     store.dispatch(add(account));
-    store.dispatch(checkAccountsAndUpsertContact({ name: account.label, pkh: account.pkh }));
+    store.dispatch(
+      checkAccountsAndUpsertContact({ name: account.label, pkh: account.address.pkh })
+    );
     store.dispatch(
       checkAccountsAndUpsertContact({
         name: account.label,
@@ -85,7 +87,7 @@ describe("Contacts reducer", () => {
     store.dispatch(
       checkAccountsAndUpsertContact({
         name: "mockName",
-        pkh: account.pkh,
+        pkh: account.address.pkh,
       })
     );
     expect(store.getState().contacts).toEqual({});

--- a/src/utils/hooks/accountUtils.ts
+++ b/src/utils/hooks/accountUtils.ts
@@ -19,13 +19,13 @@ export const getTotalTezBalance = (
 
 export const useGetSk = () => {
   const seedPhrases = useAppSelector(s => s.accounts.seedPhrases);
-  return async (a: MnemonicAccount, password: string) => {
-    const encryptedMnemonic = seedPhrases[a.seedFingerPrint];
+  return async (account: MnemonicAccount, password: string) => {
+    const encryptedMnemonic = seedPhrases[account.seedFingerPrint];
     if (!encryptedMnemonic) {
-      throw new Error(`Missing seedphrase for account ${a.pkh}`);
+      throw new Error(`Missing seedphrase for account ${account.address.pkh}`);
     }
 
     const mnemonic = await decrypt(encryptedMnemonic, password);
-    return deriveSkFromMnemonic(mnemonic, a.derivationPath, a.curve);
+    return deriveSkFromMnemonic(mnemonic, account.derivationPath, account.curve);
   };
 };

--- a/src/utils/hooks/assetsHooks.ts
+++ b/src/utils/hooks/assetsHooks.ts
@@ -93,7 +93,7 @@ export const useHasTokens = () => {
   const getFA2 = useGetAccountFA2Tokens();
   return () =>
     accounts
-      .map(account => [...getFA1(account.pkh), ...getFA2(account.pkh)].length > 0)
+      .map(account => [...getFA1(account.address.pkh), ...getFA2(account.address.pkh)].length > 0)
       .includes(true);
 };
 
@@ -116,8 +116,14 @@ export const useAllOperationDisplays = () => {
 
   const result: Record<string, OperationDisplay[]> = {};
 
-  accounts.forEach(({ pkh }) => {
-    result[pkh] = getOperationDisplays(tez[pkh], tokens[pkh], delegations[pkh], pkh, network);
+  accounts.forEach(({ address }) => {
+    result[address.pkh] = getOperationDisplays(
+      tez[address.pkh],
+      tokens[address.pkh],
+      delegations[address.pkh],
+      address.pkh,
+      network
+    );
   });
 
   return result;

--- a/src/utils/multisig/helper.test.ts
+++ b/src/utils/multisig/helper.test.ts
@@ -19,15 +19,19 @@ describe("multisig helpers", () => {
     const multisigs: MultisigWithPendingOperations[] = [
       {
         balance: "1",
-        address: mockContract(0),
-        signers: [mockPkh(0)],
+        address: { type: "contract", pkh: mockContract(0) },
+        signers: [{ type: "implicit", pkh: mockPkh(0) }],
         threshold: 1,
         pendingOperations: [],
       },
       {
         balance: "0",
-        address: mockContract(1),
-        signers: [mockPkh(0), mockPkh(1), mockPkh(3)],
+        address: { type: "contract", pkh: mockContract(1) },
+        signers: [
+          { type: "implicit", pkh: mockPkh(0) },
+          { type: "implicit", pkh: mockPkh(1) },
+          { type: "implicit", pkh: mockPkh(3) },
+        ],
         threshold: 3,
         pendingOperations: [],
       },
@@ -36,26 +40,34 @@ describe("multisig helpers", () => {
     expect(result).toEqual({
       [mockPkh(1)]: [
         {
-          address: mockContract(1),
+          address: { type: "contract", pkh: mockContract(1) },
           balance: "0",
           pendingOperations: [],
-          signers: [mockPkh(0), mockPkh(1), mockPkh(3)],
+          signers: [
+            { type: "implicit", pkh: mockPkh(0) },
+            { type: "implicit", pkh: mockPkh(1) },
+            { type: "implicit", pkh: mockPkh(3) },
+          ],
           threshold: 3,
         },
       ],
       [mockPkh(0)]: [
         {
-          address: mockContract(0),
+          address: { type: "contract", pkh: mockContract(0) },
           balance: "1",
           pendingOperations: [],
-          signers: [mockPkh(0)],
+          signers: [{ type: "implicit", pkh: mockPkh(0) }],
           threshold: 1,
         },
         {
-          address: mockContract(1),
+          address: { type: "contract", pkh: mockContract(1) },
           balance: "0",
           pendingOperations: [],
-          signers: [mockPkh(0), mockPkh(1), mockPkh(3)],
+          signers: [
+            { type: "implicit", pkh: mockPkh(0) },
+            { type: "implicit", pkh: mockPkh(1) },
+            { type: "implicit", pkh: mockPkh(3) },
+          ],
           threshold: 3,
         },
       ],
@@ -71,18 +83,18 @@ describe("multisig helpers", () => {
 
     expect(result).toEqual([
       {
-        address: mockContract(0),
+        address: { type: "contract", pkh: mockContract(0) },
         balance: 0,
         storage: {
           pending_ops: 0,
-          signers: [mockPkh(0)],
+          signers: [{ type: "implicit", pkh: mockPkh(0) }],
           threshold: "2",
         },
       },
     ]);
   });
 
-  test("getOperationsForMultisigs", async () => {
+  test.only("getOperationsForMultisigs", async () => {
     const mockResponse = {
       data: [
         {
@@ -116,39 +128,39 @@ describe("multisig helpers", () => {
 
     expect(result).toEqual([
       {
-        address: mockContract(0),
+        address: { type: "contract", pkh: mockContract(0) },
         balance: "0",
         pendingOperations: [
           {
-            approvals: [mockPkh(0)],
+            approvals: [{ type: "implicit", pkh: mockPkh(0) }],
             key: "0",
             rawActions: "action0",
           },
           {
-            approvals: [mockPkh(1)],
+            approvals: [{ type: "implicit", pkh: mockPkh(1) }],
             key: "1",
             rawActions: "action1",
           },
         ],
-        signers: [mockPkh(0)],
+        signers: [{ type: "implicit", pkh: mockPkh(0) }],
         threshold: 2,
       },
       {
-        address: mockContract(10),
+        address: { type: "contract", pkh: mockContract(10) },
         balance: "10",
         pendingOperations: [
           {
-            approvals: [mockPkh(0)],
+            approvals: [{ type: "implicit", pkh: mockPkh(0) }],
             key: "0",
             rawActions: "action0",
           },
           {
-            approvals: [mockPkh(1)],
+            approvals: [{ type: "implicit", pkh: mockPkh(1) }],
             key: "1",
             rawActions: "action1",
           },
         ],
-        signers: ["tz1W2hEsS1mj7dHPZ6267eeM4HDWJoG3s13n"],
+        signers: [{ type: "implicit", pkh: "tz1W2hEsS1mj7dHPZ6267eeM4HDWJoG3s13n" }],
         threshold: 2,
       },
     ]);

--- a/src/utils/multisig/types.ts
+++ b/src/utils/multisig/types.ts
@@ -1,22 +1,20 @@
-// For now we only allow a wallet user to be a signer of multisig.
-export type WalletAccountPkh = string;
-export type MultisigAddress = string;
+import { ContractAddress, ImplicitAddress } from "../../types/Address";
 
 export type MultisigOperation = {
   key: string;
   rawActions: string;
-  approvals: WalletAccountPkh[];
+  approvals: ImplicitAddress[];
 };
 
 export type MultisigWithPendingOperations = {
-  address: MultisigAddress;
+  address: ContractAddress;
   threshold: number;
-  signers: WalletAccountPkh[];
+  signers: ImplicitAddress[];
   balance: string;
   pendingOperations: MultisigOperation[];
 };
 
 export type AccountToMultisigs = Record<
-  WalletAccountPkh,
+  string, // pkh
   MultisigWithPendingOperations[] | undefined
 >;

--- a/src/utils/multisigsReducer.test.ts
+++ b/src/utils/multisigsReducer.test.ts
@@ -13,7 +13,7 @@ describe("Contacts reducer", () => {
 
   test("should set new multisigs", () => {
     const multisig: MultisigWithPendingOperations = {
-      address: "mockKt1",
+      address: { type: "contract", pkh: "mockKt1" },
       balance: "44",
       pendingOperations: [],
       signers: [],

--- a/src/utils/restoreAccounts.test.ts
+++ b/src/utils/restoreAccounts.test.ts
@@ -23,15 +23,15 @@ describe("restoreAccounts", () => {
     const result = await restoreAccounts(seedPhrase, defaultV1Pattern);
     const expected = [
       {
-        pk: "edpkuwYWCugiYG7nMnVUdopFmyc3sbMSiLqsJHTQgGtVhtSdLSw6HG",
+        type: "implicit",
         pkh: "tz1UNer1ijeE9ndjzSszRduR3CzX49hoBUB3",
       },
       {
-        pk: "edpkuDBhPULoNAoQbjDUo6pYdpY5o3DugXo1GAJVQGzGMGFyKUVcKN",
+        type: "implicit",
         pkh: "tz1Te4MXuNYxyyuPqmAQdnKwkD8ZgSF9M7d6",
       },
       {
-        pk: "edpktzYEtcJypEEhzZva7QPc8QcvBuKAsXSmTpR1wFPna3xWB48QDy",
+        type: "implicit",
         pkh: "tz1g7Vk9dxDALJUp4w1UTnC41ssvRa7Q4XyS",
       },
     ];
@@ -43,7 +43,7 @@ describe("restoreAccounts", () => {
     const result = await restoreAccounts(seedPhrase, defaultV1Pattern);
     const expected = [
       {
-        pk: "edpkuwYWCugiYG7nMnVUdopFmyc3sbMSiLqsJHTQgGtVhtSdLSw6HG",
+        type: "implicit",
         pkh: "tz1UNer1ijeE9ndjzSszRduR3CzX49hoBUB3",
       },
     ];
@@ -64,8 +64,7 @@ describe("restoreEncryptedAccounts", () => {
         curve: "ed25519",
         derivationPath: getDefaultMnemonicDerivationPath(0),
         type: AccountType.MNEMONIC,
-        pk: "edpkuwYWCugiYG7nMnVUdopFmyc3sbMSiLqsJHTQgGtVhtSdLSw6HG",
-        pkh: "tz1UNer1ijeE9ndjzSszRduR3CzX49hoBUB3",
+        address: { type: "implicit", pkh: "tz1UNer1ijeE9ndjzSszRduR3CzX49hoBUB3" },
         seedFingerPrint: "mockFingerPrint",
         label: "Account 0",
       },
@@ -73,8 +72,7 @@ describe("restoreEncryptedAccounts", () => {
         curve: "ed25519",
         derivationPath: getDefaultMnemonicDerivationPath(1),
         type: AccountType.MNEMONIC,
-        pk: "edpkuDBhPULoNAoQbjDUo6pYdpY5o3DugXo1GAJVQGzGMGFyKUVcKN",
-        pkh: "tz1Te4MXuNYxyyuPqmAQdnKwkD8ZgSF9M7d6",
+        address: { type: "implicit", pkh: "tz1Te4MXuNYxyyuPqmAQdnKwkD8ZgSF9M7d6" },
         seedFingerPrint: "mockFingerPrint",
         label: "Account 1",
       },
@@ -82,8 +80,7 @@ describe("restoreEncryptedAccounts", () => {
         curve: "ed25519",
         derivationPath: getDefaultMnemonicDerivationPath(2),
         type: AccountType.MNEMONIC,
-        pk: "edpktzYEtcJypEEhzZva7QPc8QcvBuKAsXSmTpR1wFPna3xWB48QDy",
-        pkh: "tz1g7Vk9dxDALJUp4w1UTnC41ssvRa7Q4XyS",
+        address: { type: "implicit", pkh: "tz1g7Vk9dxDALJUp4w1UTnC41ssvRa7Q4XyS" },
         seedFingerPrint: "mockFingerPrint",
         label: "Account 2",
       },

--- a/src/utils/store/accountsSlice.ts
+++ b/src/utils/store/accountsSlice.ts
@@ -47,9 +47,16 @@ const accountsSlice = createSlice({
 });
 
 const concatUnique = (existingAccounts: ImplicitAccount[], newAccounts: ImplicitAccount[]) => {
+  // TODO: use Set
   newAccounts.forEach(newAccount => {
-    if (existingAccounts.some(existingAccount => existingAccount.pkh === newAccount.pkh)) {
-      throw new Error(`Can't add account ${newAccount.pkh} in store since it already exists.`);
+    if (
+      existingAccounts.some(
+        existingAccount => existingAccount.address.pkh === newAccount.address.pkh
+      )
+    ) {
+      throw new Error(
+        `Can't add account ${newAccount.address.pkh} in store since it already exists.`
+      );
     }
   });
 

--- a/src/utils/store/thunks/checkAccountsAndUpsertContact.ts
+++ b/src/utils/store/thunks/checkAccountsAndUpsertContact.ts
@@ -11,7 +11,7 @@ const checkAccountsAndUpsertContact = (
   return (dispatch, getState) => {
     const { accounts } = getState();
     const existingAccount = accounts.items.find(account => {
-      return account.pkh === contact.pkh || account.label === contact.name;
+      return account.address.pkh === contact.pkh || account.label === contact.name;
     });
 
     if (existingAccount) {

--- a/src/utils/store/thunks/estimateAndupdateBatch.ts
+++ b/src/utils/store/thunks/estimateAndupdateBatch.ts
@@ -8,7 +8,6 @@ import { RootState } from "../store";
 const { updateBatch: addToBatch, batchSimulationEnd, batchSimulationStart } = assetsSlice.actions;
 export const estimateAndUpdateBatch = (
   pkh: string,
-  pk: string,
   operations: OperationValue[],
   network: TezosNetwork
 ): ThunkAction<Promise<void>, RootState, unknown, AnyAction> => {
@@ -25,7 +24,7 @@ export const estimateAndUpdateBatch = (
 
     dispatch(batchSimulationStart({ pkh }));
     try {
-      const items = await operationValuesToBatchItems(operations, pkh, pk, network);
+      const items = await operationValuesToBatchItems(operations, pkh, network);
       dispatch(addToBatch({ pkh, items }));
     } catch (error) {
       dispatch(batchSimulationEnd({ pkh }));

--- a/src/utils/store/thunks/restoreMnemonicAccounts.ts
+++ b/src/utils/store/thunks/restoreMnemonicAccounts.ts
@@ -58,9 +58,9 @@ export const deriveAccount = createAsyncThunk<
   const pattern = deductDerivationPattern(accounts[0].derivationPath);
   const nextDerivationPath = makeDerivationPath(pattern, nextIndex);
 
-  const { pk, pkh } = await thunkAPI.extra.restoreAccount(seedphrase, nextDerivationPath);
+  const { pkh } = await thunkAPI.extra.restoreAccount(seedphrase, nextDerivationPath);
 
-  const account = makeMnemonicAccount(pk, pkh, nextDerivationPath, fingerPrint, label);
+  const account = makeMnemonicAccount(pkh, nextDerivationPath, fingerPrint, label);
 
   return account;
 });

--- a/src/utils/tezos/dummySigner.test.ts
+++ b/src/utils/tezos/dummySigner.test.ts
@@ -1,20 +1,19 @@
-import { mockPk, mockPkh } from "../../mocks/factories";
+import { mockPkh } from "../../mocks/factories";
 import { DummySigner } from "./dummySigner";
 
 describe("dummySigner", () => {
   test("dummySigner sets pk and pkh", async () => {
-    const signer = new DummySigner(mockPk(0), mockPkh(0));
+    const signer = new DummySigner(mockPkh(0));
     expect(await signer.publicKeyHash()).toEqual(mockPkh(0));
-    expect(signer.pk).toEqual(mockPk(0));
   });
 
   test("sign method throws error", async () => {
-    const signer = new DummySigner(mockPk(0), mockPkh(0));
+    const signer = new DummySigner(mockPkh(0));
     await expect(signer.sign()).rejects.toThrowError("`sign` method not available");
   });
 
   test("secretKey method throws error", async () => {
-    const signer = new DummySigner(mockPk(0), mockPkh(0));
+    const signer = new DummySigner(mockPkh(0));
     await expect(signer.secretKey()).rejects.toThrowError("empty secret key");
   });
 });

--- a/src/utils/tezos/dummySigner.ts
+++ b/src/utils/tezos/dummySigner.ts
@@ -1,14 +1,12 @@
 import { Signer } from "@taquito/taquito";
 export class DummySigner implements Signer {
-  pk: string;
   pkh: string;
 
-  constructor(pk: string, pkh: string) {
-    this.pk = pk;
+  constructor(pkh: string) {
     this.pkh = pkh;
   }
   async publicKey() {
-    return this.pk;
+    return "dummy";
   }
   async publicKeyHash() {
     return this.pkh;

--- a/src/utils/tezos/estimate.ts
+++ b/src/utils/tezos/estimate.ts
@@ -11,11 +11,10 @@ import { MultisigApproveOrExecuteMethodArgs, MultisigProposeMethodArgs } from ".
 
 export const estimateMultisigPropose = async (
   params: MultisigProposeMethodArgs,
-  senderPk: string,
   senderPkh: string,
   network: TezosNetwork
 ): Promise<Estimate> => {
-  const Tezos = makeToolkitWithDummySigner(senderPk, senderPkh, network);
+  const Tezos = makeToolkitWithDummySigner(senderPkh, network);
 
   const propseMethod = await makeMultisigProposeMethod(params, Tezos);
 
@@ -24,11 +23,10 @@ export const estimateMultisigPropose = async (
 
 export const estimateMultisigApproveOrExecute = async (
   params: MultisigApproveOrExecuteMethodArgs,
-  senderPk: string,
   senderPkh: string,
   network: TezosNetwork
 ): Promise<Estimate> => {
-  const Tezos = makeToolkitWithDummySigner(senderPk, senderPkh, network);
+  const Tezos = makeToolkitWithDummySigner(senderPkh, network);
 
   const approveOrExecuteMethod = await makeMultisigApproveOrExecuteMethod(params, Tezos);
 
@@ -38,12 +36,11 @@ export const estimateMultisigApproveOrExecute = async (
 export const estimateBatch = async (
   operations: OperationValue[],
   pkh: string,
-  pk: string,
   network: TezosNetwork
 ): Promise<Estimate[]> => {
-  const batch = await operationValuesToBatchParams(operations, pk, network);
+  const batch = await operationValuesToBatchParams(operations, network);
 
-  const Tezos = makeToolkitWithDummySigner(pk, pkh, network);
+  const Tezos = makeToolkitWithDummySigner(pkh, network);
 
   return Tezos.estimate.batch(batch);
 };

--- a/src/utils/tezos/helpers.ts
+++ b/src/utils/tezos/helpers.ts
@@ -93,14 +93,10 @@ export const makeToolkitWithSigner = async (config: SignerConfig) => {
   return Tezos;
 };
 
-export const makeToolkitWithDummySigner = (
-  pk: string,
-  pkh: string,
-  network: TezosNetwork
-): TezosToolkit => {
+export const makeToolkitWithDummySigner = (pkh: string, network: TezosNetwork): TezosToolkit => {
   const Tezos = new TezosToolkit(nodeUrls[network]);
   Tezos.setProvider({
-    signer: new DummySigner(pk, pkh),
+    signer: new DummySigner(pkh),
   });
   return Tezos;
 };
@@ -121,10 +117,10 @@ export const makeFA2TransferMethod = async (
 ): Promise<ContractMethod<ContractProvider>> => {
   const michelson = [
     {
-      from_: sender,
+      from_: sender.pkh,
       txs: [
         {
-          to_: recipient,
+          to_: recipient.pkh,
           token_id: tokenId,
           amount: amount,
         },
@@ -132,7 +128,7 @@ export const makeFA2TransferMethod = async (
     },
   ];
 
-  const contractInstance = await toolkit.contract.at(contract);
+  const contractInstance = await toolkit.contract.at(contract.pkh);
   return contractInstance.methods.transfer(michelson);
 };
 
@@ -140,15 +136,15 @@ export const makeFA12TransferMethod = async (
   { sender, recipient, amount, contract }: FA12TransferMethodArgs,
   toolkit: TezosToolkit
 ): Promise<ContractMethod<ContractProvider>> => {
-  const contractInstance = await toolkit.contract.at(contract);
-  return contractInstance.methods.transfer(sender, recipient, amount);
+  const contractInstance = await toolkit.contract.at(contract.pkh);
+  return contractInstance.methods.transfer(sender.pkh, recipient.pkh, amount);
 };
 
 export const makeMultisigProposeMethod = async (
   { lambdaActions, contract }: MultisigProposeMethodArgs,
   toolkit: TezosToolkit
 ) => {
-  const contractInstance = await toolkit.contract.at(contract);
+  const contractInstance = await toolkit.contract.at(contract.pkh);
   return contractInstance.methods.propose(lambdaActions);
 };
 
@@ -156,7 +152,7 @@ export const makeMultisigApproveOrExecuteMethod = async (
   { type, contract, operationId }: MultisigApproveOrExecuteMethodArgs,
   toolkit: TezosToolkit
 ) => {
-  const contractInstance = await toolkit.contract.at(contract);
+  const contractInstance = await toolkit.contract.at(contract.pkh);
   return contractInstance.methods[type](operationId);
 };
 

--- a/src/utils/tezos/params.ts
+++ b/src/utils/tezos/params.ts
@@ -7,6 +7,7 @@ import {
   WalletParamsWithKind,
 } from "@taquito/taquito";
 import { OperationValue } from "../../components/sendForm/types";
+import { parseContractPkh, parsePkh } from "../../types/Address";
 import {
   makeFA12TransferMethod,
   makeFA2TransferMethod,
@@ -68,7 +69,12 @@ const makeTokenTransferParams = async (
   }
   const asset = operation.data;
   const { contract } = asset;
-  const args = { ...operation.value, contract };
+  const args = {
+    sender: parsePkh(operation.value.sender),
+    recipient: parsePkh(operation.value.recipient),
+    amount: operation.value.amount,
+    contract: parseContractPkh(contract),
+  };
   const transferMethod =
     asset.type === "fa1.2"
       ? makeFA12TransferMethod(args, signer)
@@ -79,14 +85,13 @@ const makeTokenTransferParams = async (
 
 export const operationValuesToBatchParams = async (
   operations: OperationValue[],
-  pk: string,
   network: TezosNetwork
 ): Promise<ParamsWithKind[]> => {
   if (!operations.length) {
     return [];
   }
 
-  const Tezos = makeToolkitWithDummySigner(pk, operations[0].value.sender, network);
+  const Tezos = makeToolkitWithDummySigner(operations[0].value.sender, network);
 
   return operationValuesToParams(operations, Tezos);
 };

--- a/src/utils/tezos/types.ts
+++ b/src/utils/tezos/types.ts
@@ -1,9 +1,10 @@
 import { MichelsonV1Expression } from "@taquito/rpc";
+import { Address, ContractAddress } from "../../types/Address";
 
 export type FA2TransferMethodArgs = {
-  sender: string;
-  recipient: string;
-  contract: string;
+  sender: Address;
+  recipient: Address;
+  contract: ContractAddress;
   tokenId: string;
   amount: string;
 };
@@ -11,7 +12,7 @@ export type FA2TransferMethodArgs = {
 export type FA12TransferMethodArgs = Omit<FA2TransferMethodArgs, "tokenId">;
 
 export type MultisigProposeMethodArgs = {
-  contract: string;
+  contract: ContractAddress;
   lambdaActions: MichelsonV1Expression;
 };
 
@@ -19,7 +20,7 @@ type ApproveOrExecute = "approve" | "execute";
 
 export type MultisigApproveOrExecuteMethodArgs = {
   type: ApproveOrExecute;
-  contract: string;
+  contract: ContractAddress;
   operationId: string;
 };
 

--- a/src/utils/useAssetsPolling.ts
+++ b/src/utils/useAssetsPolling.ts
@@ -73,9 +73,9 @@ export const useAssetsPolling = () => {
   const dispatch = useAppDispatch();
   const accounts = useImplicitAccounts();
   const network = useSelectedNetwork();
-  const pkhs = accounts.map(a => a.pkh);
+  const pkhs = accounts.map(a => a.address.pkh);
   const accountPkhSet = new Set(pkhs);
-  const multisigPkhs = useMultisigAccounts().map(m => m.pkh);
+  const multisigPkhs = useMultisigAccounts().map(m => m.address.pkh);
 
   const tezQuery = useQuery("tezBalance", {
     queryFn: async () => {

--- a/src/views/batch/BatchDisplay.tsx
+++ b/src/views/batch/BatchDisplay.tsx
@@ -112,10 +112,10 @@ export const BatchDisplay: React.FC<{
   const network = useSelectedNetwork();
 
   return (
-    <Flex data-testid={`batch-table-${account.pkh}`} mb={4}>
+    <Flex data-testid={`batch-table-${account.address.pkh}`} mb={4}>
       <Box flex={1} bg="umami.gray.900" p={4}>
         <Flex justifyContent="space-between" ml={2} mr={2} mb={4}>
-          <AccountSmallTileDisplay ml={2} pkh={account.pkh} label={account.label} />
+          <AccountSmallTileDisplay ml={2} pkh={account.address.pkh} label={account.label} />
           <Text color={"umami.gray.400"}>
             {`${items.length} transaction${items.length > 1 ? "s" : ""}`}
           </Text>

--- a/src/views/batch/BatchView.test.tsx
+++ b/src/views/batch/BatchView.test.tsx
@@ -100,13 +100,12 @@ const addItemsToBatchViaUI = async () => {
 const addItemsToBatchViaStore = async () => {
   await store.dispatch(
     estimateAndUpdateBatch(
-      mockImplicitAccount(1).pkh,
-      mockImplicitAccount(1).pk,
+      mockImplicitAccount(1).address.pkh,
       [
         {
           type: "tez",
           value: {
-            sender: mockImplicitAccount(1).pkh,
+            sender: mockImplicitAccount(1).address.pkh,
             recipient: mockPkh(1),
             amount: "1000000",
           },
@@ -114,7 +113,7 @@ const addItemsToBatchViaStore = async () => {
         {
           type: "tez",
           value: {
-            sender: mockImplicitAccount(1).pkh,
+            sender: mockImplicitAccount(1).address.pkh,
             recipient: mockPkh(2),
             amount: "2000000",
           },
@@ -122,7 +121,7 @@ const addItemsToBatchViaStore = async () => {
         {
           type: "tez",
           value: {
-            sender: mockImplicitAccount(1).pkh,
+            sender: mockImplicitAccount(1).address.pkh,
             recipient: mockPkh(3),
             amount: "3000000",
           },
@@ -135,13 +134,12 @@ const addItemsToBatchViaStore = async () => {
 
   await store.dispatch(
     estimateAndUpdateBatch(
-      mockImplicitAccount(2).pkh,
-      mockImplicitAccount(2).pk,
+      mockImplicitAccount(2).address.pkh,
       [
         {
           type: "tez",
           value: {
-            sender: mockImplicitAccount(2).pkh,
+            sender: mockImplicitAccount(2).address.pkh,
             recipient: mockPkh(9),
             amount: "4",
           },
@@ -149,7 +147,7 @@ const addItemsToBatchViaStore = async () => {
         {
           type: "tez",
           value: {
-            sender: mockImplicitAccount(2).pkh,
+            sender: mockImplicitAccount(2).address.pkh,
             recipient: mockPkh(4),
             amount: "5",
           },
@@ -157,7 +155,7 @@ const addItemsToBatchViaStore = async () => {
         {
           type: "tez",
           value: {
-            sender: mockImplicitAccount(2).pkh,
+            sender: mockImplicitAccount(2).address.pkh,
             recipient: mockPkh(5),
             amount: "6",
           },
@@ -245,8 +243,12 @@ describe("<BatchView />", () => {
       render(fixture());
       clickSubmitOnFirstBatch();
 
-      expect(screen.getByTestId("batch-table-" + mockImplicitAccount(2).pkh)).toBeInTheDocument();
-      expect(screen.getByTestId("batch-table-" + mockImplicitAccount(1).pkh)).toBeInTheDocument();
+      expect(
+        screen.getByTestId("batch-table-" + mockImplicitAccount(2).address.pkh)
+      ).toBeInTheDocument();
+      expect(
+        screen.getByTestId("batch-table-" + mockImplicitAccount(1).address.pkh)
+      ).toBeInTheDocument();
 
       const previewBtn = screen.getByRole("button", { name: /preview/i });
       fireEvent.click(previewBtn);
@@ -306,9 +308,11 @@ describe("<BatchView />", () => {
         config
       );
 
-      expect(screen.getByTestId("batch-table-" + mockImplicitAccount(2).pkh)).toBeInTheDocument();
       expect(
-        screen.queryByTestId("batch-table-" + mockImplicitAccount(1).pkh)
+        screen.getByTestId("batch-table-" + mockImplicitAccount(2).address.pkh)
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByTestId("batch-table-" + mockImplicitAccount(1).address.pkh)
       ).not.toBeInTheDocument();
     });
   });

--- a/src/views/batch/batchUtils.ts
+++ b/src/views/batch/batchUtils.ts
@@ -37,10 +37,9 @@ export const sumEstimations = (es: Estimate[]) => {
 export const operationValuesToBatchItems = async (
   operations: OperationValue[],
   pkh: string,
-  pk: string,
   network: TezosNetwork
 ) => {
-  const estimations = await estimateBatch(operations, pkh, pk, network);
+  const estimations = await estimateBatch(operations, pkh, network);
   const items = zip(operations, estimations).map(([o, e]) => {
     return {
       fee: String(e.suggestedFeeMutez),

--- a/src/views/home/AccountList.test.tsx
+++ b/src/views/home/AccountList.test.tsx
@@ -10,7 +10,6 @@ import accountsSlice from "../../utils/store/accountsSlice";
 import { store } from "../../utils/store/store";
 import { AccountsList } from "./AccountsList";
 
-import { mockPk } from "../../mocks/factories";
 import { fakeRestoreFromMnemonic } from "../../mocks/helpers";
 import "../../mocks/mockGetRandomValues";
 import { fireEvent, render, screen, waitFor, within } from "../../mocks/testUtils";
@@ -159,7 +158,7 @@ describe("<AccountList />", () => {
     });
 
     fakeExtraArguments.restoreAccount.mockResolvedValue(
-      mockImplicitAccount(2, undefined, MOCK_FINGETPRINT1)
+      mockImplicitAccount(2, undefined, MOCK_FINGETPRINT1).address
     );
 
     fireEvent.click(screen.getByRole("button", { name: /submit/i }));
@@ -201,8 +200,10 @@ const restore = async () => {
     add({
       type: AccountType.SOCIAL,
       idp: "google",
-      pkh: mockPkh(6),
-      pk: mockPk(6),
+      address: {
+        type: "implicit",
+        pkh: mockPkh(6),
+      },
       label: GOOGLE_ACCOUNT_LABEL1,
     })
   );
@@ -211,8 +212,10 @@ const restore = async () => {
     add({
       type: AccountType.SOCIAL,
       idp: "google",
-      pkh: mockPkh(7),
-      pk: mockPk(7),
+      address: {
+        type: "implicit",
+        pkh: mockPkh(7),
+      },
       label: GOOGLE_ACCOUNT_LABEL2,
     })
   );

--- a/src/views/home/AccountListWithDrawer.tsx
+++ b/src/views/home/AccountListWithDrawer.tsx
@@ -17,7 +17,7 @@ const AccountListWithDrawer: React.FC = () => {
     closeDrawer();
   };
 
-  const account = allAccounts.find(a => a.pkh === selected);
+  const account = allAccounts.find(a => a.address.pkh === selected);
   return (
     <>
       <AccountsList

--- a/src/views/home/AccountsList.tsx
+++ b/src/views/home/AccountsList.tsx
@@ -6,7 +6,7 @@ import { IconAndTextBtn } from "../../components/IconAndTextBtn";
 import { useCreateOrImportSecretModal } from "../../components/Onboarding/useOnboardingModal";
 import {
   AccountType,
-  AllAccount,
+  Account,
   LedgerAccount,
   MnemonicAccount,
   MultisigAccount,
@@ -63,17 +63,21 @@ const AccountGroup: React.FC<{
         {showCTA && <AccountPopover onCreate={onDerive} onDelete={onDelete} />}
       </Flex>
 
-      {accounts.map(a => {
+      {accounts.map(account => {
         return (
           <AccountTile
-            selected={a.pkh === selected}
+            selected={account.address.pkh === selected}
             onClick={_ => {
-              onSelect(a.pkh);
+              onSelect(account.address.pkh);
             }}
-            key={a.pkh}
-            address={a.pkh}
-            label={a.label || ""}
-            balance={a.type === AccountType.MULTISIG ? a.balance : balances[a.pkh]}
+            key={account.address.pkh}
+            address={account.address.pkh}
+            label={account.label || ""}
+            balance={
+              account.type === AccountType.MULTISIG
+                ? account.balance
+                : balances[account.address.pkh]
+            }
           />
         );
       })}
@@ -81,7 +85,7 @@ const AccountGroup: React.FC<{
   );
 };
 
-const getLabel = (a: AllAccount) => {
+const getLabel = (a: Account) => {
   switch (a.type) {
     case AccountType.MNEMONIC:
       return `Seedphrase ${a.seedFingerPrint}`;
@@ -97,7 +101,7 @@ const getLabel = (a: AllAccount) => {
     }
   }
 };
-const groupByKind = (accounts: AllAccount[]): GroupedByLabel => {
+const groupByKind = (accounts: Account[]): GroupedByLabel => {
   return accounts.reduce((group: GroupedByLabel, a) => {
     const label = getLabel(a);
 

--- a/src/views/home/HomeView.test.tsx
+++ b/src/views/home/HomeView.test.tsx
@@ -14,10 +14,10 @@ describe("<HomeView />", () => {
   test("Clicking an account tile displays Account card drawer and marks account as selected", async () => {
     render(<HomeView />);
     // If you use .click() directly on el you get the act warnings...
-    const el = screen.getByTestId("account-tile-" + mockImplicitAccount(1).pkh);
+    const el = screen.getByTestId("account-tile-" + mockImplicitAccount(1).address.pkh);
     fireEvent.click(el);
 
-    await screen.findByTestId("account-card-" + mockImplicitAccount(1).pkh);
-    await screen.findByTestId("account-tile-" + mockImplicitAccount(1).pkh + "-selected");
+    await screen.findByTestId("account-card-" + mockImplicitAccount(1).address.pkh);
+    await screen.findByTestId("account-tile-" + mockImplicitAccount(1).address.pkh + "-selected");
   });
 });

--- a/src/views/tokens/AccountTokensTile.tsx
+++ b/src/views/tokens/AccountTokensTile.tsx
@@ -53,14 +53,14 @@ const AccountTokensTileHeader: React.FC<{
 const AccountTokensTile: React.FC<{
   account: ImplicitAccount;
   onOpenSendModal: (options?: Options) => void;
-}> = ({ account: { pkh, label }, onOpenSendModal }) => {
+}> = ({ account: { address, label }, onOpenSendModal }) => {
   const getTokens = useGetAccountAllTokens();
   const network = useSelectedNetwork();
-  const tokens = getTokens(pkh);
+  const tokens = getTokens(address.pkh);
   if (tokens.length === 0) return null;
   return (
     <Card m={4} p={5} bgColor={colors.gray[900]} borderRadius="10px">
-      <AccountTokensTileHeader pkh={pkh} label={label} />
+      <AccountTokensTileHeader pkh={address.pkh} label={label} />
 
       <TableContainer
         overflowX="unset"
@@ -115,7 +115,7 @@ const AccountTokensTile: React.FC<{
                         label="Send"
                         onClick={() => {
                           onOpenSendModal({
-                            sender: pkh,
+                            sender: address.pkh,
                             mode: { type: "token", data: token },
                           });
                         }}

--- a/src/views/tokens/TokensView.tsx
+++ b/src/views/tokens/TokensView.tsx
@@ -31,7 +31,11 @@ const TokensView = () => {
           <FilterController />
           <Box overflow={"scroll"}>
             {accounts.map(account => (
-              <AccountTokensTile key={account.pkh} account={account} onOpenSendModal={onOpen} />
+              <AccountTokensTile
+                key={account.address.pkh}
+                account={account}
+                onOpenSendModal={onOpen}
+              />
             ))}
           </Box>
           {modalElement}


### PR DESCRIPTION
## Proposed changes

Address now can be either Contract or Implicit
I removed pk field because it's not used anywhere and is impossible to get for contracts (unification)

Now we are able to restrict where we can use only Contracts or only Implicits, or both. parsePkh function can be further improved to validate contracts and make sure we have valid addresses throughout the app.

This change allows to smoothly introduce other types of contract accounts

As for now we don't support Multisig hierarchies and this change checks that we don't allow to pass in contract accounts as signers.

ImplicitAccounts now can only be assigned ImplicitAddresses, MultisigAccount can be represented only as a contract address and it's signers can be only ImplicitAddresses


TODO: test that beacon stuff works with pkh instead of pk. essentially they are the same thing. But I don't think it's possible to derive pk from pkh and I think we don't need to carry pk everywhere just for this use case if that's possible

In future we should use the `Address` type everywhere instead of passing pkh strings all over the place. I didn't include it here because it'd make the PR even bigger

## Types of changes

_Put an `x` in the boxes that apply_

- [ ] Bugfix
- [ ] New feature
- [x] Refactor
- [ ] Breaking change
- [ ] Documentation Update

## Checklist

- [ ] Tests that prove my fix is effective or that my feature works have been added
- [ ] Documentation has been added (if appropriate)
- [ ] Screenshots are added (if any UI changes have been made)
- [ ] All TODOs have a corresponding task created (and the link is attached to it)

