### PR TITLE
Correct assets polling

### DIFF
--- a/src/utils/useAssetsPolling.ts
+++ b/src/utils/useAssetsPolling.ts
@@ -2,7 +2,7 @@ import { TezosNetwork } from "@airgap/tezos";
 import { compact } from "lodash";
 import { useEffect, useRef } from "react";
 import { useQuery } from "react-query";
-import { useImplicitAccounts, useMultisigAccounts } from "./hooks/accountHooks";
+import { useImplicitAccounts } from "./hooks/accountHooks";
 import { useSelectedNetwork } from "./hooks/assetsHooks";
 import { getOperationsForMultisigs, getRelevantMultisigContracts } from "./multisig/helpers";
 import {
@@ -61,66 +61,53 @@ export const useAssetsPolling = () => {
   const implicitAccounts = useImplicitAccounts();
   const network = useSelectedNetwork();
   const implicitAccountPkhs = implicitAccounts.map(account => account.address.pkh);
-  const multisigPkhs = useMultisigAccounts().map(multisig => multisig.address.pkh);
-  const allAccountPkhs = [...implicitAccountPkhs, ...multisigPkhs];
-  const pkhChunks = chunk(allAccountPkhs, MAX_ADDRESSES_PER_REQUEST);
 
-  const tezQuery = useQuery("tezBalance", {
+  const accountAssetsQuery = useQuery("allAssets", {
     queryFn: async () => {
-      const accountInfos = await Promise.all(pkhChunks.flatMap(pkhs => getAccounts(pkhs, network)));
-      dispatch(assetsActions.updateTezBalance(accountInfos.flat()));
-    },
+      const multisigs = await getRelevantMultisigContracts(network, new Set(implicitAccountPkhs));
 
-    refetchInterval: BLOCK_TIME,
-    refetchIntervalInBackground: true,
-  });
-
-  const tokenQuery = useQuery("tokenBalance", {
-    queryFn: async () => {
-      const tokenBalances = await Promise.all(
-        pkhChunks.map(pkhs => getTokenBalances(pkhs, network))
+      const pendingOperations = getOperationsForMultisigs(network, multisigs).then(
+        multisigsWithOperations => {
+          dispatch(multisigActions.set(multisigsWithOperations));
+        }
       );
-      dispatch(assetsActions.updateTokenBalance(tokenBalances.flat()));
-    },
 
-    refetchInterval: BLOCK_TIME,
-    refetchIntervalInBackground: true,
-  });
+      const allAccountPkhs = [...implicitAccountPkhs, ...multisigs.map(acc => acc.address)];
+      const pkhChunks = chunk(allAccountPkhs, MAX_ADDRESSES_PER_REQUEST);
 
-  const tezTransfersQuery = useQuery("tezTransfers", {
-    queryFn: async () => {
-      const transfers = await Promise.all(
+      const tezBalances = Promise.all(pkhChunks.flatMap(pkhs => getAccounts(pkhs, network))).then(
+        accountInfos => {
+          dispatch(assetsActions.updateTezBalance(accountInfos.flat()));
+        }
+      );
+
+      const tokens = Promise.all(pkhChunks.map(pkhs => getTokenBalances(pkhs, network))).then(
+        async tokenBalances => {
+          dispatch(assetsActions.updateTokenBalance(tokenBalances.flat()));
+
+          // token transfers have to be fetched after the balances were fetched
+          // because otherwise we might not have some tokens' info to display the operations
+          return Promise.all(
+            implicitAccountPkhs.map(pkh => getTokensTransfersPayload(pkh, network))
+          ).then(tokenTransfers => {
+            dispatch(assetsActions.updateTokenTransfers(tokenTransfers));
+          });
+        }
+      );
+
+      const tezTransfers = Promise.all(
         implicitAccountPkhs.map(pkh => getTezTransfersPayload(pkh, network))
-      );
+      ).then(tezTransfers => {
+        dispatch(assetsActions.updateTezTransfers(tezTransfers));
+      });
 
-      dispatch(assetsActions.updateTezTransfers(transfers));
-    },
-
-    refetchInterval: BLOCK_TIME,
-    refetchIntervalInBackground: true,
-  });
-
-  // TODO refactor there is some duplication piling up
-  const tokensTransfersQuery = useQuery("tokensTransfers", {
-    queryFn: async () => {
-      const transfers = await Promise.all(
-        implicitAccountPkhs.map(pkh => getTokensTransfersPayload(pkh, network))
-      );
-
-      dispatch(assetsActions.updateTokenTransfers(transfers));
-    },
-
-    refetchInterval: BLOCK_TIME,
-    refetchIntervalInBackground: true,
-  });
-
-  const delegationsQuery = useQuery("delegations", {
-    queryFn: async () => {
-      const delegations = await Promise.all(
+      const delegations = Promise.all(
         implicitAccountPkhs.map(pkh => getDelegationsPayload(pkh, network))
-      ).then(compact);
+      ).then(delegations => {
+        dispatch(assetsActions.updateDelegations(compact(delegations)));
+      });
 
-      dispatch(assetsActions.updateDelegations(delegations));
+      return Promise.all([pendingOperations, tezBalances, tokens, tezTransfers, delegations]);
     },
 
     refetchInterval: BLOCK_TIME,
@@ -147,37 +134,18 @@ export const useAssetsPolling = () => {
     refetchIntervalInBackground: true,
   });
 
-  const multisigsQuery = useQuery("multisigs", {
-    queryFn: async () => {
-      const multisigs = await getRelevantMultisigContracts(network, new Set(implicitAccountPkhs));
-
-      const multisigsWithOperations = await getOperationsForMultisigs(network, multisigs);
-
-      dispatch(multisigActions.set(multisigsWithOperations));
-    },
-
-    refetchInterval: BLOCK_TIME,
-    refetchIntervalInBackground: true,
-  });
-
-  const tezQueryRef = useRef(tezQuery);
-  const tokenQueryRef = useRef(tokenQuery);
-  const tezTransfersQueryRef = useRef(tezTransfersQuery);
-  const tokensTransfersQueryRef = useRef(tokensTransfersQuery);
-  const conversionrateQueryRef = useRef(conversionrateQuery);
-  const delegationsQueryRef = useRef(delegationsQuery);
+  const conversionRateQueryRef = useRef(conversionrateQuery);
   const blockNumberQueryRef = useRef(blockNumberQuery);
-  const multisigsQueryRef = useRef(multisigsQuery);
+  const accountAssetsQueryRef = useRef(accountAssetsQuery);
 
   // Refetch when network changes
+  // TODO: implement proper query cancellation
+  //       otherwise we might change the network in the middle of
+  //       receiving data and the data will be broken
+  // https://app.asana.com/0/1204165186238194/1204890035700189/f
   useEffect(() => {
-    tezQueryRef.current.refetch();
-    tokenQueryRef.current.refetch();
-    tezTransfersQueryRef.current.refetch();
-    tokensTransfersQueryRef.current.refetch();
-    conversionrateQueryRef.current.refetch();
-    delegationsQueryRef.current.refetch();
+    conversionRateQueryRef.current.refetch();
     blockNumberQueryRef.current.refetch();
-    multisigsQueryRef.current.refetch();
+    accountAssetsQueryRef.current.refetch();
   }, [network]);
 };


### PR DESCRIPTION
## Proposed changes

We didn't use to have a proper execution order between queries which led to incomplete data (for example if we haven't yet fetched multisigs, but have already sent a tez balances request).
Unfortunately, I didn't find a better looking solution with separate requests. There are no examples of dependant queries for refetched requests and the `enabled` field doesn't really help. Ping me if you wanna see the implementation with a dependency tree

## Types of changes

_Put an `x` in the boxes that apply_

- [x] Bugfix
- [ ] New feature
- [x] Refactor
- [ ] Breaking change
- [ ] Documentation Update

## Screenshots

On the second screenshot it's always the case that first - you get the request to the `same` endpoint and only then everything else begins

| Before | Now    |
| ------ | ------ |
| <img width="1792" alt="Screenshot 2023-06-25 at 18 54 21" src="https://github.com/trilitech/umami-v2/assets/129749432/95fccc45-74d7-4fa7-bdf1-2ff18059b194"> | <img width="1870" alt="Screenshot 2023-06-25 at 18 47 06" src="https://github.com/trilitech/umami-v2/assets/129749432/658ffffb-e45b-4ed0-a63f-32059d6aa0eb"> |

## Checklist

- [ ] Tests that prove my fix is effective or that my feature works have been added
- [ ] Documentation has been added (if appropriate)
- [x] Screenshots are added (if any UI changes have been made)
- [x] All TODOs have a corresponding task created (and the link is attached to it)
