### PR TITLE
Rename token to raw token

### DIFF
--- a/src/components/AccountCard/AccountCard.test.tsx
+++ b/src/components/AccountCard/AccountCard.test.tsx
@@ -147,7 +147,7 @@ describe("<AccountCard />", () => {
     expect(screen.getByTestId("account-card-nfts-tab")).toBeInTheDocument();
     screen.getByTestId("account-card-nfts-tab").click();
     expect(screen.queryAllByTestId("account-card-nfts-tab")).toHaveLength(1);
-    expect(screen.getByText(mockNft.token?.metadata?.name as string)).toBeInTheDocument();
+    expect(screen.getByText(mockNft.token.metadata?.name as string)).toBeInTheDocument();
   });
 
   it("should display accounts operations under operations tab if any", () => {

--- a/src/mocks/fa12Tokens.ts
+++ b/src/mocks/fa12Tokens.ts
@@ -1,7 +1,7 @@
 import { Address } from "../types/Address";
-import { Token } from "../types/Token";
+import { RawToken } from "../types/Token";
 
-export const tzBtsc = (owner: Address): Token => {
+export const tzBtsc = (owner: Address): RawToken => {
   return {
     id: 25018298793985,
     account: {
@@ -31,7 +31,7 @@ export const tzBtsc = (owner: Address): Token => {
   };
 };
 
-export const hedgehoge = (owner: Address): Token => {
+export const hedgehoge = (owner: Address): RawToken => {
   return {
     id: 53252621074433,
     account: {
@@ -62,7 +62,7 @@ export const hedgehoge = (owner: Address): Token => {
   };
 };
 
-export const ghostnetFA12: Token = {
+export const ghostnetFA12: RawToken = {
   id: 140510965530625,
   account: {
     address: "KT1MYis2J1hpjxVcfF92Mf7AfXouzaxsYfKm",

--- a/src/mocks/fa2Tokens.ts
+++ b/src/mocks/fa2Tokens.ts
@@ -1,7 +1,7 @@
 import { Address } from "../types/Address";
-import { Token } from "../types/Token";
+import { RawToken } from "../types/Token";
 
-export const uUSD = (owner: Address): Token => {
+export const uUSD = (owner: Address): RawToken => {
   return {
     id: 64166129827842,
     account: {

--- a/src/mocks/factories.ts
+++ b/src/mocks/factories.ts
@@ -13,7 +13,7 @@ import { NFTBalance } from "../types/TokenBalance";
 import { Baker } from "../types/Baker";
 import { Contact } from "../types/Contact";
 import { TezTransfer, TokenTransfer } from "../types/Operation";
-import { Token } from "../types/Token";
+import { RawToken } from "../types/Token";
 import {
   getDefaultMnemonicDerivationPath,
   getLedgerDerivationPath,
@@ -191,7 +191,7 @@ export const mockContractAddress = (index: number): ContractAddress => ({
   pkh: validContractAddresses[index],
 });
 
-export const mockNFTToken = (index: number, pkh: string, balance = 1): Token => {
+export const mockNFTToken = (index: number, pkh: string, balance = 1): RawToken => {
   return {
     id: index,
     account: {
@@ -231,7 +231,7 @@ export const mockFA2Token = (
   decimals = 4,
   symbol = "KL2",
   name = "Klondike2"
-): Token => {
+): RawToken => {
   return {
     id: 10898270846977,
     account: {
@@ -260,7 +260,7 @@ export const mockFA2Token = (
   };
 };
 
-export const mockFA1Token = (index: number, pkh: string, balance = 1): Token => {
+export const mockFA1Token = (index: number, pkh: string, balance = 1): RawToken => {
   return {
     id: 10897662672897,
     account: {

--- a/src/mocks/nftTokens.ts
+++ b/src/mocks/nftTokens.ts
@@ -1,6 +1,6 @@
-import { Token } from "../types/Token";
+import { RawToken } from "../types/Token";
 
-export const ghotnetThezard: Token = {
+export const ghotnetThezard: RawToken = {
   id: 139206711050241,
   account: {
     address: "KT1MYis2J1hpjxVcfF92Mf7AfXouzaxsYfKm",

--- a/src/mocks/tzktResponse.ts
+++ b/src/mocks/tzktResponse.ts
@@ -1,10 +1,10 @@
 import { DelegationOperation } from "@tzkt/sdk-api";
 import { TezTransfer, TokenTransfer } from "../types/Operation";
-import { Token } from "../types/Token";
+import { RawToken } from "../types/Token";
 import { RawTzktGetSameMultisigs } from "../utils/tzkt/types";
 import { mockContractAddress, mockImplicitAddress } from "./factories";
 
-export const fa1Token: Token = {
+export const fa1Token: RawToken = {
   id: 10897662672897,
   account: {
     address: "tz1UNer1ijeE9ndjzSszRduR3CzX49hoBUB3",
@@ -53,7 +53,7 @@ export const fa2Token = {
   lastTime: "2022-10-20T13:36:35Z",
 };
 
-export const nft: Token = {
+export const nft: RawToken = {
   id: 10899466223618,
   account: {
     address: "tz1UNer1ijeE9ndjzSszRduR3CzX49hoBUB3",

--- a/src/types/Operation.ts
+++ b/src/types/Operation.ts
@@ -1,9 +1,9 @@
 import * as tzktApi from "@tzkt/sdk-api";
 import { Address } from "./Address";
-import { TokenInfo } from "./Token";
+import { RawTokenInfo } from "./Token";
 
 export type TokenTransfer = Omit<tzktApi.TokenTransfer, "token"> & {
-  token: TokenInfo;
+  token: RawTokenInfo;
 };
 
 export type TezTransfer = tzktApi.TransactionOperation;

--- a/src/types/Token.ts
+++ b/src/types/Token.ts
@@ -1,7 +1,7 @@
 import * as tzktApi from "@tzkt/sdk-api";
 
 // TzKT defines metadada as any, but we need to have at least some clarity of what can be inside
-export type TokenMetadata = {
+export type Metadata = {
   name?: string;
   symbol?: string;
   decimals?: string;
@@ -39,8 +39,8 @@ export type TokenMetadata = {
   }>;
 };
 
-export type TokenInfo = Omit<tzktApi.TokenInfo, "metadata"> & {
-  metadata?: TokenMetadata;
+export type RawTokenInfo = Omit<tzktApi.TokenInfo, "metadata"> & {
+  metadata?: Metadata;
 };
 
-export type Token = Omit<tzktApi.TokenBalance, "token"> & { token: TokenInfo };
+export type RawToken = Omit<tzktApi.TokenBalance, "token"> & { token: RawTokenInfo };

--- a/src/types/TokenBalance.test.tsx
+++ b/src/types/TokenBalance.test.tsx
@@ -16,7 +16,7 @@ import {
   tokenName,
   tokenSymbol,
 } from "./TokenBalance";
-import type { TokenMetadata } from "./Token";
+import type { Metadata } from "./Token";
 import { TezosNetwork } from "@airgap/tezos";
 
 describe("fromToken", () => {
@@ -66,7 +66,7 @@ describe("fromToken", () => {
       owner: "tz1UNer1ijeE9ndjzSszRduR3CzX49hoBUB3",
       displayUri: "ipfs://zdj7Wk92xWxpzGqT6sE4cx7umUyWaX2Ck8MrSEmPAR31sNWGz",
       id: 10899466223617,
-      metadata: nft.token?.metadata as TokenMetadata,
+      metadata: nft.token.metadata as Metadata,
       totalSupply: "1",
     };
     expect(result).toEqual(expected);

--- a/src/types/TokenBalance.ts
+++ b/src/types/TokenBalance.ts
@@ -1,5 +1,5 @@
 import { BigNumber } from "bignumber.js";
-import type { Token, TokenMetadata } from "./Token";
+import type { RawToken, Metadata } from "./Token";
 import { z } from "zod";
 import { getIPFSurl } from "../utils/token/nftUtils";
 import { TezosNetwork } from "@airgap/tezos";
@@ -46,8 +46,8 @@ const nftBalanceSchema = z.object({
   token: nftTokenSchema,
 });
 
-export const fromToken = (raw: Token): TokenBalance | null => {
-  const metadata = raw.token?.metadata;
+export const fromToken = (raw: RawToken): TokenBalance | null => {
+  const metadata = raw.token.metadata;
 
   const fa1result = fa1BalanceSchema.safeParse(raw);
   if (fa1result.success) {
@@ -63,7 +63,7 @@ export const fromToken = (raw: Token): TokenBalance | null => {
   if (nftResult.success) {
     return {
       // if the nft has been parsed successfully then the metadata is definitely present
-      metadata: metadata as TokenMetadata,
+      metadata: metadata as Metadata,
       type: "nft",
       id: nftResult.data.token.id,
       contract: nftResult.data.token.contract.address,
@@ -149,12 +149,12 @@ export type FA12TokenBalance = {
   type: "fa1.2";
   contract: string;
   balance: string;
-  metadata?: TokenMetadata;
+  metadata?: Metadata;
 };
 
 export type FA2TokenBalance = {
   type: "fa2";
-  metadata?: TokenMetadata;
+  metadata?: Metadata;
   contract: string;
   tokenId: string;
   balance: string;
@@ -167,7 +167,7 @@ export type NFTBalance = {
   tokenId: string;
   balance: string;
   owner: string;
-  metadata: TokenMetadata;
+  metadata: Metadata;
   displayUri: string;
   totalSupply: string | undefined;
 };

--- a/src/utils/store/assetsSlice.ts
+++ b/src/utils/store/assetsSlice.ts
@@ -7,7 +7,7 @@ import { OperationValue } from "../../components/sendForm/types";
 import { TokenBalance, fromToken } from "../../types/TokenBalance";
 import { Baker } from "../../types/Baker";
 import { TezTransfer, TokenTransfer } from "../../types/Operation";
-import { Token } from "../../types/Token";
+import { RawToken } from "../../types/Token";
 import { TzktAccount } from "../tezos";
 import accountsSlice from "./accountsSlice";
 
@@ -134,7 +134,7 @@ const assetsSlice = createSlice({
       });
       state.balances.tokens = mapValues(groupedByPkh, rawTokenBalances => {
         return compact(
-          rawTokenBalances.map(rawTokenBalance => fromToken(rawTokenBalance as Token))
+          rawTokenBalances.map(rawTokenBalance => fromToken(rawTokenBalance as RawToken))
         );
       });
     },


### PR DESCRIPTION
## Proposed changes

It's a part of #254 
The data we get from tzkt is defined as RawToken now. It's not exactly TztkToken because I make an assumption that it must have a token field and not to confuse our Tzkt types and real Tzkt types I use the `Raw` prefix

## Types of changes

_Put an `x` in the boxes that apply_

- [x] Refactor
