### PR TITLE
Remove OperationValue

### DIFF
--- a/src/components/AccountCard/AccountCardDisplay.tsx
+++ b/src/components/AccountCard/AccountCardDisplay.tsx
@@ -8,7 +8,7 @@ import { VscWand } from "react-icons/vsc";
 import { Account, AccountType } from "../../types/Account";
 import { FA12TokenBalance, FA2TokenBalance, NFTBalance } from "../../types/TokenBalance";
 import { Delegation } from "../../types/Delegation";
-import { OperationDisplay } from "../../types/Operation";
+import { OperationDisplay } from "../../types/Transfer";
 import { CopyableAddress } from "../CopyableText";
 import { Identicon } from "../Identicon";
 import { TezRecapDisplay } from "../TezRecapDisplay";

--- a/src/components/AccountCard/AssetsPannel/AssetsPanel.tsx
+++ b/src/components/AccountCard/AssetsPannel/AssetsPanel.tsx
@@ -5,7 +5,7 @@ import { FiExternalLink } from "react-icons/fi";
 import { Account, AccountType } from "../../../types/Account";
 import { FA12TokenBalance, FA2TokenBalance, NFTBalance } from "../../../types/TokenBalance";
 import { Delegation } from "../../../types/Delegation";
-import { OperationDisplay } from "../../../types/Operation";
+import { OperationDisplay } from "../../../types/Transfer";
 import { buildTzktAddressUrl } from "../../../utils/tzkt/helpers";
 import { OperationListDisplay } from "../../../views/home/OpertionList/OperationListDisplay";
 import { IconAndTextBtnLink } from "../../IconAndTextBtn";

--- a/src/components/AccountCard/AssetsPannel/MultisigPendingAccordion/MultisigDecodedOperationItem.tsx
+++ b/src/components/AccountCard/AssetsPannel/MultisigPendingAccordion/MultisigDecodedOperationItem.tsx
@@ -1,6 +1,6 @@
 import { Box, Flex, Heading, Icon, Text } from "@chakra-ui/react";
 import { FiArrowUpRight } from "react-icons/fi";
