### PR TITLE
Split Token from TokenBalance 

### DIFF
--- a/src/components/AccountCard/AccountCard.test.tsx
+++ b/src/components/AccountCard/AccountCard.test.tsx
@@ -20,6 +20,7 @@ import { formatPkh, prettyTezAmount } from "../../utils/format";
 import { multisigToAccount } from "../../utils/multisig/helpers";
 import { Multisig } from "../../utils/multisig/types";
 import multisigsSlice, { multisigActions } from "../../utils/store/multisigsSlice";
+import tokensSlice from "../../utils/store/tokensSlice";
 const {
   updateTezBalance,
   updateTokenBalance,
@@ -38,6 +39,7 @@ const mockNft = mockNFTToken(0, pkh);
 
 const SELECTED_ACCOUNT_BALANCE = 33200000000;
 beforeEach(() => {
+  store.dispatch(assetsSlice.actions.updateNetwork(TezosNetwork.MAINNET));
   store.dispatch(setMultisigs(multisigs));
   store.dispatch(add([selectedAccount, mockImplicitAccount(1)]));
   store.dispatch(updateTezBalance([{ address: pkh, balance: SELECTED_ACCOUNT_BALANCE }]));
@@ -49,6 +51,18 @@ beforeEach(() => {
       mockFA1Token(1, pkh, 123),
       mockNft,
     ])
+  );
+  store.dispatch(
+    tokensSlice.actions.addTokens({
+      network: TezosNetwork.MAINNET,
+      tokens: [
+        hedgehoge(selectedAccount.address).token,
+        tzBtsc(selectedAccount.address).token,
+        uUSD(selectedAccount.address).token,
+        mockFA1Token(1, pkh, 123).token,
+        mockNft.token,
+      ],
+    })
   );
 });
 

