### PR TITLE
Remove dev only stuff from the prod build

### DIFF
--- a/config-overrides.js
+++ b/config-overrides.js
@@ -18,5 +18,17 @@ module.exports = function override(config) {
       Buffer: ["buffer", "Buffer"],
     }),
   ]);
+
+  if (process.env.NODE_ENV === "production") {
+    config.module.rules.push({
+      test: /\.[jt]sx?$/,
+      exclude: /node_modules/,
+      use: [
+        {
+          loader: "webpack-remove-code-blocks",
+        },
+      ],
+    });
+  }
   return config;
 };

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "main": "./public/electron.js",
   "dependencies": {
     "@airgap/beacon-wallet": "^4.0.2",
+    "@babel/runtime": "^7.22.6",
     "@chakra-ui/icons": "^2.0.17",
     "@chakra-ui/react": "^2.5.1",
     "@emotion/react": "^11.10.6",
@@ -72,6 +73,7 @@
     "stream-browserify": "^3.0.0",
     "typescript": "^4.9.5",
     "web-vitals": "^2.1.4",
+    "webpack-remove-code-blocks": "^0.1.5",
     "zod": "^3.21.4"
   },
   "scripts": {

--- a/src/components/Onboarding/connectOrCreate/ConnectOrCreate.tsx
+++ b/src/components/Onboarding/connectOrCreate/ConnectOrCreate.tsx
@@ -41,15 +41,18 @@ const ConnectOrCreate = ({
         >
           I already have a wallet
         </Button>
-        {/* TODO: hide on production */}
-        <Button
-          variant="outline"
-          w="100%"
-          size="lg"
-          onClick={_ => goToStep({ type: StepType.fakeAccount })}
-        >
-          Add a Fake Account
-        </Button>
+        {
+          /* devblock:start */
+          <Button
+            variant="outline"
+            w="100%"
+            size="lg"
+            onClick={_ => goToStep({ type: StepType.fakeAccount })}
+          >
+            Add a Fake Account
+          </Button>
+          /* devblock:end */
+        }
         <Flex w="100%" pt="20px" pb="20px">
           <Divider mt="11px" />
           <Text textAlign="center" minW="160px" size="sm" noOfLines={1}>

--- a/src/components/Onboarding/restoreSeedphrase/RestoreSeedphrase.tsx
+++ b/src/components/Onboarding/restoreSeedphrase/RestoreSeedphrase.tsx
@@ -126,18 +126,22 @@ const RestoreSeedphrase = ({ goToStep }: { goToStep: (step: Step) => void }) => 
               Continue
             </Button>
 
-            <Button
-              onClick={() => {
-                setMnemonicSize("24");
-                pasteMnemonic(seedPhrase);
-              }}
-              bg="umami.blue"
-              w="100%"
-              size="lg"
-              minH="48px"
-            >
-              Enter test seedphrase (Dev only)
-            </Button>
+            {
+              /* devblock:start */
+              <Button
+                onClick={() => {
+                  setMnemonicSize("24");
+                  pasteMnemonic(seedPhrase);
+                }}
+                bg="umami.blue"
+                w="100%"
+                size="lg"
+                minH="48px"
+              >
+                Enter test seedphrase (Dev only)
+              </Button>
+              /* devblock:end */
+            }
           </VStack>
         </form>
       </Box>

--- a/src/components/Onboarding/verifySeedphrase/VerifySeedphrase.tsx
+++ b/src/components/Onboarding/verifySeedphrase/VerifySeedphrase.tsx
@@ -64,11 +64,13 @@ const VerifySeedphrase = ({
               Continue
             </Button>
 
-            {process.env.NODE_ENV === "development" && (
+            {
+              /* devblock:start */
               <Button onClick={onSubmit} w="100%" size="lg" minH="48px">
                 Bypass (Dev only)
               </Button>
-            )}
+              /* devblock:end */
+            }
           </VStack>
         </form>
       </Box>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1914,7 +1914,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.21.5":
+"@babel/runtime@npm:^7.21.5, @babel/runtime@npm:^7.22.6":
   version: 7.22.6
   resolution: "@babel/runtime@npm:7.22.6"
   dependencies:
@@ -18125,7 +18125,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"loader-utils@npm:^1.2.3":
+"loader-utils@npm:^1.1.0, loader-utils@npm:^1.2.3":
   version: 1.4.2
   resolution: "loader-utils@npm:1.4.2"
   dependencies:
@@ -25453,6 +25453,7 @@ __metadata:
   resolution: "umami@workspace:."
   dependencies:
     "@airgap/beacon-wallet": ^4.0.2
+    "@babel/runtime": ^7.22.6
     "@chakra-ui/icons": ^2.0.17
     "@chakra-ui/react": ^2.5.1
     "@emotion/react": ^11.10.6
@@ -25553,6 +25554,7 @@ __metadata:
     wait-on: ^7.0.1
     web-vitals: ^2.1.4
     webpack: ^5.75.0
+    webpack-remove-code-blocks: ^0.1.5
     zod: ^3.21.4
   languageName: unknown
   linkType: soft
@@ -26517,6 +26519,17 @@ __metadata:
   peerDependencies:
     webpack: ^4.44.2 || ^5.47.0
   checksum: 426982030d3b0ef26432d98960ee1fa33889d8f0ed79b3d2c8e37be9b4e4beba7524c60631297ea557c642a340b76d70b0eb6a1e08b86a769409037185795038
+  languageName: node
+  linkType: hard
+
+"webpack-remove-code-blocks@npm:^0.1.5":
+  version: 0.1.5
+  resolution: "webpack-remove-code-blocks@npm:0.1.5"
+  dependencies:
+    loader-utils: ^1.1.0
+  peerDependencies:
+    webpack: ">=3.0.0"
+  checksum: a56b48fb208cfd18c31a7c20969c2e45881c5712efb6f50904c17b4aa4c6aee36774851a51079a7a4569fad99cf37740dfa60ffa9d1e015ac76d8d0626b23f32
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Proposed changes

This thing erases code inside the block so that on production we won't ever see it. NODE_ENV doesn't work because you can always pass it in manually when running the app and also this env var is fully managed by CRA in dev environment

## Types of changes
- [x] New feature

## Steps to reproduce

`yarn start` or `yarn electron:start` and it shows dev buttons & stuff
`yarn build && yarn electron:package:mac:debug` and install the app and the buttons aren't there

## Screenshots

| Dev | Prod    |
| ------ | ------ |
|<img width="426" alt="Screenshot 2023-07-24 at 09 24 40" src="https://github.com/trilitech/umami-v2/assets/129749432/a08f74f3-0ad1-4444-a1c1-bbe582188c0a"> |<img width="427" alt="Screenshot 2023-07-24 at 09 23 59" src="https://github.com/trilitech/umami-v2/assets/129749432/f7e8b77c-0a50-4305-8785-4b6c5a12ec99"> |

## Checklist

- [ ] Tests that prove my fix is effective or that my feature works have been added
- [ ] Documentation has been added (if appropriate)
- [x] Screenshots are added (if any UI changes have been made)
- [ ] All TODOs have a corresponding task created (and the link is attached to it)
