### PR TITLE
Better alignment for pending approvals count

### DIFF
--- a/src/components/AccountCard/AssetsPannel/MultisigPendingList/MultisigPendingCard.tsx
+++ b/src/components/AccountCard/AssetsPannel/MultisigPendingList/MultisigPendingCard.tsx
@@ -32,17 +32,17 @@ export const MultisigPendingCard: React.FC<{
       <Box p={1} {...getDisclosureProps()}>
         <Flex marginY={2} justifyContent="space-between">
           <MultisigOperationsDisplay rawActions={operation.rawActions} />
-          <Flex alignItems="center">
-            <Heading color={colors.gray[400]} size="sm" mr={1}>
+          <Flex alignItems="flex-end" mb="25px">
+            <Text color={colors.gray[400]} size="sm" mr={1}>
               Pending Approvals:
-            </Heading>
+            </Text>
             <Text color="w" data-testid="multisig-card-text">
               {pendingApprovals}
             </Text>
           </Flex>
         </Flex>
 
-        <Box marginY={5}>
+        <Box mb={5}>
           {signers.map(signer => (
             <MultisigSignerTile
               key={signer.pkh}


### PR DESCRIPTION
## Screenshots

Add the screenshots of how the app used to look like and how it looks now

| Before | Now    |
| ------ | ------ |
| <img width="789" alt="Screenshot 2023-06-25 at 10 46 59" src="https://github.com/trilitech/umami-v2/assets/129749432/82ff2f52-41e3-4515-b9d3-7a932594c646"> | <img width="787" alt="Screenshot 2023-06-25 at 10 49 00" src="https://github.com/trilitech/umami-v2/assets/129749432/8100fc89-c743-4d82-a5d9-8a14c41a967e"> |
| <img width="802" alt="Screenshot 2023-06-25 at 10 45 54" src="https://github.com/trilitech/umami-v2/assets/129749432/3fa8cc0f-8211-4b2f-85fc-683478a86ff1"> | <img width="807" alt="Screenshot 2023-06-25 at 10 49 06" src="https://github.com/trilitech/umami-v2/assets/129749432/1506dbc3-82a3-43e9-8184-d5fdf1078de4"> |