--- a/src/components/AccountCard/AccountCardDisplay.tsx
+++ b/src/components/AccountCard/AccountCardDisplay.tsx
@@ -50,7 +50,6 @@ export const AccountCardDisplay: React.FC<Props> = ({
   pkh,
   onSend,
   onReceive = () => {},
-  onBuyTez = () => {},
   onDelegate,
   label,
   tezBalance,

--- a/src/components/AccountCard/AssetsPannel/MultisigPendingAccordion/MultisigDecodedOperationItem.test.tsx
+++ b/src/components/AccountCard/AssetsPannel/MultisigPendingAccordion/MultisigDecodedOperationItem.test.tsx
@@ -1,11 +1,17 @@
-import { TokenBalance } from "@tzkt/sdk-api";
+import { TezosNetwork } from "@airgap/tezos";
 import { mockContractAddress, mockImplicitAddress } from "../../../../mocks/factories";
 import { render, screen } from "../../../../mocks/testUtils";
+import { RawTokenBalance } from "../../../../types/TokenBalance";
 import { assetsActions } from "../../../../utils/store/assetsSlice";
 import { store } from "../../../../utils/store/store";
+import tokensSlice from "../../../../utils/store/tokensSlice";
 import MultisigDecodedOperationItem from "./MultisigDecodedOperationItem";
 
-const { updateTokenBalance } = assetsActions;
+const { updateTokenBalance, updateNetwork } = assetsActions;
+
+beforeEach(() => {
+  store.dispatch(updateNetwork(TezosNetwork.MAINNET));
+});
 
 describe("<MultisigDecodedOperationItem/>", () => {
   it("displays delegate", () => {
@@ -29,7 +35,7 @@ describe("<MultisigDecodedOperationItem/>", () => {
   it("Non NFT FA tokens amount renders correctly", () => {
     const mockContract = mockContractAddress(0);
 
-    const mockBalancePlayload: TokenBalance = {
+    const mockBalancePlayload: RawTokenBalance = {
       account: { address: "mockPkh" },
 
       balance: "1",
@@ -44,6 +50,12 @@ describe("<MultisigDecodedOperationItem/>", () => {
       },
     };
     store.dispatch(updateTokenBalance([mockBalancePlayload]));
+    store.dispatch(
+      tokensSlice.actions.addTokens({
+        network: TezosNetwork.MAINNET,
+        tokens: [mockBalancePlayload.token],
+      })
+    );
 
     render(
       <MultisigDecodedOperationItem
@@ -70,7 +82,7 @@ describe("<MultisigDecodedOperationItem/>", () => {
   it("NFT amount renders correctly", () => {
     const mockContract = mockContractAddress(0);
 
-    const mockBalancePlayload: TokenBalance = {
+    const mockBalancePlayload: RawTokenBalance = {
       account: { address: mockImplicitAddress(0).pkh },
       balance: "1",
       token: {
@@ -86,6 +98,12 @@ describe("<MultisigDecodedOperationItem/>", () => {
     };
 
     store.dispatch(updateTokenBalance([mockBalancePlayload]));
+    store.dispatch(
+      tokensSlice.actions.addTokens({
+        network: TezosNetwork.MAINNET,
+        tokens: [mockBalancePlayload.token],
+      })
+    );
 
     render(
       <MultisigDecodedOperationItem

--- a/src/components/AccountCard/AssetsPannel/MultisigPendingAccordion/MultisigDecodedOperationItem.tsx
+++ b/src/components/AccountCard/AssetsPannel/MultisigPendingAccordion/MultisigDecodedOperationItem.tsx
@@ -9,8 +9,8 @@ import {
   tokenSymbol,
 } from "../../../../types/TokenBalance";
 import { prettyTezAmount } from "../../../../utils/format";
-import { useSearchAsset } from "../../../../utils/hooks/assetsHooks";
 import { CopyableAddress } from "../../../CopyableText";
+import { useGetToken } from "../../../../utils/hooks/tokensHooks";
 
 const MultisigDecodedOperationItem: React.FC<{
   operation: RawOperation;
@@ -40,7 +40,8 @@ const MultisigDecodedOperationItem: React.FC<{
 const MultisigOperationAmount: React.FC<{
   operation: RawOperation;
 }> = ({ operation }) => {
-  const searchAsset = useSearchAsset();
+  const getToken = useGetToken();
+
   switch (operation.type) {
     case "tez":
       return (
@@ -54,7 +55,7 @@ const MultisigOperationAmount: React.FC<{
 
     case "fa1.2":
     case "fa2": {
-      const asset = searchAsset(operation.contract.pkh, operation.tokenId);
+      const asset = getToken(operation.contract.pkh, operation.tokenId);
 
       if (!asset) {
         return null;

--- a/src/components/AccountCard/AssetsPannel/MultisigPendingAccordion/MultisigPendingAccordionItem.test.tsx
+++ b/src/components/AccountCard/AssetsPannel/MultisigPendingAccordion/MultisigPendingAccordionItem.test.tsx
@@ -22,9 +22,6 @@ jest.mock("../../../../utils/hooks/accountUtils");
 beforeEach(() => {
   (useGetSk as jest.Mock).mockReturnValue(() => Promise.resolve("mockkey"));
 });
-afterEach(() => {
-  store.dispatch(accountsSlice.actions.reset());
-});
 
 describe("<MultisigPendingCard/>", () => {
   it("displays the correct number of pending approvals", () => {

--- a/src/components/AccountCard/AssetsPannel/TokenList.tsx
+++ b/src/components/AccountCard/AssetsPannel/TokenList.tsx
@@ -15,7 +15,7 @@ const TokenTile = ({ token }: { token: FA12TokenBalance | FA2TokenBalance }) => 
   const name = tokenName(token);
   const symbol = tokenSymbol(token);
   const iconUri = httpIconUri(token);
-  const prettyAmount = tokenPrettyBalance(token, { showSymbol: false });
+  const prettyAmount = tokenPrettyBalance(token.balance, token, { showSymbol: false });
   return (
     <Flex
       justifyContent="space-around"

--- a/src/components/CSVFileUploader/CSVFileUploadForm.tsx
+++ b/src/components/CSVFileUploader/CSVFileUploadForm.tsx
@@ -38,7 +38,7 @@ const CSVFileUploadForm = ({ onClose }: { onClose: () => void }) => {
   const network = useSelectedNetwork();
   const toast = useToast();
   const getPk = useGetPk();
-  const getToken = useGetToken(network);
+  const getToken = useGetToken();
   const dispatch = useAppDispatch();
   const isSimulating = useBatchIsSimulating();
   const clearBatch = useClearBatch();

--- a/src/components/sendForm/SendForm.test.tsx
+++ b/src/components/sendForm/SendForm.test.tsx
@@ -18,7 +18,12 @@ import {
 } from "../../mocks/helpers";
 import { fireEvent, render, screen, waitFor, within } from "../../mocks/testUtils";
 import { AccountType, MnemonicAccount } from "../../types/Account";
-import { FA12TokenBalance, FA2TokenBalance, fromRaw, TokenBalance } from "../../types/TokenBalance";
+import {
+  FA12TokenBalance,
+  FA2TokenBalance,
+  fromRaw,
+  TokenBalanceWithToken,
+} from "../../types/TokenBalance";
 import { SignerType, SkSignerConfig } from "../../types/SignerConfig";
 import * as accountUtils from "../../utils/hooks/accountUtils";
 import assetsSlice, { BatchItem } from "../../utils/store/assetsSlice";
@@ -535,7 +540,7 @@ describe("<SendForm />", () => {
 
   describe("case send NFT", () => {
     const fillFormAndSimulate = async () => {
-      render(fixture(MOCK_PKH, { type: "token", data: fromRaw(nft) as TokenBalance }));
+      render(fixture(MOCK_PKH, { type: "token", data: fromRaw(nft) as TokenBalanceWithToken }));
       expect(screen.getByTestId("real-address-input-sender")).toHaveAttribute(
         "value",
         mockImplicitAccount(1).address.pkh

--- a/src/components/sendForm/steps/SubmitStep.tsx
+++ b/src/components/sendForm/steps/SubmitStep.tsx
@@ -15,7 +15,6 @@ import BigNumber from "bignumber.js";
 import { AccountType } from "../../../types/Account";
 import { SignerConfig } from "../../../types/SignerConfig";
 import { useGetOwnedAccount } from "../../../utils/hooks/accountHooks";
-import { useSelectedNetwork } from "../../../utils/hooks/assetsHooks";
 import { useGetToken } from "../../../utils/hooks/tokensHooks";
 import { getBatchSubtotal } from "../../../views/batch/batchUtils";
 import { useRenderBakerSmallTile } from "../../../views/delegations/BakerSmallTile";
@@ -28,8 +27,7 @@ import { BatchRecap } from "./BatchRecap";
 
 const NonBatchRecap = ({ transfer }: { transfer: OperationValue }) => {
   const isDelegation = transfer.type === "delegation";
-  const network = useSelectedNetwork();
-  const getToken = useGetToken(network);
+  const getToken = useGetToken();
   const token =
     transfer.type === "fa1.2" || transfer.type === "fa2"
       ? getToken(transfer.contract.pkh, transfer.tokenId)

--- a/src/components/useAccountsFilter.test.tsx
+++ b/src/components/useAccountsFilter.test.tsx
@@ -12,10 +12,6 @@ beforeEach(() => {
   store.dispatch(accountsSlice.actions.add(accounts));
 });
 
-afterEach(() => {
-  store.dispatch(accountsSlice.actions.reset());
-});
-
 const TestComponent = () => {
   const { accountsFilter } = useAccountsFilter();
   return accountsFilter;

--- a/src/types/Address.ts
+++ b/src/types/Address.ts
@@ -1,7 +1,9 @@
 import { validateAddress, ValidationResult } from "@taquito/utils";
+import { Alias } from "@tzkt/sdk-api";
 import { z } from "zod";
 
 export type RawPkh = string;
+export type RawAlias = Omit<Alias, "address"> & { address: RawPkh };
 
 export type ContractAddress = {
   type: "contract";

--- a/src/types/Operation.ts
+++ b/src/types/Operation.ts
@@ -2,7 +2,8 @@ import * as tzktApi from "@tzkt/sdk-api";
 import { Address } from "./Address";
 import { RawTokenInfo } from "./Token";
 
-export type TokenTransfer = Omit<tzktApi.TokenTransfer, "token"> & {
+export type TokenTransfer = Omit<tzktApi.TokenTransfer, "amount" | "token"> & {
+  amount: string;
   token: RawTokenInfo;
 };
 

--- a/src/utils/hooks/tokensHooks.ts
+++ b/src/utils/hooks/tokensHooks.ts
@@ -3,10 +3,12 @@ import { get } from "lodash";
 import { RawPkh } from "../../types/Address";
 import { Token } from "../../types/Token";
 import { useAppSelector } from "../store/hooks";
+import { useSelectedNetwork } from "./assetsHooks";
 
 export type TokenLookup = (contract: RawPkh, tokenId: string) => Token | undefined;
 
-export const useGetToken = (network: TezosNetwork): TokenLookup => {
+export const useGetToken = (): TokenLookup => {
+  const network = useSelectedNetwork();
   const tokens = useAppSelector(s => s.tokens[network]);
   return (contract, tokenId) => get(tokens, [contract, tokenId]);
 };

--- a/src/utils/store/assetsSlice.test.ts
+++ b/src/utils/store/assetsSlice.test.ts
@@ -138,13 +138,6 @@ describe("Assets reducer", () => {
               balance: "10000000000",
               contract: "KT1G1cCRNBgQ48mVDjopHjEmTN5Sbtar8nn9",
               tokenId: "0",
-              metadata: {
-                icon: "ipfs://QmXL3FZ5kcwXC8mdwkS1iCHS2qVoyg69ugBhU2ap8z1zcs",
-                name: "Hedgehoge",
-                symbol: "HEH",
-                decimals: "6",
-              },
-              type: "fa1.2",
             },
           ],
         },

--- a/src/utils/store/assetsSlice.ts
+++ b/src/utils/store/assetsSlice.ts
@@ -1,10 +1,9 @@
 import { TezosNetwork } from "@airgap/tezos";
 import { createSlice } from "@reduxjs/toolkit";
-import { DelegationOperation, TokenBalance as TzktTokenBalance } from "@tzkt/sdk-api";
+import { DelegationOperation } from "@tzkt/sdk-api";
 import { compact, groupBy, mapValues } from "lodash";
-
 import { OperationValue } from "../../components/sendForm/types";
-import { TokenBalance, fromRaw } from "../../types/TokenBalance";
+import { TokenBalance, fromRaw, eraseToken } from "../../types/TokenBalance";
 import { Baker } from "../../types/Baker";
 import { TezTransfer, TokenTransfer } from "../../types/Operation";
 import { RawTokenBalance } from "../../types/TokenBalance";
@@ -126,16 +125,10 @@ const assetsSlice = createSlice({
       }, {});
     },
 
-    updateTokenBalance: (state, { payload }: { payload: TzktTokenBalance[] }) => {
-      const groupedByPkh = groupBy(payload, tokenBalance => {
-        // there are no token balances without an owner
-        // URL to verify https://api.mainnet.tzkt.io/v1/tokens/balances?account.null
-        return tokenBalance.account?.address as string;
-      });
+    updateTokenBalance: (state, { payload }: { payload: RawTokenBalance[] }) => {
+      const groupedByPkh = groupBy(payload, tokenBalance => tokenBalance.account.address);
       state.balances.tokens = mapValues(groupedByPkh, rawTokenBalances => {
-        return compact(
-          rawTokenBalances.map(rawTokenBalance => fromRaw(rawTokenBalance as RawTokenBalance))
-        );
+        return compact(rawTokenBalances.map(fromRaw)).map(eraseToken);
       });
     },
 

--- a/src/utils/useAssetsPolling.ts
+++ b/src/utils/useAssetsPolling.ts
@@ -39,6 +39,7 @@ const getTokensTransfersPayload = async (
   network: TezosNetwork
 ): Promise<TokenTransfersPayload> => {
   const transfers = await getTokenTransfers(pkh, network);
+  // there are no token transfers without a token & amount assigned
   return { pkh, transfers: transfers as TokenTransfer[] };
 };
 

--- a/src/views/batch/BatchDisplay.tsx
+++ b/src/views/batch/BatchDisplay.tsx
@@ -112,7 +112,7 @@ export const BatchDisplay: React.FC<{
 }> = ({ account, batch, onDelete, onSend }) => {
   const items = batch.items;
   const network = useSelectedNetwork();
-  const getToken = useGetToken(network);
+  const getToken = useGetToken();
 
   return (
     <Flex data-testid={`batch-table-${account.address.pkh}`} mb={4}>

--- a/src/views/nfts/NFTsView.test.tsx
+++ b/src/views/nfts/NFTsView.test.tsx
@@ -1,13 +1,15 @@
+import { TezosNetwork } from "@airgap/tezos";
 import { render, screen } from "@testing-library/react";
-import { mockNFTToken, mockImplicitAccount } from "../../mocks/factories";
+import { mockNFTToken, mockImplicitAccount, mockImplicitAddress } from "../../mocks/factories";
 import { HashRouter } from "react-router-dom";
 import { ReduxStore } from "../../providers/ReduxStore";
 import accountsSlice from "../../utils/store/accountsSlice";
 import assetsSlice from "../../utils/store/assetsSlice";
 import { store } from "../../utils/store/store";
+import tokensSlice from "../../utils/store/tokensSlice";
 import NFTsViewBase from "./NftsView";
 
-const { updateTokenBalance } = assetsSlice.actions;
+const { updateTokenBalance, updateNetwork } = assetsSlice.actions;
 
 beforeEach(() => {
   store.dispatch(accountsSlice.actions.add([mockImplicitAccount(0)]));
@@ -29,6 +31,7 @@ describe("NFTsView", () => {
 
   it("displays nfts of all accounts by default", () => {
     store.dispatch(accountsSlice.actions.add([mockImplicitAccount(1), mockImplicitAccount(2)]));
+    store.dispatch(updateNetwork(TezosNetwork.MAINNET));
     store.dispatch(
       updateTokenBalance([
         mockNFTToken(1, mockImplicitAccount(1).address.pkh),
@@ -36,6 +39,17 @@ describe("NFTsView", () => {
         mockNFTToken(1, mockImplicitAccount(2).address.pkh),
         mockNFTToken(2, mockImplicitAccount(2).address.pkh),
       ])
+    );
+    store.dispatch(
+      tokensSlice.actions.addTokens({
+        network: TezosNetwork.MAINNET,
+        tokens: [
+          mockNFTToken(1, mockImplicitAddress(1).pkh).token,
+          mockNFTToken(2, mockImplicitAddress(1).pkh).token,
+          mockNFTToken(1, mockImplicitAddress(2).pkh).token,
+          mockNFTToken(2, mockImplicitAddress(2).pkh).token,
+        ],
+      })
     );
 
     render(fixture());

--- a/src/views/operations/operationsUtils.ts
+++ b/src/views/operations/operationsUtils.ts
@@ -3,7 +3,7 @@ import { formatRelative } from "date-fns";
 import { z } from "zod";
 import { tokenPrettyBalance } from "../../types/TokenBalance";
 import { OperationDisplay, TezTransfer, TokenTransfer } from "../../types/Operation";
-import { fromRaw } from "../../types/TokenBalance";
+import { fromRaw } from "../../types/Token";
 import { compact } from "lodash";
 import { getIPFSurl } from "../../utils/token/nftUtils";
 import { BigNumber } from "bignumber.js";
@@ -143,11 +143,11 @@ export const getTokenOperationDisplay = (
   forAddress: string,
   network = TezosNetwork.MAINNET
 ) => {
-  const asset = fromRaw({ balance: transfer.amount, token: transfer.token });
+  const token = fromRaw(transfer.token);
 
   const transferRequired = TokenTransaction.safeParse(transfer);
 
-  if (!asset || !transferRequired.success) {
+  if (!token || !transferRequired.success) {
     console.warn("getTokenOperationDisplay failed parsing");
     return null;
   }
@@ -168,10 +168,10 @@ export const getTokenOperationDisplay = (
   const prettyTimestamp = formatRelative(new Date(parsed.timestamp), new Date());
 
   let prettyAmount: string;
-  if (asset.type === "nft") {
-    prettyAmount = asset.balance;
+  if (token.type === "nft") {
+    prettyAmount = transfer.amount;
   } else {
-    prettyAmount = tokenPrettyBalance(asset, { showSymbol: true });
+    prettyAmount = tokenPrettyBalance(transfer.amount, token, { showSymbol: true });
   }
 
   const result: OperationDisplay = {

--- a/src/views/tokens/AccountTokensTile.tsx
+++ b/src/views/tokens/AccountTokensTile.tsx
@@ -112,7 +112,7 @@ const AccountTokensTile: React.FC<{
                       textFirst
                     />
                   </Td>
-                  <Td w="15%">{tokenPrettyBalance(token, { showSymbol: false })}</Td>
+                  <Td w="15%">{tokenPrettyBalance(token.balance, token, { showSymbol: false })}</Td>
                   <Td>
                     <Flex alignItems="center" justifyContent="space-between" paddingX={3}>
                       {/* TODO: fetch token values  */}

--- a/src/views/tokens/TokensView.test.tsx
+++ b/src/views/tokens/TokensView.test.tsx
@@ -3,9 +3,11 @@ import { hedgehoge, tzBtsc } from "../../mocks/fa12Tokens";
 import { uUSD } from "../../mocks/fa2Tokens";
 import { mockImplicitAccount, mockImplicitAddress } from "../../mocks/factories";
 import { ReduxStore } from "../../providers/ReduxStore";
+import { SupportedNetworks } from "../../utils/network";
 import accountsSlice from "../../utils/store/accountsSlice";
-import assetsSlice from "../../utils/store/assetsSlice";
+import assetsSlice, { assetsActions } from "../../utils/store/assetsSlice";
 import { store } from "../../utils/store/store";
+import { tokensActions } from "../../utils/store/tokensSlice";
 import TokensView from "./TokensView";
 
 const fixture = () => (
@@ -24,7 +26,8 @@ describe("<TokensView />", () => {
     expect(screen.getByText(/no tokens found/i)).toBeInTheDocument();
   });
 
-  it("shows all available tokens from all accounts", () => {
+  test.each(SupportedNetworks)("shows all available tokens from all accounts on %s", network => {
+    store.dispatch(assetsActions.updateNetwork(network));
     store.dispatch(accountsSlice.actions.add([mockImplicitAccount(1)]));
     const tokenBalances = [
       hedgehoge(mockImplicitAddress(0)),
@@ -33,6 +36,7 @@ describe("<TokensView />", () => {
       uUSD(mockImplicitAddress(0)),
     ];
     store.dispatch(assetsSlice.actions.updateTokenBalance(tokenBalances));
+    store.dispatch(tokensActions.addTokens({ network, tokens: tokenBalances.map(tb => tb.token) }));
     render(fixture());
 
     expect(screen.getAllByText("Hedgehoge")).toHaveLength(2);


### PR DESCRIPTION
## Proposed changes

It's a part of #254 
Now we store TokenBalance (contract, tokenId, amount) per account separate from an actual Token which removes the data duplication between the two in the store. Also, if you have 5 accounts having the same token the token is now stored only once in tokensSlice.
In some places we do not the two in conjunction and for this purpose there is a `TokenBalanceWithToken`. `useGetAccountAssets` makes it.


## Types of changes

- [x] Refactor
- [x] Breaking change

## Checklist

- [x] Tests that prove my fix is effective or that my feature works have been added
