### PR TITLE
Set default token decimals to 0

### DIFF
--- a/src/components/AccountCard/AccountCard.test.tsx
+++ b/src/components/AccountCard/AccountCard.test.tsx
@@ -138,7 +138,7 @@ describe("<AccountCard />", () => {
     {
       const { getByTestId } = within(tokenTiles[2]);
       expect(getByTestId("token-name")).toHaveTextContent("FA1.2 token");
-      expect(getByTestId("token-balance")).toHaveTextContent("0.0123");
+      expect(getByTestId("token-balance")).toHaveTextContent("123");
       expect(getByTestId("token-symbol")).toHaveTextContent("FA1.2");
     }
 

--- a/src/components/CSVFileUploader/utils.test.ts
+++ b/src/components/CSVFileUploader/utils.test.ts
@@ -58,7 +58,7 @@ describe("csv utils", () => {
     });
   });
 
-  it("converts Tez transfer to OperationValue", () => {
+  it("converts Tez transfer to Operation", () => {
     expect(fixture([mockImplicitAddress(1).pkh, "1"])).toEqual({
       type: "tez",
       amount: "1000000",
@@ -66,11 +66,11 @@ describe("csv utils", () => {
     });
   });
 
-  it("converts FA1.2 transfer to OperationValue", () => {
+  it("converts FA1.2 transfer to Operation", () => {
     const mockCSVFA12TransferRow = [mockImplicitAddress(1).pkh, "10000", ghostFA12.contract];
     expect(fixture(mockCSVFA12TransferRow, (_contract, _tokenId) => ghostFA12)).toEqual({
       type: "fa1.2",
-      amount: "100000000",
+      amount: "10000",
       recipient: mockImplicitAddress(1),
       sender,
       contract: parseContractPkh(ghostFA12.contract),
@@ -78,7 +78,7 @@ describe("csv utils", () => {
     });
   });
 
-  it("converts FA2 transfer to OperationValue", () => {
+  it("converts FA2 transfer to Operation", () => {
     const mockCSVFA2TransferRow = [
       mockImplicitAddress(1).pkh,
       "1",

--- a/src/types/TokenBalance.test.tsx
+++ b/src/types/TokenBalance.test.tsx
@@ -373,7 +373,7 @@ describe("metadataUri", () => {
 });
 
 describe("tokenDecimal", () => {
-  it("returns token decimal", () => {
+  it("returns token decimal if it's present in the metadata", () => {
     const fa2token: FA2TokenBalance = {
       type: "fa2",
       contract: "KT1QTcAXeefhJ3iXLurRt81WRKdv7YqyYFmo",
@@ -384,7 +384,16 @@ describe("tokenDecimal", () => {
       },
     };
     expect(tokenDecimal(fa2token)).toEqual("3");
-    fa2token.metadata = {};
-    expect(tokenDecimal(fa2token)).toEqual("4");
+  });
+
+  it("returns 0 if metadata doesn't have the decimal field", () => {
+    const fa2token: FA2TokenBalance = {
+      type: "fa2",
+      contract: "KT1QTcAXeefhJ3iXLurRt81WRKdv7YqyYFmo",
+      balance: "1",
+      tokenId: "123",
+      metadata: {},
+    };
+    expect(tokenDecimal(fa2token)).toEqual("0");
   });
 });

--- a/src/types/TokenBalance.ts
+++ b/src/types/TokenBalance.ts
@@ -182,4 +182,4 @@ export const DEFAULT_NFT_NAME = "NFT";
 export const DEFAULT_FA1_SYMBOL = "FA1.2";
 export const DEFAULT_FA2_SYMBOL = "FA2";
 export const DEFAULT_NFT_SYMBOL = "NFT";
-export const DEFAULT_TOKEN_DECIMALS = "4";
+export const DEFAULT_TOKEN_DECIMALS = "0";

--- a/src/views/operations/operationUtils.test.ts
+++ b/src/views/operations/operationUtils.test.ts
@@ -372,7 +372,7 @@ describe("getTezOperationDisplay", () => {
       tzktUrl: "https://mainnet.tzkt.io/transactions/109855847219200",
       amount: {
         id: 10897625972737,
-        prettyDisplay: "+2.74 FA1.2",
+        prettyDisplay: "+27400 FA1.2",
         url: undefined,
       },
       prettyTimestamp: "today at 3:30 PM",
@@ -411,7 +411,7 @@ describe("getOperationsDisplays", () => {
         id: 109855847219201,
         amount: {
           id: 10897625972737,
-          prettyDisplay: "+2.74 FA1.2",
+          prettyDisplay: "+27400 FA1.2",
           url: undefined,
         },
         prettyTimestamp: "today at 3:30 PM",


### PR DESCRIPTION
## Proposed changes

As we discussed it's much easier and safer to do so to prevent unexpected "I sent 1 but reality it was 10K tokens"

## Types of changes

- [x] Bugfix

## Screenshots

| Before | Now    |
| ------ | ------ |
| <img width="1148" alt="Screenshot 2023-07-20 at 15 09 24" src="https://github.com/trilitech/umami-v2/assets/129749432/b5647a35-ce9b-4f35-bc33-87f8ec39a34e"> | <img width="771" alt="Screenshot 2023-07-20 at 15 08 50" src="https://github.com/trilitech/umami-v2/assets/129749432/b0f540d9-6420-4424-bcfd-15a0b90ae538"> |

## Checklist

- [x] Tests that prove my fix is effective or that my feature works have been added
- [x] Screenshots are added (if any UI changes have been made)
