### PR TITLE
Set identicons background to white

### DIFF
--- a/src/components/AddressAutocomplete.tsx
+++ b/src/components/AddressAutocomplete.tsx
@@ -80,7 +80,7 @@ const Suggestions = ({
             }}
           >
             <>
-              <Identicon identiconSize={30} address={contact.pkh} mr={4} />
+              <Identicon identiconSize={20} p="5px" address={contact.pkh} mr={4} />
               <Text size="sm">{contact.name}</Text>
             </>
           </ListItem>

--- a/src/components/Identicon.tsx
+++ b/src/components/Identicon.tsx
@@ -9,10 +9,9 @@ const ReactIdenticons = require("react-identicons").default;
 export const Identicon: React.FC<
   {
     address: string;
-
     identiconSize?: number;
   } & ChakraProps
-> = ({ address, identiconSize = 48, ...props }) => {
+> = ({ address, identiconSize = 32, ...props }) => {
   return (
     <Box
       sx={{
@@ -20,12 +19,16 @@ export const Identicon: React.FC<
           borderRadius: "4px",
         },
       }}
+      bg="white"
+      borderRadius="4px"
+      p="8px"
       {...props}
     >
       <ReactIdenticons
         style={{
           borderRadius: 4,
         }}
+        bg="white"
         size={identiconSize}
         string={address}
       />


### PR DESCRIPTION
## Proposed changes

We should have white BG with round corners and some padding for the identicons according to the design. Tried to match it as much as I can.

## Types of changes

- [x] New feature


## Screenshots

<img width="500" alt="Screenshot 2023-07-29 at 10 41 04" src="https://github.com/trilitech/umami-v2/assets/129749432/a703296a-fe14-44c6-a38a-471c30dceced">
<img width="322" alt="Screenshot 2023-07-29 at 10 41 16" src="https://github.com/trilitech/umami-v2/assets/129749432/e446a44c-3fc1-406e-be7e-4302ae887046">

## Checklist

- [x] Screenshots are added (if any UI changes have been made)
