### PR TITLE
Add support for fa2 tokens without metadata

### DIFF
--- a/src/types/Asset.ts
+++ b/src/types/Asset.ts
@@ -59,15 +59,11 @@ export const fromToken = (raw: Token): Asset | null => {
     };
   }
 
-  if (!metadata) {
-    // We don't support FA2 without metadata yet
-    return null;
-  }
-
   const nftResult = nftParser.safeParse(raw);
   if (nftResult.success) {
     return {
-      metadata,
+      // if the nft has been parsed successfully then the metadata is definitely present
+      metadata: metadata as TokenMetadata,
       type: "nft",
       id: nftResult.data.token.id,
       contract: nftResult.data.token.contract.address,


### PR DESCRIPTION
there are thousands of such things on the network and we need to somehow work with it. metadata is optional on the FA2Token type already anyway