### PR TITLE
Better exceptions stacktraces in production builds

### DIFF
--- a/config-overrides.js
+++ b/config-overrides.js
@@ -30,5 +30,9 @@ module.exports = function override(config) {
       ],
     });
   }
+  // keep sources as they are for error reporting
+  // source maps do not work without devtools enabled in electron
+  // TODO: find a better solution, check how rollbar & sentry handle this
+  config.optimization.minimize = false;
   return config;
 };


### PR DESCRIPTION
## Proposed changes

without it what we get in errors:
<img width="2202" alt="Screenshot 2023-08-07 at 10 42 17" src="https://github.com/trilitech/umami-v2/assets/129749432/10d81fe3-1058-4c82-9a88-80de8c629fa0">

that's what we get with it
<img width="2205" alt="Screenshot 2023-08-07 at 10 42 22" src="https://github.com/trilitech/umami-v2/assets/129749432/a0807e67-ca16-4664-bb39-8683da566356">


ideally it should be this:
<img width="2271" alt="Screenshot 2023-08-07 at 10 42 51" src="https://github.com/trilitech/umami-v2/assets/129749432/319eccf0-12f6-4ab9-869b-684f6b0e5acd">