-import { RawOperation } from "../../../../types/RawOperation";
+import { Operation } from "../../../../types/Operation";
 import colors from "../../../../style/colors";
 import {
   formatTokenAmount,
@@ -13,7 +13,7 @@ import { CopyableAddress } from "../../../CopyableText";
 import { useGetToken } from "../../../../utils/hooks/tokensHooks";
 
 const MultisigDecodedOperationItem: React.FC<{
-  operation: RawOperation;
+  operation: Operation;
 }> = ({ operation }) => {
   switch (operation.type) {
     case "delegation":
@@ -38,7 +38,7 @@ const MultisigDecodedOperationItem: React.FC<{
 };
 
 const MultisigOperationAmount: React.FC<{
-  operation: RawOperation;
+  operation: Operation;
 }> = ({ operation }) => {
   const getToken = useGetToken();
 

--- a/src/components/CSVFileUploader/utils.ts
+++ b/src/components/CSVFileUploader/utils.ts
@@ -5,7 +5,7 @@ import {
   parseContractPkh,
   parsePkh,
 } from "../../types/Address";
-import { RawOperation } from "../../types/RawOperation";
+import { Operation } from "../../types/Operation";
 import { getRealAmount } from "../../types/TokenBalance";
 import { tezToMutez } from "../../utils/format";
 import { validateNonNegativeNumber } from "../../utils/helpers";
@@ -15,7 +15,7 @@ export const parseOperation = (
   sender: Address,
   row: string[],
   getToken: TokenLookup
-): RawOperation => {
+): Operation => {
   const filteredRow = row.filter(col => col.length > 0);
   const len = filteredRow.length;
   if (len < 2 || 4 < len) {

--- a/src/components/OperationTile.tsx
+++ b/src/components/OperationTile.tsx
@@ -4,7 +4,7 @@ import { AiOutlineCheckCircle } from "react-icons/ai";
 import { BsArrowDownLeft, BsArrowUpRight } from "react-icons/bs";
 import colors from "../style/colors";
 import { useIsBlockFinalised } from "../utils/hooks/assetsHooks";
-import { OperationDisplay } from "../types/Operation";
+import { OperationDisplay } from "../types/Transfer";
 import { getIsInbound } from "../views/operations/operationsUtils";
 import { CopyableAddress } from "./CopyableText";
 

--- a/src/components/sendForm/SendForm.tsx
+++ b/src/components/sendForm/SendForm.tsx
@@ -1,7 +1,7 @@
 import { useToast } from "@chakra-ui/react";
 import { TransferParams } from "@taquito/taquito";
 import { useEffect, useRef, useState } from "react";
-import { RawOperation } from "../../types/RawOperation";
+import { Operation } from "../../types/Operation";
 import { SignerConfig } from "../../types/SignerConfig";
 import { useGetPk } from "../../utils/hooks/accountHooks";
 import { useClearBatch, useSelectedNetwork } from "../../utils/hooks/assetsHooks";
@@ -66,7 +66,7 @@ export const SendForm = ({
     setIsLoading(false);
   };
 
-  const addToBatch = async (operation: RawOperation, sender: string) => {
+  const addToBatch = async (operation: Operation, sender: string) => {
     const pk = getPk(sender);
 
     try {

--- a/src/components/sendForm/steps/BatchRecap.tsx
+++ b/src/components/sendForm/steps/BatchRecap.tsx
@@ -1,8 +1,8 @@
-import { RawOperation } from "../../../types/RawOperation";
+import { Operation } from "../../../types/Operation";
 import { getBatchSubtotal } from "../../../views/batch/batchUtils";
 import { Subtotal, TransactionsAmount } from "../components/TezAmountRecaps";
 
-export const BatchRecap = ({ transfer }: { transfer: RawOperation[] }) => {
+export const BatchRecap = ({ transfer }: { transfer: Operation[] }) => {
   return (
     <>
       <TransactionsAmount amount={transfer.length} />

--- a/src/components/sendForm/steps/FillStep.tsx
+++ b/src/components/sendForm/steps/FillStep.tsx
@@ -24,7 +24,7 @@ import { FormProvider, useForm, useFormContext } from "react-hook-form";
 import { AccountType, MultisigAccount } from "../../../types/Account";
 import { parseContractPkh, parseImplicitPkh, parsePkh } from "../../../types/Address";
 import { getRealAmount, tokenSymbol } from "../../../types/TokenBalance";
-import { Delegation, RawOperation } from "../../../types/RawOperation";
+import { Delegation, Operation } from "../../../types/Operation";
 import { tezToMutez } from "../../../utils/format";
 import {
   useAccountIsMultisig,
@@ -127,7 +127,7 @@ const getAmountSymbol = (asset?: Token) => {
 };
 
 export const FillBatchForm: React.FC<{
-  transfer: RawOperation[];
+  transfer: Operation[];
   onSubmit: () => void;
   isLoading?: boolean;
   signer: string;
@@ -350,7 +350,7 @@ const buildTezFromFormValues = (
   v: FormValues,
   parameter?: TransferParams["parameter"]
 ): FormOperations => {
-  const value: RawOperation[] = [
+  const value: Operation[] = [
     {
       type: "tez",
       amount: tezToMutez(v.amount).toString(),
@@ -392,7 +392,7 @@ const buildTokenFromFormValues = (v: FormValues, asset: Token): FormOperations =
 
 export const FillStep: React.FC<{
   onSubmit: (v: FormOperations) => void;
-  onSubmitBatch: (v: RawOperation, signer: string) => void;
+  onSubmitBatch: (v: Operation, signer: string) => void;
   isLoading: boolean;
   sender: string;
   recipient?: string;

--- a/src/components/sendForm/steps/SubmitStep.tsx
+++ b/src/components/sendForm/steps/SubmitStep.tsx
@@ -13,7 +13,7 @@ import {
 } from "@chakra-ui/react";
 import BigNumber from "bignumber.js";
 import { AccountType } from "../../../types/Account";
-import { RawOperation } from "../../../types/RawOperation";
+import { Operation } from "../../../types/Operation";
 import { SignerConfig } from "../../../types/SignerConfig";
 import { useGetOwnedAccount } from "../../../utils/hooks/accountHooks";
 import { useGetToken } from "../../../utils/hooks/tokensHooks";
@@ -26,7 +26,7 @@ import { Fee, Subtotal, Total } from "../components/TezAmountRecaps";
 import { EstimatedOperation } from "../types";
 import { BatchRecap } from "./BatchRecap";
 
-const NonBatchRecap = ({ transfer }: { transfer: RawOperation }) => {
+const NonBatchRecap = ({ transfer }: { transfer: Operation }) => {
   const isDelegation = transfer.type === "delegation";
   const getToken = useGetToken();
   const token =

--- a/src/components/sendForm/types.ts
+++ b/src/components/sendForm/types.ts
@@ -1,5 +1,5 @@
 import { ContractAddress, ImplicitAddress, parseContractPkh, parsePkh } from "../../types/Address";
-import { FA12Operation, FA2Operation, RawOperation } from "../../types/RawOperation";
+import { FA12Operation, FA2Operation, Operation } from "../../types/Operation";
 import { Token } from "../../types/Token";
 
 type TezMode = { type: "tez" };
@@ -19,7 +19,7 @@ export type DelegationMode = {
 type BatchMode = {
   type: "batch";
   data: {
-    batch: RawOperation[];
+    batch: Operation[];
     signer: string;
   };
 };
@@ -28,14 +28,14 @@ export type SendFormMode = TezMode | TokenMode | DelegationMode | BatchMode;
 
 export type ProposalOperations = {
   type: "proposal";
-  content: RawOperation[];
+  content: Operation[];
   sender: ContractAddress;
   signer: ImplicitAddress;
 };
 
 export type ImplicitOperations = {
   type: "implicit";
-  content: RawOperation[];
+  content: Operation[];
   signer: ImplicitAddress;
 };
 

--- a/src/components/sendForm/util/execution.ts
+++ b/src/components/sendForm/util/execution.ts
@@ -1,12 +1,12 @@
 import { makeBatchLambda } from "../../../multisig/multisigUtils";
 import { parseContractPkh } from "../../../types/Address";
-import { RawOperation } from "../../../types/RawOperation";
+import { Operation } from "../../../types/Operation";
 import { SignerConfig } from "../../../types/SignerConfig";
 import { proposeMultisigLambda, submitBatch } from "../../../utils/tezos";
 import { FormOperations } from "../types";
 
 const makeProposeOperation = async (
-  operations: RawOperation[],
+  operations: Operation[],
   sender: string,
   config: SignerConfig
 ) => {
@@ -16,7 +16,7 @@ const makeProposeOperation = async (
   return proposeMultisigLambda({ contract, lambdaActions }, config);
 };
 
-const makeTransferImplicit = async (operations: RawOperation[], config: SignerConfig) => {
+const makeTransferImplicit = async (operations: Operation[], config: SignerConfig) => {
   return submitBatch(operations, config).then(res => {
     return {
       hash: res.opHash,

--- a/src/integration/tezos.integration.test.ts
+++ b/src/integration/tezos.integration.test.ts
@@ -2,7 +2,7 @@ import { TezosNetwork } from "@airgap/tezos";
 import { devPublicKeys0, devPublicKeys1 } from "../mocks/devSignerKeys";
 import { ghostFA12, ghostFA2, ghostTezzard } from "../mocks/tokens";
 import { parseContractPkh, parseImplicitPkh } from "../types/Address";
-import { RawOperation } from "../types/RawOperation";
+import { Operation } from "../types/Operation";
 
 import { estimateBatch, operationsToBatchParams } from "../utils/tezos";
 
@@ -15,7 +15,7 @@ const pkh1 = parseImplicitPkh(devPublicKeys1.pkh);
 describe("Tezos utils", () => {
   describe("Batch", () => {
     test("batchParams are generated correctly for tez, tez with params, FA1.2, FA2 contracts and delegations", async () => {
-      const input: RawOperation[] = [
+      const input: Operation[] = [
         {
           type: "tez",
           amount: "3",

--- a/src/mocks/factories.ts
+++ b/src/mocks/factories.ts
@@ -11,14 +11,14 @@ import { ContractAddress, ImplicitAddress } from "../types/Address";
 import { NFTBalance } from "../types/TokenBalance";
 import { Baker } from "../types/Baker";
 import { Contact } from "../types/Contact";
-import { TezTransfer, TokenTransfer } from "../types/Operation";
+import { TezTransfer, TokenTransfer } from "../types/Transfer";
 import { RawTokenBalance } from "../types/TokenBalance";
 import {
   getDefaultMnemonicDerivationPath,
   getLedgerDerivationPath,
 } from "../utils/account/derivationPathUtils";
 import { MultisigOperation, Multisig } from "../utils/multisig/types";
-import { RawOperation } from "../types/RawOperation";
+import { Operation } from "../types/Operation";
 
 export const mockTezTransaction = (id: number) => {
   return {
@@ -309,7 +309,7 @@ export const mockBaker = (index: number) =>
     address: mockImplicitAddress(index).pkh,
   } as Baker);
 
-export const mockTezTransfer = (index: number): RawOperation => {
+export const mockTezTransfer = (index: number): Operation => {
   return {
     type: "tez",
     amount: String(index),
@@ -317,7 +317,7 @@ export const mockTezTransfer = (index: number): RawOperation => {
   };
 };
 
-export const mockNftTransfer = (index: number): RawOperation => {
+export const mockNftTransfer = (index: number): Operation => {
   return {
     type: "fa2",
     amount: String(index),
@@ -328,7 +328,7 @@ export const mockNftTransfer = (index: number): RawOperation => {
   };
 };
 
-export const mockDelegationTransfer = (index: number): RawOperation => {
+export const mockDelegationTransfer = (index: number): Operation => {
   return {
     type: "delegation",
     recipient: mockImplicitAddress(index + 1),

--- a/src/mocks/transfers.ts
+++ b/src/mocks/transfers.ts
@@ -1,4 +1,4 @@
-import { TezTransfer } from "../types/Operation";
+import { TezTransfer } from "../types/Transfer";
 
 const MOCK_TIMESTAMP = "2020-05-24T13:12:18Z";
 const MOCK_HASH = "onqKcUZLbN9LdoJsPeRtDrHqYibm4osdtQJmGGQ4GAg3SjQUMT3";

--- a/src/mocks/tzktResponse.ts
+++ b/src/mocks/tzktResponse.ts
@@ -1,5 +1,5 @@
 import { DelegationOperation } from "@tzkt/sdk-api";
-import { TezTransfer, TokenTransfer } from "../types/Operation";
+import { TezTransfer, TokenTransfer } from "../types/Transfer";
 import { RawTokenBalance } from "../types/TokenBalance";
 import { RawTzktGetSameMultisigs } from "../utils/tzkt/types";
 import { mockContractAddress, mockImplicitAddress } from "./factories";

--- a/src/multisig/decode/decodeLambda.ts
+++ b/src/multisig/decode/decodeLambda.ts
@@ -1,5 +1,5 @@
 import { encodePubKey } from "@taquito/utils";
-import { RawOperation } from "../../types/RawOperation";
+import { Operation } from "../../types/Operation";
 import {
   batchHeadSchema,
   contractTezSchema,
@@ -23,7 +23,7 @@ const convertToPkh = (addressBytes: string): string => {
   return encodePubKey(addressBytes);
 };
 
-export const parseTez = (michelson: MichelsonV1Expression[]): RawOperation => {
+export const parseTez = (michelson: MichelsonV1Expression[]): Operation => {
   const parseResult = tezSchema.parse(michelson);
 
   const to = parseResult[0].args[1].bytes;
@@ -36,7 +36,7 @@ export const parseTez = (michelson: MichelsonV1Expression[]): RawOperation => {
   };
 };
 
-export const parseTezContract = (michelson: MichelsonV1Expression[]): RawOperation => {
+export const parseTezContract = (michelson: MichelsonV1Expression[]): Operation => {
   const parseResult = contractTezSchema.parse(michelson);
 
   const to = parseResult[0].args[1].bytes;
@@ -49,7 +49,7 @@ export const parseTezContract = (michelson: MichelsonV1Expression[]): RawOperati
   };
 };
 
-const parseFa2 = (michelson: MichelsonV1Expression[]): RawOperation[] => {
+const parseFa2 = (michelson: MichelsonV1Expression[]): Operation[] => {
   const parseResult = fa2Schema.parse(michelson);
   const contractAddress = parseContractPkh(convertToPkh(parseResult[0].args[1].bytes));
   const operations = parseResult[4].args[1];
@@ -74,7 +74,7 @@ const parseFa2 = (michelson: MichelsonV1Expression[]): RawOperation[] => {
   });
 };
 
-const parseFa1 = (michelson: MichelsonV1Expression[]): RawOperation => {
+const parseFa1 = (michelson: MichelsonV1Expression[]): Operation => {
   const parseResult = fa1Schema.parse(michelson);
 
   const lambdaRecipient = parseResult[0];
@@ -94,7 +94,7 @@ const parseFa1 = (michelson: MichelsonV1Expression[]): RawOperation => {
   };
 };
 
-const parseSetDelegate = (michelson: MichelsonV1Expression[]): RawOperation => {
+const parseSetDelegate = (michelson: MichelsonV1Expression[]): Operation => {
   const parseResult = setDelegateSchema.parse(michelson);
 
   return {
@@ -103,7 +103,7 @@ const parseSetDelegate = (michelson: MichelsonV1Expression[]): RawOperation => {
   };
 };
 
-const parseRemoveDelegate = (_michelson: MichelsonV1Expression[]): RawOperation => {
+const parseRemoveDelegate = (_michelson: MichelsonV1Expression[]): Operation => {
   return { type: "delegation", recipient: undefined };
 };
 
@@ -116,7 +116,7 @@ const parsings = [
   { schema: removeDelegateSchema, parsingFn: parseRemoveDelegate },
 ];
 
-const parse = (michelson: MichelsonV1Expression[], acc: RawOperation[] = []): RawOperation[] => {
+const parse = (michelson: MichelsonV1Expression[], acc: Operation[] = []): Operation[] => {
   if (michelson.length === 0) {
     return acc;
   }
@@ -145,7 +145,7 @@ export const decode = (michelson: MichelsonV1Expression[]) => {
   return parse(michelson.slice(2));
 };
 
-export const parseRawMichelson = (rawMichelson: string): RawOperation[] => {
+export const parseRawMichelson = (rawMichelson: string): Operation[] => {
   const michelson: MichelsonV1Expression[] = JSON.parse(rawMichelson);
   return decode(michelson);
 };

--- a/src/multisig/multisigSandbox.integration.test.ts
+++ b/src/multisig/multisigSandbox.integration.test.ts
@@ -5,7 +5,7 @@ import { makeDefaultDevSignerKeys, makeToolkitFromDefaultDevSeed } from "../mock
 import { ghostTezzard } from "../mocks/tokens";
 import { contract, makeStorageMichelsonJSON } from "./multisigContract";
 import { makeBatchLambda } from "./multisigUtils";
-import { MultisigStorage } from "../types/RawOperation";
+import { MultisigStorage } from "../types/Operation";
 import { parseContractPkh, parsePkh } from "../types/Address";
 
 jest.unmock("../utils/tezos");

--- a/src/multisig/multisigUtils.ts
+++ b/src/multisig/multisigUtils.ts
@@ -1,6 +1,6 @@
 import { MANAGER_LAMBDA } from "@taquito/taquito";
 import { makeFA12TransactionParameter, makeFA2TransactionParameter } from "../utils/tezos";
-import { FA12Operation, FA2Operation, RawOperation } from "../types/RawOperation";
+import { FA12Operation, FA2Operation, Operation } from "../types/Operation";
 import type { MichelsonV1Expression, TransactionOperationParameter } from "@taquito/rpc";
 import { isEqual } from "lodash";
 
@@ -109,7 +109,7 @@ const headlessLambda = (lambda: MichelsonV1Expression[]): MichelsonV1Expression[
   return lambda;
 };
 
-export const makeLambda = (operation: RawOperation): MichelsonV1Expression[] => {
+export const makeLambda = (operation: Operation): MichelsonV1Expression[] => {
   switch (operation.type) {
     case "tez":
       switch (operation.recipient.type) {
@@ -149,7 +149,7 @@ export const makeLambda = (operation: RawOperation): MichelsonV1Expression[] => 
  * @param network Network is needed for fetching contract parameter elements in lambda
  * @returns Lambda in MichelsonJSON (=Micheline) format
  */
-export const makeBatchLambda = (operations: RawOperation[]) => {
+export const makeBatchLambda = (operations: Operation[]) => {
   const opsLambdas = operations.map(operation => makeLambda(operation)).flatMap(headlessLambda);
 
   return [...LAMBDA_HEADER, ...opsLambdas];

--- a/src/types/Operation.ts
+++ b/src/types/Operation.ts
@@ -1,29 +1,40 @@
-import * as tzktApi from "@tzkt/sdk-api";
-import { Address } from "./Address";
-import { RawTokenInfo } from "./Token";
+import { BigMapAbstraction, TransferParams } from "@taquito/taquito";
+import { BigNumber } from "bignumber.js";
+import { Address, ContractAddress, ImplicitAddress } from "./Address";
 
-export type TokenTransfer = Omit<tzktApi.TokenTransfer, "amount" | "token"> & {
-  amount: string;
-  token: RawTokenInfo;
+export type MultisigStorage = {
+  last_op_id: BigNumber;
+  pending_ops: BigMapAbstraction;
+  threshold: BigNumber;
+  owner: Address;
+  metadata: BigMapAbstraction;
+  signers: Address[];
 };
 
-export type TezTransfer = tzktApi.TransactionOperation;
+export type TezOperation = {
+  type: "tez";
+  recipient: Address;
+  amount: string;
+  parameter?: TransferParams["parameter"];
+};
 
-// OperationDisplay is nicely formated for display in tables
-export type OperationDisplay = {
-  id: number;
-  type: "transaction" | "delegation";
-  amount: {
-    prettyDisplay: string;
-    url?: string;
-    id?: number;
-  };
-  fee?: string;
+export type FA2Operation = {
+  type: "fa2";
   sender: Address;
   recipient: Address;
-  status?: string;
-  prettyTimestamp: string;
-  timestamp: string;
-  tzktUrl?: string;
-  level: number;
+  contract: ContractAddress;
+  tokenId: string;
+  amount: string;
 };
+
+export type FA12Operation = Omit<FA2Operation, "type" | "tokenId"> & {
+  type: "fa1.2";
+  tokenId: "0";
+};
+
+export type Delegation = {
+  type: "delegation";
+  recipient: ImplicitAddress | undefined;
+};
+
+export type Operation = TezOperation | FA12Operation | FA2Operation | Delegation;

--- a/src/types/Transfer.ts
+++ b/src/types/Transfer.ts
@@ -1,0 +1,29 @@
+import * as tzktApi from "@tzkt/sdk-api";
+import { Address } from "./Address";
+import { RawTokenInfo } from "./Token";
+
+export type TokenTransfer = Omit<tzktApi.TokenTransfer, "amount" | "token"> & {
+  amount: string;
+  token: RawTokenInfo;
+};
+
+export type TezTransfer = tzktApi.TransactionOperation;
+
+// OperationDisplay is nicely formated for display in tables
+export type OperationDisplay = {
+  id: number;
+  type: "transaction" | "delegation";
+  amount: {
+    prettyDisplay: string;
+    url?: string;
+    id?: number;
+  };
+  fee?: string;
+  sender: Address;
+  recipient: Address;
+  status?: string;
+  prettyTimestamp: string;
+  timestamp: string;
+  tzktUrl?: string;
+  level: number;
+};

--- a/src/utils/beacon/BeaconNotification/BeaconRequestNotification.tsx
+++ b/src/utils/beacon/BeaconNotification/BeaconRequestNotification.tsx
@@ -11,7 +11,7 @@ import React from "react";
 import SendForm from "../../../components/sendForm";
 import { SendFormMode } from "../../../components/sendForm/types";
 import { parseImplicitPkh, parsePkh } from "../../../types/Address";
-import { RawOperation } from "../../../types/RawOperation";
+import { Operation } from "../../../types/Operation";
 import { useFirstAccount, useGetImplicitAccount } from "../../hooks/accountHooks";
 import { walletClient } from "../beacon";
 import BeaconErrorPanel from "./pannels/BeaconErrorPanel";
@@ -23,7 +23,7 @@ const SingleTransaction = ({
   onSuccess,
   sender,
 }: {
-  transfer: RawOperation;
+  transfer: Operation;
   onSuccess: (hash: string) => any;
   sender: string;
 }) => {
@@ -50,7 +50,7 @@ const BatchTransaction = ({
   onSuccess,
   signer,
 }: {
-  transfer: RawOperation[];
+  transfer: Operation[];
   onSuccess: (hash: string) => any;
   signer: string;
 }) => {
@@ -144,7 +144,7 @@ export const BeaconNotification: React.FC<{
 
 const beaconToUmamiOperation = (operation: PartialTezosOperation, sender: string) => {
   if (operation.kind === TezosOperationType.TRANSACTION) {
-    const result: RawOperation = {
+    const result: Operation = {
       type: "tez",
       amount: operation.amount,
       recipient: parsePkh(operation.destination),
@@ -155,7 +155,7 @@ const beaconToUmamiOperation = (operation: PartialTezosOperation, sender: string
   }
 
   if (operation.kind === TezosOperationType.DELEGATION) {
-    const result: RawOperation = {
+    const result: Operation = {
       type: "delegation",
       recipient:
         operation.delegate !== undefined ? parseImplicitPkh(operation.delegate) : undefined,

--- a/src/utils/hooks/assetsHooks.ts
+++ b/src/utils/hooks/assetsHooks.ts
@@ -8,7 +8,7 @@ import {
   keepNFTs,
   NFTBalance,
 } from "../../types/TokenBalance";
-import { OperationDisplay } from "../../types/Operation";
+import { OperationDisplay } from "../../types/Transfer";
 import {
   getOperationDisplays,
   sortOperationsByTimestamp,

--- a/src/utils/store/assetsSlice.test.ts
+++ b/src/utils/store/assetsSlice.test.ts
@@ -16,7 +16,7 @@ import accountsSlice from "./accountsSlice";
 import { estimateAndUpdateBatch } from "./thunks/estimateAndupdateBatch";
 import { estimateBatch } from "../tezos";
 import { hedgehoge } from "../../mocks/fa12Tokens";
-import { RawOperation } from "../../types/RawOperation";
+import { Operation } from "../../types/Operation";
 jest.mock("../tezos");
 
 const estimateBatchMock = estimateBatch as jest.Mock;
@@ -492,7 +492,7 @@ describe("Assets reducer", () => {
 
       estimateBatchMock.mockResolvedValueOnce(mockEstimations);
 
-      const operations: RawOperation[] = [];
+      const operations: Operation[] = [];
 
       const action = estimateAndUpdateBatch(
         mockImplicitAddress(1).pkh,

--- a/src/utils/store/assetsSlice.ts
+++ b/src/utils/store/assetsSlice.ts
@@ -4,13 +4,13 @@ import { DelegationOperation } from "@tzkt/sdk-api";
 import { compact, groupBy, mapValues } from "lodash";
 import { TokenBalance, fromRaw, eraseToken } from "../../types/TokenBalance";
 import { Baker } from "../../types/Baker";
-import { TezTransfer, TokenTransfer } from "../../types/Operation";
+import { TezTransfer, TokenTransfer } from "../../types/Transfer";
 import { RawTokenBalance } from "../../types/TokenBalance";
 import { TzktAccount } from "../tezos";
 import accountsSlice from "./accountsSlice";
-import { RawOperation } from "../../types/RawOperation";
+import { Operation } from "../../types/Operation";
 
-export type BatchItem = { operation: RawOperation; fee: string };
+export type BatchItem = { operation: Operation; fee: string };
 export type Batch = {
   isSimulating: boolean;
   items: Array<BatchItem>;

--- a/src/utils/store/thunks/estimateAndupdateBatch.ts
+++ b/src/utils/store/thunks/estimateAndupdateBatch.ts
@@ -1,6 +1,6 @@
 import { TezosNetwork } from "@airgap/tezos";
 import { AnyAction, ThunkAction } from "@reduxjs/toolkit";
-import { RawOperation } from "../../../types/RawOperation";
+import { Operation } from "../../../types/Operation";
 import { operationsToBatchItems } from "../../../views/batch/batchUtils";
 import assetsSlice from "../assetsSlice";
 import { RootState } from "../store";
@@ -9,7 +9,7 @@ const { updateBatch: addToBatch, batchSimulationEnd, batchSimulationStart } = as
 export const estimateAndUpdateBatch = (
   pkh: string,
   pk: string,
-  operations: RawOperation[],
+  operations: Operation[],
   network: TezosNetwork
 ): ThunkAction<Promise<void>, RootState, unknown, AnyAction> => {
   return async (dispatch, getState) => {

--- a/src/utils/tezos/estimate.ts
+++ b/src/utils/tezos/estimate.ts
@@ -1,6 +1,6 @@
 import { TezosNetwork } from "@airgap/tezos";
 import { Estimate } from "@taquito/taquito";
-import { RawOperation } from "../../types/RawOperation";
+import { Operation } from "../../types/Operation";
 import {
   makeMultisigApproveOrExecuteMethod,
   makeMultisigProposeMethod,
@@ -36,7 +36,7 @@ export const estimateMultisigApproveOrExecute = async (
 };
 
 export const estimateBatch = async (
-  operations: RawOperation[],
+  operations: Operation[],
   pkh: string,
   pk: string,
   network: TezosNetwork

--- a/src/utils/tezos/fetch.ts
+++ b/src/utils/tezos/fetch.ts
@@ -11,7 +11,7 @@ import axios from "axios";
 import { bakersUrl, coincapUrl, tzktUrls } from "./consts";
 import { coinCapResponseType } from "./types";
 import { Baker } from "../../types/Baker";
-import { TezTransfer } from "../../types/Operation";
+import { TezTransfer } from "../../types/Transfer";
 import { RawTokenBalance } from "../../types/TokenBalance";
 
 // TzKT defines type Account = {type: string};

--- a/src/utils/tezos/operations.ts
+++ b/src/utils/tezos/operations.ts
@@ -1,6 +1,6 @@
 import { TransactionOperation, TransferParams } from "@taquito/taquito";
 import { BatchWalletOperation } from "@taquito/taquito/dist/types/wallet/batch-operation";
-import { RawOperation } from "../../types/RawOperation";
+import { Operation } from "../../types/Operation";
 import { SignerConfig } from "../../types/SignerConfig";
 import {
   makeMultisigApproveOrExecuteMethod,
@@ -44,7 +44,7 @@ export const approveOrExecuteMultisigOperation = async (
 };
 
 export const submitBatch = async (
-  operation: RawOperation[],
+  operation: Operation[],
   config: SignerConfig
 ): Promise<BatchWalletOperation> => {
   const Tezos = await makeToolkitWithSigner(config);

--- a/src/utils/tezos/params.ts
+++ b/src/utils/tezos/params.ts
@@ -1,16 +1,16 @@
 import { TezosNetwork } from "@airgap/tezos";
 import { OpKind, ParamsWithKind, TezosToolkit, WalletParamsWithKind } from "@taquito/taquito";
-import { RawOperation } from "../../types/RawOperation";
+import { Operation } from "../../types/Operation";
 import { makeTokenTransferParams, makeToolkitWithDummySigner } from "./helpers";
 
 export const operationsToWalletParams = async (
-  operations: RawOperation[],
+  operations: Operation[],
   signer: TezosToolkit
 ): Promise<WalletParamsWithKind[]> =>
   operationsToParams(operations, signer) as Promise<WalletParamsWithKind[]>;
 
 export const operationsToParams = async (
-  operations: RawOperation[],
+  operations: Operation[],
   toolkit: TezosToolkit
 ): Promise<ParamsWithKind[]> => {
   const result: ParamsWithKind[] = [];
@@ -48,7 +48,7 @@ export const operationsToParams = async (
 };
 
 export const operationsToBatchParams = async (
-  operations: RawOperation[],
+  operations: Operation[],
   pk: string,
   pkh: string,
   network: TezosNetwork

--- a/src/utils/useAssetsPolling.ts
+++ b/src/utils/useAssetsPolling.ts
@@ -2,7 +2,7 @@ import { TezosNetwork } from "@airgap/tezos";
 import { chunk, compact } from "lodash";
 import { useEffect, useRef } from "react";
 import { useQuery } from "react-query";
-import { TokenTransfer } from "../types/Operation";
+import { TokenTransfer } from "../types/Transfer";
 import { useImplicitAccounts } from "./hooks/accountHooks";
 import { useSelectedNetwork } from "./hooks/assetsHooks";
 import { getPendingOperationsForMultisigs, getRelevantMultisigContracts } from "./multisig/helpers";

--- a/src/views/batch/BatchDisplay.tsx
+++ b/src/views/batch/BatchDisplay.tsx
@@ -23,7 +23,7 @@ import { AccountSmallTileDisplay } from "../../components/AccountSelector/Accoun
 import { IconAndTextBtnLink } from "../../components/IconAndTextBtn";
 import { Fee, Subtotal, Total } from "../../components/sendForm/components/TezAmountRecaps";
 import { ImplicitAccount } from "../../types/Account";
-import { RawOperation } from "../../types/RawOperation";
+import { Operation } from "../../types/Operation";
 import { formatTokenAmount, tokenSymbol } from "../../types/TokenBalance";
 import { formatPkh, prettyTezAmount } from "../../utils/format";
 import { useSelectedNetwork } from "../../utils/hooks/assetsHooks";
@@ -33,7 +33,7 @@ import { getIPFSurl } from "../../utils/token/nftUtils";
 import { buildTzktAddressUrl } from "../../utils/tzkt/helpers";
 import { getBatchSubtotal, getTotalFee } from "./batchUtils";
 
-const renderAmount = (operation: RawOperation, getToken: TokenLookup) => {
+const renderAmount = (operation: Operation, getToken: TokenLookup) => {
   switch (operation.type) {
     case "fa1.2":
     case "fa2": {

--- a/src/views/batch/batchUtils.ts
+++ b/src/views/batch/batchUtils.ts
@@ -4,7 +4,7 @@ import { Estimate } from "@taquito/taquito";
 import { TezosNetwork } from "@airgap/tezos";
 import { estimateBatch } from "../../utils/tezos";
 import { zip } from "../../utils/helpers";
-import { RawOperation } from "../../types/RawOperation";
+import { Operation } from "../../types/Operation";
 
 export const getTotalFee = (items: BatchItem[]): BigNumber => {
   const fee = items.reduce((acc, curr) => {
@@ -14,7 +14,7 @@ export const getTotalFee = (items: BatchItem[]): BigNumber => {
   return fee;
 };
 
-export const getBatchSubtotal = (ops: RawOperation[]) => {
+export const getBatchSubtotal = (ops: Operation[]) => {
   const subTotal = ops.reduce((acc, curr) => {
     switch (curr.type) {
       case "tez":
@@ -35,7 +35,7 @@ export const sumEstimations = (es: Estimate[]) => {
 };
 
 export const operationsToBatchItems = async (
-  operations: RawOperation[],
+  operations: Operation[],
   pkh: string,
   pk: string,
   network: TezosNetwork

--- a/src/views/home/OpertionList/OperationListDisplay.tsx
+++ b/src/views/home/OpertionList/OperationListDisplay.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import NestedScroll from "../../../components/NestedScroll";
 import { NoOperations } from "../../../components/NoItems";
 import { OperationTile } from "../../../components/OperationTile";
-import { OperationDisplay } from "../../../types/Operation";
+import { OperationDisplay } from "../../../types/Transfer";
 import { getKey } from "../../operations/operationsUtils";
 
 export const OperationListDisplay: React.FC<{ operations: OperationDisplay[] }> = ({

--- a/src/views/operations/OperationsView.tsx
+++ b/src/views/operations/OperationsView.tsx
@@ -21,7 +21,7 @@ import { IconAndTextBtn } from "../../components/IconAndTextBtn";
 import { NoOperations } from "../../components/NoItems";
 import { TopBar } from "../../components/TopBar";
 import { TzktLink } from "../../components/TzktLink";
-import { OperationDisplay } from "../../types/Operation";
+import { OperationDisplay } from "../../types/Transfer";
 import { useGetOperationDisplays, useIsBlockFinalised } from "../../utils/hooks/assetsHooks";
 import { getAmountColor, getKey, sortOperationsByTimestamp } from "./operationsUtils";
 

--- a/src/views/operations/operationUtils.test.ts
+++ b/src/views/operations/operationUtils.test.ts
@@ -6,7 +6,7 @@ import {
   getTransactionsResult,
   rawTzktNftTransfer,
 } from "../../mocks/tzktResponse";
-import { OperationDisplay, TezTransfer, TokenTransfer } from "../../types/Operation";
+import { OperationDisplay, TezTransfer, TokenTransfer } from "../../types/Transfer";
 import { SupportedNetworks } from "../../utils/network";
 import {
   getOperationDisplays,

--- a/src/views/operations/operationsUtils.ts
+++ b/src/views/operations/operationsUtils.ts
@@ -2,7 +2,7 @@ import { TezosNetwork } from "@airgap/tezos";
 import { formatRelative } from "date-fns";
 import { z } from "zod";
 import { tokenPrettyBalance } from "../../types/TokenBalance";
-import { OperationDisplay, TezTransfer, TokenTransfer } from "../../types/Operation";
+import { OperationDisplay, TezTransfer, TokenTransfer } from "../../types/Transfer";
 import { fromRaw } from "../../types/Token";
 import { compact } from "lodash";
 import { getIPFSurl } from "../../utils/token/nftUtils";


### PR DESCRIPTION
## Proposed changes

It's a part of #254 
`OperationValue` is obsolete and it was replaced with just `Operation`. Where we need the asset we can use the `useGetToken` hook

## Types of changes

- [x] Refactor
