### PR TITLE
Fix multisig recap 

### DIFF
--- a/src/components/sendForm/steps/SubmitStep.tsx
+++ b/src/components/sendForm/steps/SubmitStep.tsx
@@ -82,7 +82,7 @@ export const SubmitStep: React.FC<{
               <Heading size="md" width={20}>
                 From:
               </Heading>
-              <AccountSmallTile pkh={operations.signer.address.pkh} />
+              <AccountSmallTile pkh={operations.sender.address.pkh} />
             </Flex>
             {isBatch ? (
               <BatchRecap transfer={transfer} />


### PR DESCRIPTION
## Fix multisig recap 

The recap UI of multisig is misleading. For example, if we propose a send tez operation to restored account 1 from multisig account 1 with restored account 0 being the signer, we get the following recap UI
<img width="494" alt="Screenshot 2023-08-04 at 11 14 49" src="https://github.com/trilitech/umami-v2/assets/128799322/902ea6ae-1f29-42c3-b934-748c33fd6a06">
The correct way to display it is this:
<img width="493" alt="Screenshot 2023-08-04 at 11 21 02" src="https://github.com/trilitech/umami-v2/assets/128799322/021ebb1c-72a4-4157-903b-2d7cbf374708">



## Types of changes

_Put an `x` in the boxes that apply_

- [x] Bugfix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation Update

## Steps to reproduce

- step one
- step two
- step three

## Screenshots

Add the screenshots of how the app used to look like and how it looks now

| Before | Now    |
| ------ | ------ |
| Image1 | Image2 |
| Image3 | Image4 |

## Checklist

- [ ] Tests that prove my fix is effective or that my feature works have been added
- [ ] Documentation has been added (if appropriate)
- [ ] Screenshots are added (if any UI changes have been made)
- [ ] All TODOs have a corresponding task created (and the link is attached to it)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
