### PR TITLE
Kill parallel CI jobs running for the same branch

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,6 +2,10 @@ name: Test
 
 on: push
 
+concurrency:
+  group: ${{ github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Proposed changes

if you push new changes before the previous CI run is finished, the previous run will be cancelled. This way we can save some money on irrelevant tests

That what happens when you do so (only on the same branch, the limit of 1 job is per PR)
<img width="924" alt="Screenshot 2023-08-08 at 09 21 07" src="https://github.com/trilitech/umami-v2/assets/129749432/255d33a4-f106-41ad-b8ec-e5a34676ec26">

## Types of changes

- [ ] Bugfix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation Update
