### PR TITLE
Add delegation support for multisig

### DIFF
--- a/src/components/AccountCard/AssetsPanel/MultisigPendingAccordion/MultisigDecodedOperationItem.tsx
+++ b/src/components/AccountCard/AssetsPanel/MultisigPendingAccordion/MultisigDecodedOperationItem.tsx
@@ -19,7 +19,13 @@ const MultisigDecodedOperationItem: React.FC<{
     case "delegation":
       return (
         <Box marginY={6} pl={5} m={1} data-testid="decoded-item-delegate">
-          {operation.recipient ? `Delegate to ${operation.recipient}` : "Undelegate"}
+          {!operation.recipient ? (
+            "Undelegate"
+          ) : (
+            <>
+              Delegate to <AddressPill address={operation.recipient} />
+            </>
+          )}
         </Box>
       );
     default:


### PR DESCRIPTION
## Proposed changes

Add support for delegation operations for multisig.

Replaced  `buildTezFromFormValues` and `buildTokenFromFormValues` with `makeFormOperations`.


## Types of changes

- [x] New feature
- [x] Refactor

## Screenshots

<img width="588" alt="Screenshot 2023-07-31 at 13 46 04" src="https://github.com/trilitech/umami-v2/assets/129749432/290e1641-f6c3-4b36-8ca1-a0468391b9aa">
<img width="490" alt="Screenshot 2023-07-31 at 13 46 18" src="https://github.com/trilitech/umami-v2/assets/129749432/06e542f5-c52c-4d7f-94cc-5de42ffc103f">
<img width="574" alt="Screenshot 2023-07-31 at 13 47 08" src="https://github.com/trilitech/umami-v2/assets/129749432/41dc22f5-10ce-4399-871b-40dd6d0f586b">
<img width="568" alt="Screenshot 2023-07-31 at 13 47 47" src="https://github.com/trilitech/umami-v2/assets/129749432/e5c5e074-d9b1-40df-8af9-021f25a65005">


## Checklist

- [x] Tests that prove my fix is effective or that my feature works have been added
- [x] Screenshots are added (if any UI changes have been made)
