### PR TITLE
Add docker-compose for tzkt+test_node

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,62 @@
+version: "3"
+
+services:
+  db:
+    container_name: tzkt-db
+    restart: always
+    image: postgres:13
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-tzkt}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-qwerty}
+      POSTGRES_DB: ${POSTGRES_DB:-tzkt_db}
+    volumes:
+      - postgres:/var/lib/postgresql/data
+    ports:
+      - 127.0.0.1:5432:5432
+
+  flextesa:
+    container_name: tezos-node
+    restart: always
+    image: serjonya/flextesa:latest
+    command: nairobibox start
+    environment:
+      block_time: 1
+    ports:
+      - 0.0.0.0:20000:20000
+
+  sync:
+    container_name: tzkt-sync
+    restart: always
+    image: serjonya/tzkt-sync:latest
+    environment:
+      ConnectionStrings__DefaultConnection: host=db;port=5432;database=${POSTGRES_DB:-tzkt_db};username=${POSTGRES_USER:-tzkt};password=${POSTGRES_PASSWORD:-qwerty};command timeout=${COMMAND_TIMEOUT:-600};
+      Kestrel__Endpoints__Http__Url: http://0.0.0.0:5001
+      TezosNode__Endpoint: ${NODE_RPC:-http://flextesa:20000/}
+      Home__Enabled: true
+      HealthChecks__Enabled: true
+    depends_on:
+      - db
+      - flextesa
+    ports:
+      - 0.0.0.0:5001:5001
+
+  api:
+    container_name: tzkt-api
+    restart: always
+    image: serjonya/tzkt-api:latest
+    depends_on:
+      - sync
+    environment:
+      ConnectionStrings__DefaultConnection: host=db;port=5432;database=${POSTGRES_DB:-tzkt_db};username=${POSTGRES_USER:-tzkt};password=${POSTGRES_PASSWORD:-qwerty};command timeout=${COMMAND_TIMEOUT:-600};
+      Kestrel__Endpoints__Http__Url: http://0.0.0.0:5000
+      Home__Enabled: true
+      HealthChecks__Enabled: true
+    ports:
+      - 0.0.0.0:5000:5000
+
+networks:
+  default:
+    name: tzkt
+
+volumes:
+  postgres:


### PR DESCRIPTION
## Proposed changes

This thing will spin up a local node and fully operational tzkt indexer which is available on localhost:5000

## TODO
- [ ] push my images built for Mac m1 to docker hub
- [ ] wait for flextesa fix to be merged and released https://gitlab.com/tezos/flextesa/-/merge_requests/92
- [x] find a way to quickly kill flextesa container (answer: docker kill)
- [ ] remove the volume from Postgres so that on each start it is clean
- [ ] find a way to easily bootstrap accounts, contracts, bakers (maybe with some JSON config). checkout flextesa's `start` shell function
- [ ] verify that taquito can work with a custom nodeUrl
- [ ] Run the app with the local running nodes and see if it works
- [ ] Add ability to pass in rpc url & tzkt urls for tests

## Types of changes

_Put an `x` in the boxes that apply_

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation Update

## Steps to reproduce

- step one
- step two
- step three

## Screenshots

Add the screenshots of how the app used to look like and how it looks now

| Before | Now    |
| ------ | ------ |
| Image1 | Image2 |
| Image3 | Image4 |

## Checklist

- [ ] Tests that prove my fix is effective or that my feature works have been added
- [ ] Documentation has been added (if appropriate)
- [ ] Screenshots are added (if any UI changes have been made)
- [ ] All TODOs have a corresponding task created (and the link is attached to it)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
