### PR TITLE
Make the token param required for token operations

### DIFF
--- a/src/mocks/tzktResponse.ts
+++ b/src/mocks/tzktResponse.ts
@@ -1,5 +1,5 @@
-import { DelegationOperation, TokenTransfer } from "@tzkt/sdk-api";
-import { TezTransfer } from "../types/Operation";
+import { DelegationOperation } from "@tzkt/sdk-api";
+import { TezTransfer, TokenTransfer } from "../types/Operation";
 import { Token } from "../types/Token";
 import { RawTzktGetSameMultisigs } from "../utils/tzkt/types";
 import { mockContractAddress, mockImplicitAddress } from "./factories";

--- a/src/types/Operation.ts
+++ b/src/types/Operation.ts
@@ -1,9 +1,9 @@
 import * as tzktApi from "@tzkt/sdk-api";
 import { Address } from "./Address";
-import { tokenInfo } from "./Token";
+import { TokenInfo } from "./Token";
 
 export type TokenTransfer = Omit<tzktApi.TokenTransfer, "token"> & {
-  token?: null | tokenInfo;
+  token: TokenInfo;
 };
 
 export type TezTransfer = tzktApi.TransactionOperation;

--- a/src/types/Token.ts
+++ b/src/types/Token.ts
@@ -1,5 +1,6 @@
 import * as tzktApi from "@tzkt/sdk-api";
 
+// TzKT defines metadada as any, but we need to have at least some clarity of what can be inside
 export type TokenMetadata = {
   name?: string;
   symbol?: string;
@@ -38,8 +39,8 @@ export type TokenMetadata = {
   }>;
 };
 
-export type tokenInfo = Omit<tzktApi.TokenInfo, "metadata"> & {
+export type TokenInfo = Omit<tzktApi.TokenInfo, "metadata"> & {
   metadata?: TokenMetadata;
 };
 
-export type Token = Omit<tzktApi.TokenBalance, "token"> & { token?: tokenInfo };
+export type Token = Omit<tzktApi.TokenBalance, "token"> & { token: TokenInfo };

--- a/src/utils/useAssetsPolling.ts
+++ b/src/utils/useAssetsPolling.ts
@@ -2,6 +2,7 @@ import { TezosNetwork } from "@airgap/tezos";
 import { chunk, compact } from "lodash";
 import { useEffect, useRef } from "react";
 import { useQuery } from "react-query";
+import { TokenTransfer } from "../types/Operation";
 import { useImplicitAccounts } from "./hooks/accountHooks";
 import { useSelectedNetwork } from "./hooks/assetsHooks";
 import { getPendingOperationsForMultisigs, getRelevantMultisigContracts } from "./multisig/helpers";
@@ -37,7 +38,7 @@ const getTokensTransfersPayload = async (
   network: TezosNetwork
 ): Promise<TokenTransfersPayload> => {
   const transfers = await getTokenTransfers(pkh, network);
-  return { pkh, transfers };
+  return { pkh, transfers: transfers as TokenTransfer[] };
 };
 
 const getDelegationsPayload = async (

--- a/src/views/operations/operationUtils.test.ts
+++ b/src/views/operations/operationUtils.test.ts
@@ -1,4 +1,4 @@
-import { DelegationOperation, TokenTransfer } from "@tzkt/sdk-api";
+import { DelegationOperation } from "@tzkt/sdk-api";
 import { mockImplicitAddress } from "../../mocks/factories";
 import {
   getLatestDelegationResult,
@@ -6,7 +6,7 @@ import {
   getTransactionsResult,
   rawTzktNftTransfer,
 } from "../../mocks/tzktResponse";
-import { OperationDisplay, TezTransfer } from "../../types/Operation";
+import { OperationDisplay, TezTransfer, TokenTransfer } from "../../types/Operation";
 import { SupportedNetworks } from "../../utils/network";
 import {
   getOperationDisplays,

--- a/src/views/operations/operationsUtils.ts
+++ b/src/views/operations/operationsUtils.ts
@@ -3,7 +3,6 @@ import { formatRelative } from "date-fns";
 import { z } from "zod";
 import { tokenPrettyBalance } from "../../types/TokenBalance";
 import { OperationDisplay, TezTransfer, TokenTransfer } from "../../types/Operation";
-import { Token } from "../../types/Token";
 import { fromToken } from "../../types/TokenBalance";
 import { compact } from "lodash";
 import { getIPFSurl } from "../../utils/token/nftUtils";
@@ -11,15 +10,6 @@ import { BigNumber } from "bignumber.js";
 import { prettyTezAmount } from "../../utils/format";
 import { DelegationOperation } from "@tzkt/sdk-api";
 import { parsePkh } from "../../types/Address";
-
-export const classifyTokenTransfer = (transfer: TokenTransfer) => {
-  const token: Token = {
-    balance: transfer.amount,
-    token: transfer.token === null ? undefined : transfer.token,
-  };
-
-  return fromToken(token);
-};
 
 export const getHashUrl = (hash: string, network: TezosNetwork) => {
   return `https://${network}.tzkt.io/${hash}`;
@@ -153,7 +143,7 @@ export const getTokenOperationDisplay = (
   forAddress: string,
   network = TezosNetwork.MAINNET
 ) => {
-  const asset = classifyTokenTransfer(transfer);
+  const asset = fromToken({ balance: transfer.amount, token: transfer.token });
 
   const transferRequired = TokenTransaction.safeParse(transfer);
 


### PR DESCRIPTION
## Proposed changes

This is a part of #254 

Any token transfer must include the token, otherwise it's not a token transfer. To simplify our life I made a required field. because an optional field which essentially resolved to `TokenInfo | null | undefined`, and, at the same time,  will be provided anyway, is a nightmare