### PR TITLE
Disable refetch on window focus

### DIFF
--- a/src/utils/useAssetsPolling.ts
+++ b/src/utils/useAssetsPolling.ts
@@ -114,6 +114,7 @@ export const useAssetsPolling = () => {
 
     refetchInterval: BLOCK_TIME,
     refetchIntervalInBackground: true,
+    refetchOnWindowFocus: false,
   });
 
   const conversionrateQuery = useQuery("conversionRate", {
@@ -124,6 +125,7 @@ export const useAssetsPolling = () => {
 
     refetchInterval: CONVERSION_RATE_REFRESH_RATE,
     refetchIntervalInBackground: true,
+    refetchOnWindowFocus: false,
   });
 
   const blockNumberQuery = useQuery("blockNumber", {
@@ -134,6 +136,7 @@ export const useAssetsPolling = () => {
 
     refetchInterval: BLOCK_TIME,
     refetchIntervalInBackground: true,
+    refetchOnWindowFocus: false,
   });
 
   useQuery("bakers", {


### PR DESCRIPTION
## Proposed changes

This flag is set to `true` by default and it doesn't make sense for production use because we expect the data to get updated once per 15 seconds and it's especially annoying in development when you switch between devtools and the browser tab

## Types of changes

_Put an `x` in the boxes that apply_

- [ ] Bugfix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation Update
