### PR TITLE
Remove the asset dependency in makeTokenTransferParams

### DIFF
--- a/src/components/sendForm/types.ts
+++ b/src/components/sendForm/types.ts
@@ -26,8 +26,8 @@ type BatchMode = {
 
 export type SendFormMode = TezMode | TokenMode | DelegationMode | BatchMode;
 
-type FA12OperationWithAsset = FA12Operation & { data: FA12Token };
-type FA2OperationWithAsset = FA2Operation & { data: FA2Token | NFT };
+export type FA12OperationWithAsset = FA12Operation & { data: FA12Token };
+export type FA2OperationWithAsset = FA2Operation & { data: FA2Token | NFT };
 
 export type OperationValue =
   | TezOperation

--- a/src/utils/tezos/params.ts
+++ b/src/utils/tezos/params.ts
@@ -6,8 +6,11 @@ import {
   TransferParams,
   WalletParamsWithKind,
 } from "@taquito/taquito";
-import { OperationValue } from "../../components/sendForm/types";
-import { parseContractPkh } from "../../types/Address";
+import {
+  FA12OperationWithAsset,
+  FA2OperationWithAsset,
+  OperationValue,
+} from "../../components/sendForm/types";
 import {
   makeFA12TransferMethod,
   makeFA2TransferMethod,
@@ -63,24 +66,13 @@ export const operationValuesToParams = async (
 };
 
 const makeTokenTransferParams = async (
-  operation: OperationValue,
-  signer: TezosToolkit
+  operation: FA12OperationWithAsset | FA2OperationWithAsset,
+  tezosToolkit: TezosToolkit
 ): Promise<TransferParams> => {
-  if (operation.type !== "fa1.2" && operation.type !== "fa2") {
-    throw new Error("Incorrect type");
-  }
-  const asset = operation.data;
-  const { contract } = asset;
-  const args = {
-    sender: operation.sender,
-    recipient: operation.recipient,
-    amount: operation.amount,
-    contract: parseContractPkh(contract),
-  };
   const transferMethod =
-    asset.type === "fa1.2"
-      ? makeFA12TransferMethod(args, signer)
-      : makeFA2TransferMethod({ ...args, tokenId: asset.tokenId }, signer);
+    operation.type === "fa1.2"
+      ? makeFA12TransferMethod(operation, tezosToolkit)
+      : makeFA2TransferMethod(operation, tezosToolkit);
 
   return (await transferMethod).toTransferParams();
 };


### PR DESCRIPTION
there is no need to check the types and throw an exception if we can restrict the input type

there is no need in the asset at all because we can simply pass in the operation itself, it already has everything that's needed