### PR TITLE
Disable devtools by default

### DIFF
--- a/public/electron.js
+++ b/public/electron.js
@@ -41,7 +41,7 @@ function createWindow() {
       sandbox: true,
       webSecurity: true,
       experimentalFeatures: false,
-      devTools: process.env.NODE_ENV !== "production",
+      devTools: process.env.ENABLE_DEV_TOOLS === "true", // Do not change. It's important for security that devtools are disabled by default
     },
   });
 


### PR DESCRIPTION
## Proposed changes

It's insecure to have the dev tools enabled

## Types of changes

_Put an `x` in the boxes that apply_

- [x] Bugfix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation Update
