### PR TITLE
Limit bigmap request concurrency

### DIFF
--- a/src/mocks/tzktResponse.ts
+++ b/src/mocks/tzktResponse.ts
@@ -708,6 +708,6 @@ export const tzktGetSameMultisigsResponse: tzktGetSameMultisigsResponseType = [
   },
   {
     address: mockContractAddress(10).pkh,
-    storage: { threshold: "2", pending_ops: 0, signers: [mockImplicitAddress(10).pkh] },
+    storage: { threshold: "2", pending_ops: 1, signers: [mockImplicitAddress(10).pkh] },
   },
 ];

--- a/src/utils/multisig/helpers.ts
+++ b/src/utils/multisig/helpers.ts
@@ -1,5 +1,5 @@
 import { TezosNetwork } from "@airgap/tezos";
-import { compact } from "lodash";
+import { chunk, compact } from "lodash";
 import { parseContractPkh, parseImplicitPkh } from "../../types/Address";
 import { tzktGetSameMultisigsResponseType } from "../tzkt/types";
 import { getAllMultiSigContracts, getPendingOperations } from "./fetch";
@@ -18,31 +18,38 @@ export const getRelevantMultisigContracts = async (
 
 export const getOperationsForMultisigs = async (
   network: TezosNetwork,
-  multisigs: tzktGetSameMultisigsResponseType
+  multisigs: tzktGetSameMultisigsResponseType,
+  chunkSize = 5
 ): Promise<MultisigWithPendingOperations[]> => {
-  const multisigsWithOperations = await Promise.all(
-    multisigs.map(async ({ address, storage: { signers, pending_ops, threshold } }) => {
-      const response = await getPendingOperations(network, pending_ops);
+  let multisigsWithOperations: MultisigWithPendingOperations[] = [];
+  const multisigChunks = chunk(multisigs, chunkSize);
 
-      const operations = response.map(({ key, value }) => {
-        if (!value || !key) {
-          return null;
-        }
+  for (const chunk of multisigChunks) {
+    const responses = await Promise.all(
+      chunk.map(async ({ address, storage: { signers, pending_ops, threshold } }) => {
+        const response = await getPendingOperations(network, pending_ops);
+
+        const operations = response.map(({ key, value }) => {
+          if (!value || !key) {
+            return null;
+          }
+          return {
+            key,
+            rawActions: value.actions,
+            approvals: value.approvals.map(parseImplicitPkh),
+          };
+        });
+
         return {
-          key,
-          rawActions: value.actions,
-          approvals: value.approvals.map(parseImplicitPkh),
-        };
-      });
-
-      return {
-        address: parseContractPkh(address),
-        threshold: Number(threshold),
-        signers: signers.map(parseImplicitPkh),
-        pendingOperations: compact(operations),
-      };
-    })
-  );
+          address: parseContractPkh(address),
+          threshold: Number(threshold),
+          signers: signers.map(parseImplicitPkh),
+          pendingOperations: compact(operations),
+        } as MultisigWithPendingOperations;
+      })
+    );
+    multisigsWithOperations = multisigsWithOperations.concat(responses);
+  }
 
   return multisigsWithOperations;
 };


### PR DESCRIPTION
## Proposed changes

Bigmaps on the ghostnet lead to 429 even though they are fast they still run simultaneously. So I limited the amount of concurrent requests to just 5. It should be enough to be able to load them fast (on average they take around 30ms) and not hit the rate limit.
Also I improved the test so that we see that different bitmaps get different responses

## Types of changes

_Put an `x` in the boxes that apply_

- [ ] Bugfix
- [ ] New feature
- [x] Refactor
- [ ] Breaking change
- [ ] Documentation Update

## Screenshots

See the waterfall. Just for the screenshots I set the chunk size to 1

| Before | Now    |
| ------ | ------ |
| <img width="1573" alt="Screenshot 2023-06-25 at 09 56 28" src="https://github.com/trilitech/umami-v2/assets/129749432/89b25fa4-3ca8-4cd3-8205-5f25d52c3104"> | <img width="1615" alt="Screenshot 2023-06-25 at 09 56 06" src="https://github.com/trilitech/umami-v2/assets/129749432/48659477-d466-4496-912c-43a7716e723b"> |


## Checklist

- [x] Tests that prove my fix is effective or that my feature works have been added
- [ ] Documentation has been added (if appropriate)
- [x] Screenshots are added (if any UI changes have been made)
- [ ] All TODOs have a corresponding task created (and the link is attached to it)
