### PR TITLE
Batch token balances requests

### DIFF
--- a/src/components/AccountCard/AccountCard.test.tsx
+++ b/src/components/AccountCard/AccountCard.test.tsx
@@ -1,7 +1,6 @@
 import {
   mockFA1Token,
   mockImplicitAccount,
-  mockImplicitAddress,
   mockMultisigAccount,
   mockNFTToken,
 } from "../../mocks/factories";
@@ -11,7 +10,7 @@ import { store } from "../../utils/store/store";
 
 import { TezosNetwork } from "@airgap/tezos";
 import AccountCard from ".";
-import { hedgeHoge, tzBtsc } from "../../mocks/fa12Tokens";
+import { hedgehoge, tzBtsc } from "../../mocks/fa12Tokens";
 import { uUSD } from "../../mocks/fa2Tokens";
 import { act, render, screen, within } from "../../mocks/testUtils";
 import { mockTzktTezTransfer } from "../../mocks/transfers";
@@ -27,31 +26,11 @@ beforeEach(() => {
   store.dispatch(updateTezBalance([{ address: pkh, balance: 33200000000 }]));
   store.dispatch(
     updateTokenBalance([
-      {
-        pkh: selectedAccount.address.pkh,
-        tokens: [
-          hedgeHoge,
-          tzBtsc,
-          uUSD,
-          mockFA1Token(1, mockImplicitAddress(1).pkh, 123),
-          mockNft,
-        ],
-      },
-    ])
-  );
-
-  store.dispatch(
-    updateTokenBalance([
-      {
-        pkh: selectedAccount.address.pkh,
-        tokens: [
-          hedgeHoge,
-          tzBtsc,
-          uUSD,
-          mockFA1Token(1, mockImplicitAddress(1).pkh, 123),
-          mockNft,
-        ],
-      },
+      hedgehoge(selectedAccount.address),
+      tzBtsc(selectedAccount.address),
+      uUSD(selectedAccount.address),
+      mockFA1Token(1, pkh, 123),
+      mockNft,
     ])
   );
 });

--- a/src/components/AccountCard/AssetsPannel/MultisigPendingList/MultisigDecodedOperationItem.test.tsx
+++ b/src/components/AccountCard/AssetsPannel/MultisigPendingList/MultisigDecodedOperationItem.test.tsx
@@ -1,6 +1,7 @@
+import { TokenBalance } from "@tzkt/sdk-api";
 import { mockContractAddress, mockImplicitAddress } from "../../../../mocks/factories";
 import { render, screen } from "../../../../mocks/testUtils";
-import { assetsActions, TokenBalancePayload } from "../../../../utils/store/assetsSlice";
+import { assetsActions } from "../../../../utils/store/assetsSlice";
 import { store } from "../../../../utils/store/store";
 import MultisigDecodedOperationItem from "./MultisigDecodedOperationItem";
 
