### PR TITLE
Use code & type hashes to retrieve multisigs

### DIFF
--- a/src/utils/multisig/consts.ts
+++ b/src/utils/multisig/consts.ts
@@ -1,6 +1,0 @@
-import { TezosNetwork } from "../../types/TezosNetwork";
-
-export const multisigAddress = {
-  [TezosNetwork.MAINNET]: `KT1Lw11GPDxpdWXWudFUUBMA2Cihevmt8QCf`,
-  [TezosNetwork.GHOSTNET]: `KT1Mqvf7bnYe4Ty2n7ZbGkdbebCd4WoTJUUp`,
-};

--- a/src/utils/multisig/fetch.test.ts
+++ b/src/utils/multisig/fetch.test.ts
@@ -2,7 +2,6 @@ import axios from "axios";
 import { ghostMultisigContracts } from "../../mocks/tzktResponse";
 import { TezosNetwork } from "../../types/TezosNetwork";
 import { tzktUrls } from "../tezos/consts";
-import { multisigAddress } from "./consts";
 import { getAllMultiSigContracts } from "./fetch";
 
 jest.mock("axios");
@@ -15,9 +14,9 @@ describe("multisig fetch", () => {
 
     const result = await getAllMultiSigContracts(TezosNetwork.GHOSTNET);
     expect(mockedAxios.get).toBeCalledWith(
-      `${tzktUrls[TezosNetwork.GHOSTNET]}/v1/contracts/${
-        multisigAddress[TezosNetwork.GHOSTNET]
-      }/same?includeStorage=true&limit=10000`
+      `${
+        tzktUrls[TezosNetwork.GHOSTNET]
+      }/v1/contracts?typeHash=1963879877&codeHash=-1890025422&includeStorage=true&limit=10000`
     );
     expect(
       result.map(({ address, storage: { pending_ops, signers, threshold } }) => ({

--- a/src/utils/multisig/fetch.ts
+++ b/src/utils/multisig/fetch.ts
@@ -2,16 +2,15 @@ import axios from "axios";
 import { TezosNetwork } from "../../types/TezosNetwork";
 import { tzktUrls } from "../tezos/consts";
 import { RawTzktGetBigMapKeys, RawTzktGetSameMultisigs } from "../tzkt/types";
-import { multisigAddress } from "./consts";
-
 const MULTISIG_FETCH_LIMIT = 10000;
+const TYPE_HASH = 1963879877;
+const CODE_HASH = -1890025422;
 
 export const getAllMultiSigContracts = async (
   network: TezosNetwork
 ): Promise<RawTzktGetSameMultisigs> => {
   try {
-    const contractAddress = multisigAddress[network];
-    const url = `${tzktUrls[network]}/v1/contracts/${contractAddress}/same?includeStorage=true&limit=${MULTISIG_FETCH_LIMIT}`;
+    const url = `${tzktUrls[network]}/v1/contracts?typeHash=${TYPE_HASH}&codeHash=${CODE_HASH}&includeStorage=true&limit=${MULTISIG_FETCH_LIMIT}`;
     const { data } = await axios.get<RawTzktGetSameMultisigs>(url);
 
     return data;


### PR DESCRIPTION
## Proposed changes

They are the same for all networks and we don't have a first contract problem on new networks anymore.

compare outputs of:

https://api.ghostnet.tzkt.io/v1/contracts?codeHash=-1890025422&typeHash=1963879877&select=id&limit=1000
and
https://api.ghostnet.tzkt.io/v1/contracts/KT1Mqvf7bnYe4Ty2n7ZbGkdbebCd4WoTJUUp/same?select=id&limit=1000

https://api.tzkt.io/v1/contracts?codeHash=-1890025422&typeHash=1963879877&select=id&limit=1000
and
https://api.tzkt.io/v1/contracts/KT1Lw11GPDxpdWXWudFUUBMA2Cihevmt8QCf/same?select=id&limit=1000

## Types of changes

- [x] New feature
- [x] Refactor
