### PR TITLE
Batch tez balance requests

### DIFF
--- a/src/components/AccountCard/AccountCard.test.tsx
+++ b/src/components/AccountCard/AccountCard.test.tsx
@@ -17,14 +17,12 @@ import { mockTzktTezTransfer } from "../../mocks/transfers";
 const { updateTezBalance, updateTokenBalance, updateTezTransfers } = assetsSlice.actions;
 const { add } = accountsSlice.actions;
 
-const tezBalance = "33200000000";
-
 const selectedAccount = mockImplicitAccount(0);
 const pkh = selectedAccount.address.pkh;
 const mockNft = mockNFTToken(0, pkh);
 beforeEach(() => {
   store.dispatch(add([selectedAccount, mockImplicitAccount(1)]));
-  store.dispatch(updateTezBalance([{ pkh: pkh, tez: tezBalance }]));
+  store.dispatch(updateTezBalance([{ address: pkh, balance: 33200000000 }]));
   store.dispatch(
     updateTokenBalance([
       {

--- a/src/multisig/multisigSandbox2.integration.test.ts
+++ b/src/multisig/multisigSandbox2.integration.test.ts
@@ -8,10 +8,10 @@ import {
   approveOrExecuteMultisigOperation,
   estimateMultisigApproveOrExecute,
   estimateMultisigPropose,
+  getAccounts,
   proposeMultisigLambda,
   transferMutez,
 } from "../utils/tezos";
-import { getBalancePayload } from "../utils/useAssetsPolling";
 import { makeBatchLambda } from "./multisigUtils";
 
 jest.unmock("../utils/tezos");
@@ -40,10 +40,8 @@ describe("multisig Sandbox", () => {
     const devAccount2Address = parseImplicitPkh(await devAccount2.publicKeyHash());
     const devAccount2Sk = await devAccount2.secretKey();
 
-    const { tez: preDevAccount2TezBalance } = await getBalancePayload(
-      devAccount2Address.pkh,
-      TezosNetwork.GHOSTNET
-    );
+    const accountInfos = await getAccounts([devAccount2Address.pkh], TezosNetwork.GHOSTNET);
+    const { balance: preDevAccount2TezBalance } = accountInfos[0];
 
     // First, devAccount2 send tez to MULTISIG_GHOSTNET_1
     const { fee } = await transferMutez(
@@ -173,11 +171,9 @@ describe("multisig Sandbox", () => {
     console.log("execute done");
     await sleep(25000);
 
-    const { tez: postDevAccount2TezBalance } = await getBalancePayload(
-      devAccount2Address.pkh,
-      TezosNetwork.GHOSTNET
-    );
+    const accountInfosAfter = await getAccounts([devAccount2Address.pkh], TezosNetwork.GHOSTNET);
+    const { balance: postDevAccount2TezBalance } = accountInfosAfter[0];
 
-    expect(parseInt(postDevAccount2TezBalance) + fee).toEqual(parseInt(preDevAccount2TezBalance));
+    expect(postDevAccount2TezBalance + fee).toEqual(preDevAccount2TezBalance);
   });
 });

--- a/src/utils/assetsReducer.test.ts
+++ b/src/utils/assetsReducer.test.ts
@@ -56,7 +56,7 @@ describe("Assets reducer", () => {
   });
 
   test("tez balances are replaced", () => {
-    store.dispatch(updateTezBalance([{ pkh: "foo", tez: "43" }]));
+    store.dispatch(updateTezBalance([{ address: "foo", balance: 43 }]));
 
     expect(store.getState().assets).toEqual({
       balances: {
@@ -76,8 +76,8 @@ describe("Assets reducer", () => {
 
     store.dispatch(
       updateTezBalance([
-        { pkh: "bar", tez: "44" },
-        { pkh: "baz", tez: "55" },
+        { address: "bar", balance: 44 },
+        { address: "baz", balance: 55 },
       ])
     );
 
@@ -102,16 +102,16 @@ describe("Assets reducer", () => {
   test("tez balances are updated", () => {
     store.dispatch(
       updateTezBalance([
-        { pkh: "bar", tez: "44" },
-        { pkh: "baz", tez: "55" },
+        { address: "bar", balance: 44 },
+        { address: "baz", balance: 55 },
       ])
     );
 
     store.dispatch(
       updateTezBalance([
         {
-          pkh: "baz",
-          tez: "66",
+          address: "baz",
+          balance: 66,
         },
       ])
     );
@@ -165,8 +165,8 @@ describe("Assets reducer", () => {
   test("updating network resets operations and balances", () => {
     store.dispatch(
       updateTezBalance([
-        { pkh: "bar", tez: "44" },
-        { pkh: "baz", tez: "55" },
+        { address: "bar", balance: 44 },
+        { address: "baz", balance: 55 },
       ])
     );
 
@@ -216,8 +216,8 @@ describe("Assets reducer", () => {
   test("reseting accounts resets assetsState", () => {
     store.dispatch(
       updateTezBalance([
-        { pkh: "bar", tez: "44" },
-        { pkh: "baz", tez: "55" },
+        { address: "bar", balance: 44 },
+        { address: "baz", balance: 55 },
       ])
     );
 

--- a/src/utils/multisig/fetch.test.ts
+++ b/src/utils/multisig/fetch.test.ts
@@ -9,8 +9,8 @@ jest.mock("axios");
 
 const mockedAxios = axios as jest.Mocked<typeof axios>;
 
-describe("multisi fetch", () => {
-  test("getSameContractsWithStorage", async () => {
+describe("multisig fetch", () => {
+  test("getAllMultiSigContracts", async () => {
     mockedAxios.get.mockResolvedValue({ data: ghostMultisigContracts });
 
     const result = await getAllMultiSigContracts(TezosNetwork.GHOSTNET);

--- a/src/utils/multisig/helper.test.ts
+++ b/src/utils/multisig/helper.test.ts
@@ -1,107 +1,106 @@
 import axios from "axios";
 import { mockContractAddress, mockImplicitAddress } from "../../mocks/factories";
 import { tzktGetBigMapKeysResponseType } from "../../utils/tzkt/types";
-import { TezosNetwork } from "@airgap/tezos";
 import { getOperationsForMultisigs, getRelevantMultisigContracts } from "./helpers";
 import { tzktGetSameMultisigsResponse } from "../../mocks/tzktResponse";
 import { parseImplicitPkh } from "../../types/Address";
+import { SupportedNetworks } from "../network";
 jest.mock("axios");
 
 const mockedAxios = axios as jest.Mocked<typeof axios>;
 
 describe("multisig helpers", () => {
-  test("getRelevantMultisigContracts", async () => {
-    const mockResponse = {
-      data: tzktGetSameMultisigsResponse,
-    };
-    mockedAxios.get.mockResolvedValue(mockResponse);
-    const result = await getRelevantMultisigContracts(
-      TezosNetwork.GHOSTNET,
-      new Set([mockImplicitAddress(0).pkh])
-    );
-
-    expect(result).toEqual([
-      {
-        address: mockContractAddress(0).pkh,
-        balance: 0,
-        storage: {
-          pending_ops: 0,
-          signers: [mockImplicitAddress(0).pkh],
-          threshold: "2",
-        },
-      },
-    ]);
-  });
-
-  test("getOperationsForMultisigs", async () => {
-    const mockResponse = {
-      data: [
-        {
-          active: true,
-          key: "0",
-          value: { actions: "action0", approvals: [mockImplicitAddress(0).pkh] },
-        },
-        {
-          active: true,
-          key: "1",
-          value: { actions: "action1", approvals: [mockImplicitAddress(1).pkh] },
-        },
-      ] as tzktGetBigMapKeysResponseType,
-    };
-    mockedAxios.get.mockResolvedValue(mockResponse);
-
-    const result = await getOperationsForMultisigs(
-      TezosNetwork.GHOSTNET,
-      tzktGetSameMultisigsResponse
-    );
-
-    tzktGetSameMultisigsResponse.forEach(res => {
-      const {
-        storage: { pending_ops },
-      } = res;
-
-      expect(mockedAxios.get).toBeCalledWith(
-        `https://api.ghostnet.tzkt.io/v1/bigmaps/${pending_ops}/keys?active=true`
+  SupportedNetworks.forEach(async network => {
+    test("getRelevantMultisigContracts", async () => {
+      const mockResponse = {
+        data: tzktGetSameMultisigsResponse,
+      };
+      mockedAxios.get.mockResolvedValue(mockResponse);
+      const result = await getRelevantMultisigContracts(
+        network,
+        new Set([mockImplicitAddress(0).pkh])
       );
+
+      expect(result).toEqual([
+        {
+          address: mockContractAddress(0).pkh,
+          balance: 0,
+          storage: {
+            pending_ops: 0,
+            signers: [mockImplicitAddress(0).pkh],
+            threshold: "2",
+          },
+        },
+      ]);
     });
 
-    expect(result).toEqual([
-      {
-        address: mockContractAddress(0),
-        balance: "0",
-        pendingOperations: [
+    test("getOperationsForMultisigs", async () => {
+      const mockResponse = {
+        data: [
           {
-            approvals: [mockImplicitAddress(0)],
+            active: true,
             key: "0",
-            rawActions: "action0",
+            value: { actions: "action0", approvals: [mockImplicitAddress(0).pkh] },
           },
           {
-            approvals: [mockImplicitAddress(1)],
+            active: true,
             key: "1",
-            rawActions: "action1",
+            value: { actions: "action1", approvals: [mockImplicitAddress(1).pkh] },
           },
-        ],
-        signers: [mockImplicitAddress(0)],
-        threshold: 2,
-      },
-      {
-        address: mockContractAddress(10),
-        balance: "10",
-        pendingOperations: [
-          {
-            approvals: [mockImplicitAddress(0)],
-            key: "0",
-            rawActions: "action0",
-          },
-          {
-            approvals: [mockImplicitAddress(1)],
-            key: "1",
-            rawActions: "action1",
-          },
-        ],
-        signers: [parseImplicitPkh("tz1W2hEsS1mj7dHPZ6267eeM4HDWJoG3s13n")],
-        threshold: 2,
-      },
-    ]);
+        ] as tzktGetBigMapKeysResponseType,
+      };
+      mockedAxios.get.mockResolvedValue(mockResponse);
+
+      const result = await getOperationsForMultisigs(network, tzktGetSameMultisigsResponse);
+
+      tzktGetSameMultisigsResponse.forEach(res => {
+        const {
+          storage: { pending_ops },
+        } = res;
+
+        expect(mockedAxios.get).toBeCalledWith(
+          `https://api.${network}.tzkt.io/v1/bigmaps/${pending_ops}/keys?active=true`
+        );
+      });
+
+      expect(result).toEqual([
+        {
+          address: mockContractAddress(0),
+          balance: "0",
+          pendingOperations: [
+            {
+              approvals: [mockImplicitAddress(0)],
+              key: "0",
+              rawActions: "action0",
+            },
+            {
+              approvals: [mockImplicitAddress(1)],
+              key: "1",
+              rawActions: "action1",
+            },
+          ],
+          signers: [mockImplicitAddress(0)],
+          threshold: 2,
+        },
+        {
+          address: mockContractAddress(10),
+          balance: "10",
+          pendingOperations: [
+            {
+              approvals: [mockImplicitAddress(0)],
+              key: "0",
+              rawActions: "action0",
+            },
+            {
+              approvals: [mockImplicitAddress(1)],
+              key: "1",
+              rawActions: "action1",
+            },
+          ],
+          signers: [parseImplicitPkh("tz1W2hEsS1mj7dHPZ6267eeM4HDWJoG3s13n")],
+          threshold: 2,
+        },
+      ]);
+    });
   });
 });

--- a/src/utils/network.ts
+++ b/src/utils/network.ts
@@ -1,0 +1,3 @@
+import { TezosNetwork } from "@airgap/tezos";
+
+export const SupportedNetworks = [TezosNetwork.GHOSTNET, TezosNetwork.MAINNET];

--- a/src/utils/store/assetsSlice.ts
+++ b/src/utils/store/assetsSlice.ts
@@ -8,6 +8,7 @@ import { Asset, fromToken } from "../../types/Asset";
 import { Baker } from "../../types/Baker";
 import { TezTransfer, TokenTransfer } from "../../types/Operation";
 import { Token } from "../../types/Token";
+import { TzktAccount } from "../tezos";
 import accountsSlice from "./accountsSlice";
 
 export type BatchItem = { operation: OperationValue; fee: string };
@@ -38,7 +39,6 @@ type State = {
   batches: Record<string, Batch | undefined>;
 };
 
-export type TezBalancePayload = { pkh: string; tez: string };
 export type TokenBalancePayload = { pkh: string; tokens: Token[] };
 export type TezTransfersPayload = {
   pkh: string;
@@ -121,9 +121,9 @@ const assetsSlice = createSlice({
       state.transfers.tokens = newTezTransfers;
     },
 
-    updateTezBalance: (state, { payload }: { type: string; payload: TezBalancePayload[] }) => {
-      state.balances.mutez = payload.reduce((acc, mutezBalance) => {
-        return { ...acc, [mutezBalance.pkh]: mutezBalance.tez };
+    updateTezBalance: (state, { payload }: { payload: TzktAccount[] }) => {
+      state.balances.mutez = payload.reduce((acc, accountInfo) => {
+        return { ...acc, [accountInfo.address]: String(accountInfo.balance) };
       }, {});
     },
 

--- a/src/utils/tezos/fetch.ts
+++ b/src/utils/tezos/fetch.ts
@@ -9,16 +9,25 @@ import {
   TokenTransfer,
 } from "@tzkt/sdk-api";
 import axios from "axios";
-import { bakersUrl, coincapUrl, nodeUrls, tzktUrls } from "./consts";
+import { bakersUrl, coincapUrl, tzktUrls } from "./consts";
 import { coinCapResponseType } from "./types";
 import { tokensGetTokenBalances } from "@tzkt/sdk-api";
-import { TezosToolkit } from "@taquito/taquito";
 import { Baker } from "../../types/Baker";
 import { TezTransfer } from "../../types/Operation";
 
-export const getBalance = async (pkh: string, network: TezosNetwork) => {
-  const Tezos = new TezosToolkit(nodeUrls[network]);
-  return Tezos.tz.getBalance(pkh);
+// TzKT defines type Account = {type: string};
+// whilst accountsGet returns all the info about accounts
+// for now we need only the balance, but we can extend it later
+export type TzktAccount = { address: string; balance: number };
+
+export const getAccounts = async (
+  pkhs: string[],
+  network: TezosNetwork
+): Promise<TzktAccount[]> => {
+  const response = await axios.get<TzktAccount[]>(
+    `${tzktUrls[network]}/v1/accounts?address.in=${pkhs.join(",")}&select=address,balance`
+  );
+  return response.data;
 };
 
 export const getTokens = async (pkh: string, network: TezosNetwork): Promise<Token[]> =>

--- a/src/views/operations/operationUtils.test.ts
+++ b/src/views/operations/operationUtils.test.ts
@@ -1,4 +1,3 @@
-import { TezosNetwork } from "@airgap/tezos";
 import { DelegationOperation, TokenTransfer } from "@tzkt/sdk-api";
 import { mockImplicitAddress } from "../../mocks/factories";
 import {
@@ -7,6 +6,7 @@ import {
   getTransactionsResult,
 } from "../../mocks/tzktResponse";
 import { OperationDisplay, TezTransfer } from "../../types/Operation";
+import { SupportedNetworks } from "../../utils/network";
 import {
   getOperationDisplays,
   getTezOperationDisplay,
@@ -663,7 +663,7 @@ describe("getOperationsDisplays", () => {
 
 describe("getTransactionUrl", () => {
   it("should return a proper URL", () => {
-    [TezosNetwork.GHOSTNET, TezosNetwork.MAINNET].forEach(network => {
+    SupportedNetworks.forEach(network => {
       expect(
         getTransactionUrl({
           transactionId: 123,


### PR DESCRIPTION
## Proposed changes

[Task link](https://app.asana.com/0/1204165186238194/1204849210925944/f)

Instead of making 1 request per account now we fetch all of them (including multisigs) in batches of 10 (because more might not pass the limit of a URI length).

## Types of changes

_Put an `x` in the boxes that apply_

- [ ] Bugfix
- [x] New feature
- [x] Refactor
- [ ] Breaking change
- [ ] Documentation Update

## Checklist

- [x] Tests that prove my fix is effective or that my feature works have been added
- [x] Documentation has been added (if appropriate)
- [ ] Screenshots are added (if any UI changes have been made)
- [ ] All TODOs have a corresponding task created (and the link is attached to it)