@@ -31,22 +32,19 @@ describe("<MultisigDecodedOperationItem/>", () => {
   it("Non NFT FA tokens amount renders correctly", () => {
     const mockContract = mockContractAddress(0);
 
-    const mockBalancePlayload: TokenBalancePayload = {
-      pkh: "mockPkh",
-      tokens: [
-        {
-          balance: "1",
-          token: {
-            contract: { address: mockContract.pkh },
-            standard: "fa2",
-            tokenId: "0",
-            metadata: {
-              decimals: "2",
-              symbol: "mockSymbol",
-            },
-          },
+    const mockBalancePlayload: TokenBalance = {
+      account: { address: "mockPkh" },
+
+      balance: "1",
+      token: {
+        contract: { address: mockContract.pkh },
+        standard: "fa2",
+        tokenId: "0",
+        metadata: {
+          decimals: "2",
+          symbol: "mockSymbol",
         },
-      ],
+      },
     };
     store.dispatch(updateTokenBalance([mockBalancePlayload]));
 
@@ -69,32 +67,25 @@ describe("<MultisigDecodedOperationItem/>", () => {
       />
     );
 
-    expect(screen.getByTestId("deocded-fa-amount")).toHaveTextContent("-3 mockSymbol");
+    expect(screen.getByTestId("decoded-fa-amount")).toHaveTextContent("-3 mockSymbol");
   });
 
   it("NFT amount renders correctly", () => {
     const mockContract = mockContractAddress(0);
 
-    const mockBalancePlayload: TokenBalancePayload = {
-      pkh: "mockPkh",
-      tokens: [
-        {
-          balance: "1",
-          account: {
-            address: "address",
-          },
-          token: {
-            id: 0,
-            contract: { address: mockContract.pkh },
-            standard: "fa2",
-            tokenId: "3",
-            metadata: {
-              name: "mockNFTName",
-              displayUri: "mockDisplayUri",
-            },
-          },
+    const mockBalancePlayload: TokenBalance = {
+      account: { address: mockImplicitAddress(0).pkh },
+      balance: "1",
+      token: {
+        id: 0,
+        contract: { address: mockContract.pkh },
+        standard: "fa2",
+        tokenId: "3",
+        metadata: {
+          name: "mockNFTName",
+          displayUri: "mockDisplayUri",
         },
-      ],
+      },
     };
 
     store.dispatch(updateTokenBalance([mockBalancePlayload]));
@@ -112,6 +103,6 @@ describe("<MultisigDecodedOperationItem/>", () => {
       />
     );
 
-    expect(screen.getByTestId("deocded-fa-amount")).toHaveTextContent("300 mockNFTName");
+    expect(screen.getByTestId("decoded-fa-amount")).toHaveTextContent("300 mockNFTName");
   });
 });

--- a/src/components/AccountCard/AssetsPannel/MultisigPendingList/MultisigDecodedOperationItem.tsx
+++ b/src/components/AccountCard/AssetsPannel/MultisigPendingList/MultisigDecodedOperationItem.tsx
@@ -63,7 +63,7 @@ const MultisigOperationAmount: React.FC<{
       const isNFT = asset.type === "nft";
 
       return (
-        <Flex alignItems="center" data-testid="deocded-fa-amount">
+        <Flex alignItems="center" data-testid="decoded-fa-amount">
           <Icon h={5} w={5} as={FiArrowUpRight} color={colors.gray[400]}></Icon>
           {isNFT ? (
             <Text textAlign="center" ml={1}>

--- a/src/mocks/fa12Tokens.ts
+++ b/src/mocks/fa12Tokens.ts
@@ -1,60 +1,65 @@
+import { Address } from "../types/Address";
 import { Token } from "../types/Token";
 
-export const tzBtsc: Token = {
-  id: 25018298793985,
-  account: {
-    address: "tz1Mj7RzPmMAqDUNFBn5t5VbXmWW4cSUAdtT",
-  },
-  token: {
-    id: 24975299837953,
-    contract: {
-      alias: "tzBTC",
-      address: "KT1PWx2mnDueood7fEmfbBDKx1D9BAnnXitn",
+export const tzBtsc = (owner: Address): Token => {
+  return {
+    id: 25018298793985,
+    account: {
+      address: owner.pkh,
     },
-    tokenId: "0",
-    standard: "fa1.2",
-    totalSupply: "107615636205",
-    metadata: {
-      name: "tzBTC",
-      symbol: "tzBTC",
-      decimals: "8",
+    token: {
+      id: 24975299837953,
+      contract: {
+        alias: "tzBTC",
+        address: "KT1PWx2mnDueood7fEmfbBDKx1D9BAnnXitn",
+      },
+      tokenId: "0",
+      standard: "fa1.2",
+      totalSupply: "107615636205",
+      metadata: {
+        name: "tzBTC",
+        symbol: "tzBTC",
+        decimals: "8",
+      },
     },
-  },
-  balance: "2205",
-  transfersCount: 68,
-  firstLevel: 890534,
-  firstTime: "2020-04-01T14:11:25Z",
-  lastLevel: 3028779,
-  lastTime: "2023-01-04T17:57:29Z",
+    balance: "2205",
+    transfersCount: 68,
+    firstLevel: 890534,
+    firstTime: "2020-04-01T14:11:25Z",
+    lastLevel: 3028779,
+    lastTime: "2023-01-04T17:57:29Z",
+  };
 };
 
-export const hedgeHoge: Token = {
-  id: 53252621074433,
-  account: {
-    address: "tz1Mj7RzPmMAqDUNFBn5t5VbXmWW4cSUAdtT",
-  },
-  token: {
-    id: 53248292552705,
-    contract: {
-      alias: "Hedgehoge",
-      address: "KT1G1cCRNBgQ48mVDjopHjEmTN5Sbtar8nn9",
+export const hedgehoge = (owner: Address): Token => {
+  return {
+    id: 53252621074433,
+    account: {
+      address: owner.pkh,
     },
-    tokenId: "0",
-    standard: "fa1.2",
-    totalSupply: "42000000000000",
-    metadata: {
-      icon: "ipfs://QmXL3FZ5kcwXC8mdwkS1iCHS2qVoyg69ugBhU2ap8z1zcs",
-      name: "Hedgehoge",
-      symbol: "HEH",
-      decimals: "6",
+    token: {
+      id: 53248292552705,
+      contract: {
+        alias: "Hedgehoge",
+        address: "KT1G1cCRNBgQ48mVDjopHjEmTN5Sbtar8nn9",
+      },
+      tokenId: "0",
+      standard: "fa1.2",
+      totalSupply: "42000000000000",
+      metadata: {
+        icon: "ipfs://QmXL3FZ5kcwXC8mdwkS1iCHS2qVoyg69ugBhU2ap8z1zcs",
+        name: "Hedgehoge",
+        symbol: "HEH",
+        decimals: "6",
+      },
     },
-  },
-  balance: "10000000000",
-  transfersCount: 1,
-  firstLevel: 1477579,
-  firstTime: "2021-05-19T01:09:54Z",
-  lastLevel: 1477579,
-  lastTime: "2021-05-19T01:09:54Z",
+    balance: "10000000000",
+    transfersCount: 1,
+    firstLevel: 1477579,
+    firstTime: "2021-05-19T01:09:54Z",
+    lastLevel: 1477579,
+    lastTime: "2021-05-19T01:09:54Z",
+  };
 };
 
 export const ghostnetFA12: Token = {

--- a/src/mocks/fa2Tokens.ts
+++ b/src/mocks/fa2Tokens.ts
@@ -1,30 +1,33 @@
+import { Address } from "../types/Address";
 import { Token } from "../types/Token";
 
-export const uUSD: Token = {
-  id: 64166129827842,
-  account: {
-    address: "tz1Mj7RzPmMAqDUNFBn5t5VbXmWW4cSUAdtT",
-  },
-  token: {
-    id: 64166129827841,
-    contract: {
-      address: "KT1QTcAXeefhJ3iXLurRt81WRKdv7YqyYFmo",
+export const uUSD = (owner: Address): Token => {
+  return {
+    id: 64166129827842,
+    account: {
+      address: owner.pkh,
     },
-    tokenId: "0",
-    standard: "fa2",
-    totalSupply: "55000413808",
-    metadata: {
-      name: "youves uUSD",
-      symbol: "uUSD",
-      decimals: "12",
-      thumbnailUri: "ipfs://QmbvhanNCxydZEbGu1RdqkG3LcpNGv7XYsCHgzWBXnmxRd",
-      shouldPreferSymbol: true,
+    token: {
+      id: 64166129827841,
+      contract: {
+        address: "KT1QTcAXeefhJ3iXLurRt81WRKdv7YqyYFmo",
+      },
+      tokenId: "0",
+      standard: "fa2",
+      totalSupply: "55000413808",
+      metadata: {
+        name: "youves uUSD",
+        symbol: "uUSD",
+        decimals: "12",
+        thumbnailUri: "ipfs://QmbvhanNCxydZEbGu1RdqkG3LcpNGv7XYsCHgzWBXnmxRd",
+        shouldPreferSymbol: true,
+      },
     },
-  },
-  balance: "19218750000",
-  transfersCount: 3,
-  firstLevel: 1566786,
-  firstTime: "2021-07-21T12:05:58Z",
-  lastLevel: 1566979,
-  lastTime: "2021-07-21T15:18:58Z",
+    balance: "19218750000",
+    transfersCount: 3,
+    firstLevel: 1566786,
+    firstTime: "2021-07-21T12:05:58Z",
+    lastLevel: 1566979,
+    lastTime: "2021-07-21T15:18:58Z",
+  };
 };

--- a/src/mocks/tzktResponse.ts
+++ b/src/mocks/tzktResponse.ts
@@ -1,7 +1,6 @@
 import { DelegationOperation, TokenTransfer } from "@tzkt/sdk-api";
 import { TezTransfer } from "../types/Operation";
 import { Token } from "../types/Token";
-import { TokenBalancePayload } from "../utils/store/assetsSlice";
 import { tzktGetSameMultisigsResponseType } from "../utils/tzkt/types";
 import { mockContractAddress, mockImplicitAddress } from "./factories";
 
@@ -712,21 +711,3 @@ export const tzktGetSameMultisigsResponse: tzktGetSameMultisigsResponseType = [
     storage: { threshold: "2", pending_ops: 0, signers: [mockImplicitAddress(10).pkh] },
   },
 ];
-
-export const mockBalancePlayload: TokenBalancePayload = {
-  pkh: "baz",
-  tokens: [
-    {
-      balance: "1",
-      token: {
-        contract: { address: "mockContract" },
-        standard: "fa2",
-        tokenId: "0",
-        metadata: {
-          decimals: "2",
-          symbol: "mockSymbol",
-        },
-      },
-    },
-  ],
-};

--- a/src/types/Asset.test.tsx
+++ b/src/types/Asset.test.tsx
@@ -1,4 +1,4 @@
-import { tzBtsc, hedgeHoge } from "../mocks/fa12Tokens";
+import { tzBtsc, hedgehoge } from "../mocks/fa12Tokens";
 import { uUSD } from "../mocks/fa2Tokens";
 import { mockNFT, mockImplicitAddress } from "../mocks/factories";
 import { fa1Token, fa2Token, nft } from "../mocks/tzktResponse";
@@ -82,7 +82,7 @@ describe("fromToken", () => {
   });
 
   test("fa1 token with name symbol and decimals (tzBTC)", () => {
-    const result = fromToken(tzBtsc);
+    const result = fromToken(tzBtsc(mockImplicitAddress(0)));
 
     const expected = {
       type: "fa1.2",
@@ -97,8 +97,8 @@ describe("fromToken", () => {
     expect(result).toEqual(expected);
   });
 
-  test("fa1 token with name symbol decimals and icon (hedgeHoge)", () => {
-    const result = fromToken(hedgeHoge);
+  test("fa1 token with name symbol decimals and icon (Hedgehoge)", () => {
+    const result = fromToken(hedgehoge(mockImplicitAddress(0)));
 
     const expected = {
       type: "fa1.2",
@@ -115,7 +115,7 @@ describe("fromToken", () => {
   });
 
   test("fa2 token with thumbnailUri (uUSD)", () => {
-    const result = fromToken(uUSD);
+    const result = fromToken(uUSD(mockImplicitAddress(0)));
     const expected = {
       type: "fa2",
       contract: "KT1QTcAXeefhJ3iXLurRt81WRKdv7YqyYFmo",

--- a/src/types/Asset.ts
+++ b/src/types/Asset.ts
@@ -60,7 +60,7 @@ export const fromToken = (raw: Token): Asset | null => {
   }
 
   if (!metadata) {
-    console.log("Impossible state, FA2 metadata is empty");
+    // We don't support FA2 without metadata yet
     return null;
   }
 

--- a/src/utils/store/assetsSlice.test.ts
+++ b/src/utils/store/assetsSlice.test.ts
@@ -1,5 +1,5 @@
-import assetsSlice from "./store/assetsSlice";
-import { store } from "./store/store";
+import assetsSlice from "./assetsSlice";
+import { store } from "./store";
 
 import { TezosNetwork } from "@airgap/tezos";
 import { waitFor } from "@testing-library/react";
@@ -11,13 +11,13 @@ import {
   mockTezTransaction,
   mockTezTransfer,
   mockTokenTransaction,
-} from "../mocks/factories";
-import accountsSlice from "./store/accountsSlice";
-import { estimateAndUpdateBatch } from "./store/thunks/estimateAndupdateBatch";
-import { estimateBatch } from "./tezos";
-import { OperationValue } from "../components/sendForm/types";
-import { mockBalancePlayload } from "../mocks/tzktResponse";
-jest.mock("./tezos");
+} from "../../mocks/factories";
+import accountsSlice from "./accountsSlice";
+import { estimateAndUpdateBatch } from "./thunks/estimateAndupdateBatch";
+import { estimateBatch } from "../tezos";
+import { OperationValue } from "../../components/sendForm/types";
+import { hedgehoge } from "../../mocks/fa12Tokens";
+jest.mock("../tezos");
 
 const estimateBatchMock = estimateBatch as jest.Mock;
 
@@ -132,22 +132,23 @@ describe("Assets reducer", () => {
   });
 
   test("token balances are updated", () => {
-    store.dispatch(updateTokenBalance([mockBalancePlayload]));
+    store.dispatch(updateTokenBalance([hedgehoge(mockImplicitAddress(0))]));
 
     expect(store.getState().assets).toEqual({
       balances: {
         mutez: {},
         tokens: {
-          baz: [
+          [mockImplicitAddress(0).pkh]: [
             {
-              balance: "1",
-              contract: "mockContract",
+              balance: "10000000000",
+              contract: "KT1G1cCRNBgQ48mVDjopHjEmTN5Sbtar8nn9",
               metadata: {
-                decimals: "2",
-                symbol: "mockSymbol",
+                icon: "ipfs://QmXL3FZ5kcwXC8mdwkS1iCHS2qVoyg69ugBhU2ap8z1zcs",
+                name: "Hedgehoge",
+                symbol: "HEH",
+                decimals: "6",
               },
-              tokenId: "0",
-              type: "fa2",
+              type: "fa1.2",
             },
           ],
         },
@@ -170,34 +171,7 @@ describe("Assets reducer", () => {
       ])
     );
 
-    store.dispatch(updateTokenBalance([mockBalancePlayload]));
-
-    expect(store.getState().assets).toEqual({
-      balances: {
-        mutez: { bar: "44", baz: "55" },
-        tokens: {
-          baz: [
-            {
-              balance: "1",
-              contract: "mockContract",
-              metadata: {
-                decimals: "2",
-                symbol: "mockSymbol",
-              },
-              tokenId: "0",
-              type: "fa2",
-            },
-          ],
-        },
-      },
-      conversionRate: null,
-      delegations: {},
-      bakers: [],
-      network: "mainnet",
-      transfers: { tez: {}, tokens: {} },
-      batches: {},
-      blockLevel: null,
-    });
+    store.dispatch(updateTokenBalance([hedgehoge(mockImplicitAddress(0))]));
 
     store.dispatch(updateNetwork(TezosNetwork.GHOSTNET));
 
@@ -221,34 +195,7 @@ describe("Assets reducer", () => {
       ])
     );
 
-    store.dispatch(updateTokenBalance([mockBalancePlayload]));
-
-    expect(store.getState().assets).toEqual({
-      balances: {
-        mutez: { bar: "44", baz: "55" },
-        tokens: {
-          baz: [
-            {
-              balance: "1",
-              contract: "mockContract",
-              metadata: {
-                decimals: "2",
-                symbol: "mockSymbol",
-              },
-              tokenId: "0",
-              type: "fa2",
-            },
-          ],
-        },
-      },
-      conversionRate: null,
-      delegations: {},
-      bakers: [],
-      network: "mainnet",
-      transfers: { tez: {}, tokens: {} },
-      batches: {},
-      blockLevel: null,
-    });
+    store.dispatch(updateTokenBalance([hedgehoge(mockImplicitAddress(0))]));
 
     store.dispatch(accountsSlice.actions.reset());
 

--- a/src/utils/tezos/fetch.ts
+++ b/src/utils/tezos/fetch.ts
@@ -4,14 +4,13 @@ import {
   DelegationOperation,
   operationsGetDelegations,
   operationsGetTransactions,
-  Token,
+  TokenBalance,
   tokensGetTokenTransfers,
   TokenTransfer,
 } from "@tzkt/sdk-api";
 import axios from "axios";
 import { bakersUrl, coincapUrl, tzktUrls } from "./consts";
 import { coinCapResponseType } from "./types";
-import { tokensGetTokenBalances } from "@tzkt/sdk-api";
 import { Baker } from "../../types/Baker";
 import { TezTransfer } from "../../types/Operation";
 
@@ -30,16 +29,15 @@ export const getAccounts = async (
   return response.data;
 };
 
-export const getTokens = async (pkh: string, network: TezosNetwork): Promise<Token[]> =>
-  tokensGetTokenBalances(
-    {
-      account: { eq: pkh },
-      balance: { gt: "0" },
-    },
-    {
-      baseUrl: tzktUrls[network],
-    }
+export const getTokenBalances = async (
+  pkhs: string[],
+  network: TezosNetwork
+): Promise<TokenBalance[]> => {
+  const response = await axios.get<TokenBalance[]>(
+    `${tzktUrls[network]}/v1/tokens/balances?account.in=${pkhs.join(",")}&balance.gt=0`
   );
+  return response.data;
+};
 
 export const getTezTransfers = (
   address: string,

--- a/src/views/nfts/NFTsView.test.tsx
+++ b/src/views/nfts/NFTsView.test.tsx
@@ -22,20 +22,10 @@ describe("NFTsView", () => {
   it("displays nfts of all accounts by default", () => {
     store.dispatch(
       updateTokenBalance([
-        {
-          pkh: mockImplicitAddress(1).pkh,
-          tokens: [
-            mockNFTToken(1, mockImplicitAddress(1).pkh),
-            mockNFTToken(2, mockImplicitAddress(1).pkh),
-          ],
-        },
-        {
-          pkh: mockImplicitAddress(2).pkh,
-          tokens: [
-            mockNFTToken(1, mockImplicitAddress(2).pkh),
-            mockNFTToken(2, mockImplicitAddress(2).pkh),
-          ],
-        },
+        mockNFTToken(1, mockImplicitAddress(1).pkh),
+        mockNFTToken(2, mockImplicitAddress(1).pkh),
+        mockNFTToken(1, mockImplicitAddress(2).pkh),
+        mockNFTToken(2, mockImplicitAddress(2).pkh),
       ])
     );
 


### PR DESCRIPTION
## Proposed changes

Token balances are now batched.

The batch size is increased to 40 because it should fit the "limit".

assetsReducer test file renamed to assetsSlice.test.tsx because it tests only it and there is no assetsReducer in the codebase

console.warn from fromToken is removed because we do have such cases, but not to pollute the console I just removed it. We have a ticket to address it

There was a bug in assetsSlice tests. The fa1 token had wrong owner pkh

Multisig tokens are also fetched

<img width="1353" alt="Screenshot 2023-06-23 at 14 45 43" src="https://github.com/trilitech/umami-v2/assets/129749432/ab5368e6-bfaa-4372-be5a-62dc3b352f14">
<img width="1132" alt="Screenshot 2023-06-23 at 16 43 08" src="https://github.com/trilitech/umami-v2/assets/129749432/4d10a397-d27f-40d3-955d-104f301a1c91">

## Types of changes

_Put an `x` in the boxes that apply_

- [ ] Bugfix
- [ ] New feature
- [x] Refactor
- [ ] Breaking change
- [x] Documentation Update

## Checklist

- [x] Tests that prove my fix is effective or that my feature works have been added
- [x] Documentation has been added (if appropriate)
- [ ] Screenshots are added (if any UI changes have been made)
- [ ] All TODOs have a corresponding task created (and the link is attached to it)
