### PR TITLE
Add custom FormErrorMessage

### DIFF
--- a/src/assets/icons/Exclamation.tsx
+++ b/src/assets/icons/Exclamation.tsx
@@ -1,0 +1,25 @@
+import { Icon, IconProps } from "@chakra-ui/react";
+import colors from "../../style/colors";
+
+const ExclamationIcon: React.FC<IconProps> = props => {
+  return (
+    <Icon
+      width="12"
+      height="12"
+      viewBox="0 0 12 12"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <path
+        d="M6 3.66667V6.58333M6 8.33333H6.00583M11.25 6C11.25 8.89949 8.89949 11.25 6 11.25C3.1005 11.25 0.75 8.89949 0.75 6C0.75 3.1005 3.1005 0.75 6 0.75C8.89949 0.75 11.25 3.1005 11.25 6Z"
+        stroke={colors.orange}
+        strokeWidth="1.2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </Icon>
+  );
+};
+
+export default ExclamationIcon;

--- a/src/components/BuyTez/BuyTezForm.tsx
+++ b/src/components/BuyTez/BuyTezForm.tsx
@@ -7,7 +7,6 @@ import {
   ModalFooter,
   Box,
   Button,
-  FormErrorMessage,
 } from "@chakra-ui/react";
 import { FormProvider, useForm } from "react-hook-form";
 import { TezosNetwork } from "../../types/TezosNetwork";
@@ -15,6 +14,7 @@ import { navigateToExternalLink } from "../../utils/helpers";
 import { useSelectedNetwork } from "../../utils/hooks/assetsHooks";
 import { wertUrls } from "../../utils/tezos/consts";
 import { OwnedImplicitAccountsAutocomplete } from "../AddressAutocomplete";
+import { FormErrorMessage } from "../FormErrorMessage";
 
 const BuyTezForm = () => {
   const network = useSelectedNetwork();

--- a/src/components/CSVFileUploader/CSVFileUploadForm.tsx
+++ b/src/components/CSVFileUploader/CSVFileUploadForm.tsx
@@ -11,7 +11,6 @@ import {
   useToast,
   Text,
   Flex,
-  FormErrorMessage,
 } from "@chakra-ui/react";
 import Papa, { ParseResult } from "papaparse";
 import { FormProvider, useForm } from "react-hook-form";
@@ -26,6 +25,7 @@ import { OwnedAccountsAutocomplete } from "../AddressAutocomplete";
 import { parseOperation } from "./utils";
 import { makeFormOperations } from "../sendForm/types";
 import { useAsyncActionHandler } from "../../utils/hooks/useAsyncActionHandler";
+import { FormErrorMessage } from "../FormErrorMessage";
 
 type FormFields = {
   sender: RawPkh;

--- a/src/components/ChangePassword/ChangePasswordForm.tsx
+++ b/src/components/ChangePassword/ChangePasswordForm.tsx
@@ -3,7 +3,6 @@ import {
   Button,
   Text,
   FormControl,
-  FormErrorMessage,
   FormLabel,
   Input,
   ModalCloseButton,
@@ -20,6 +19,7 @@ import changeMnemonicPassword from "../../utils/redux/thunks/changeMnemonicPassw
 import { MIN_LENGTH } from "../Onboarding/masterPassword/password/EnterAndConfirmPassword";
 import { DynamicModalContext } from "../DynamicModal";
 import { useContext } from "react";
+import { FormErrorMessage } from "../FormErrorMessage";
 
 type ChangePasswordFormValues = {
   currentPassword: string;

--- a/src/components/ContactModal.tsx
+++ b/src/components/ContactModal.tsx
@@ -3,7 +3,6 @@ import {
   Button,
   Flex,
   FormControl,
-  FormErrorMessage,
   FormLabel,
   Heading,
   Input,
@@ -26,6 +25,7 @@ import { useContactExists } from "../utils/hooks/contactsHooks";
 import { useAppDispatch } from "../utils/redux/hooks";
 import { contactsActions } from "../utils/redux/slices/contactsSlice";
 import { CopyableAddress } from "./CopyableText";
+import { FormErrorMessage } from "./FormErrorMessage";
 
 export const UpsertContactModal: FC<{
   title: string;

--- a/src/components/FormErrorMessage.tsx
+++ b/src/components/FormErrorMessage.tsx
@@ -1,0 +1,16 @@
+import {
+  FormErrorMessageProps,
+  Icon,
+  FormErrorMessage as OriginalFormErrorMessage,
+} from "@chakra-ui/react";
+import colors from "../style/colors";
+import ExclamationIcon from "../assets/icons/Exclamation";
+
+export const FormErrorMessage = ({ children, ...props }: FormErrorMessageProps) => {
+  return (
+    <OriginalFormErrorMessage color={colors.orange} fontSize="12px" {...props}>
+      <Icon as={ExclamationIcon} mr="6px" />
+      {children}
+    </OriginalFormErrorMessage>
+  );
+};

--- a/src/components/Offboarding/OffboardingForm.tsx
+++ b/src/components/Offboarding/OffboardingForm.tsx
@@ -7,7 +7,6 @@ import {
   ModalFooter,
   Box,
   Button,
-  FormErrorMessage,
   Input,
   Checkbox,
   Divider,
@@ -16,6 +15,7 @@ import { FormProvider, useForm } from "react-hook-form";
 import WarningIcon from "../../assets/icons/Warning";
 import colors from "../../style/colors";
 import { useReset } from "../../utils/hooks/accountHooks";
+import { FormErrorMessage } from "../FormErrorMessage";
 
 const CONFIRMATION_CODE = "wasabi";
 

--- a/src/components/Onboarding/masterPassword/password/EnterAndConfirmPassword.tsx
+++ b/src/components/Onboarding/masterPassword/password/EnterAndConfirmPassword.tsx
@@ -1,15 +1,8 @@
-import {
-  Button,
-  Center,
-  FormControl,
-  FormErrorMessage,
-  FormLabel,
-  Input,
-  VStack,
-} from "@chakra-ui/react";
+import { Button, Center, FormControl, FormLabel, Input, VStack } from "@chakra-ui/react";
 import { useForm } from "react-hook-form";
 import { SupportedIcons } from "../../../CircleIcon";
 import ModalContentWrapper from "../../ModalContentWrapper";
+import { FormErrorMessage } from "../../../FormErrorMessage";
 
 export const MIN_LENGTH = 8;
 

--- a/src/components/Onboarding/masterPassword/password/EnterPassword.tsx
+++ b/src/components/Onboarding/masterPassword/password/EnterPassword.tsx
@@ -1,17 +1,9 @@
-import {
-  Button,
-  Center,
-  FormControl,
-  FormErrorMessage,
-  FormLabel,
-  Heading,
-  Input,
-  VStack,
-} from "@chakra-ui/react";
+import { Button, Center, FormControl, FormLabel, Heading, Input, VStack } from "@chakra-ui/react";
 import { useForm } from "react-hook-form";
 import { SupportedIcons } from "../../../CircleIcon";
 import ModalContentWrapper from "../../ModalContentWrapper";
 import { MIN_LENGTH } from "./EnterAndConfirmPassword";
+import { FormErrorMessage } from "../../../FormErrorMessage";
 
 const EnterPassword = ({
   onSubmit: onSubmitPassword,

--- a/src/components/Onboarding/verifySeedphrase/VerifySeedphrase.tsx
+++ b/src/components/Onboarding/verifySeedphrase/VerifySeedphrase.tsx
@@ -4,7 +4,6 @@ import {
   Box,
   Button,
   FormControl,
-  FormErrorMessage,
   InputGroup,
   InputLeftElement,
 } from "@chakra-ui/react";
@@ -14,6 +13,7 @@ import ModalContentWrapper from "../ModalContentWrapper";
 import { useForm } from "react-hook-form";
 import { Step, StepType, VerifySeedphraseStep } from "../useOnboardingModal";
 import { selectRandomElements } from "../../../utils/tezos/helpers";
+import { FormErrorMessage } from "../../FormErrorMessage";
 
 const VerifySeedphrase = ({
   goToStep,

--- a/src/components/SendFlow/MultisigAccount/FormPage.tsx
+++ b/src/components/SendFlow/MultisigAccount/FormPage.tsx
@@ -1,7 +1,6 @@
 import {
   Button,
   FormControl,
-  FormErrorMessage,
   FormLabel,
   IconButton,
   Input,
@@ -25,6 +24,7 @@ import {
   useOpenSignPageFormAction,
 } from "../../../components/SendFlow/onSubmitFormActionHooks";
 import { formDefaultValues, FormPageProps } from "../utils";
+import { FormErrorMessage } from "../../FormErrorMessage";
 
 export type FormValues = {
   name: string;

--- a/src/components/SendFlow/NFT/FormPage.tsx
+++ b/src/components/SendFlow/NFT/FormPage.tsx
@@ -1,7 +1,6 @@
 import {
   Flex,
   FormControl,
-  FormErrorMessage,
   FormLabel,
   Heading,
   Input,
@@ -28,6 +27,7 @@ import {
   useHandleOnSubmitFormActions,
   useOpenSignPageFormAction,
 } from "../onSubmitFormActionHooks";
+import { FormErrorMessage } from "../../FormErrorMessage";
 
 export type FormValues = {
   quantity: number;

--- a/src/components/SendFlow/Tez/FormPage.tsx
+++ b/src/components/SendFlow/Tez/FormPage.tsx
@@ -1,6 +1,5 @@
 import {
   FormControl,
-  FormErrorMessage,
   FormLabel,
   Input,
   InputGroup,
@@ -27,6 +26,7 @@ import {
   useHandleOnSubmitFormActions,
   useOpenSignPageFormAction,
 } from "../onSubmitFormActionHooks";
+import { FormErrorMessage } from "../../FormErrorMessage";
 
 export type FormValues = {
   sender: RawPkh;
@@ -121,7 +121,6 @@ const FormPage: React.FC<FormPageProps<FormValues>> = props => {
                 />
                 <InputRightElement>{TEZ}</InputRightElement>
               </InputGroup>
-              {/* TODO: make a custom FormErrorMessage because its styling cannot be applied through theme.ts */}
               {errors.prettyAmount && (
                 <FormErrorMessage data-testid="amount-error">
                   {errors.prettyAmount.message}

--- a/src/components/sendForm/components/SignButton.tsx
+++ b/src/components/sendForm/components/SignButton.tsx
@@ -1,12 +1,4 @@
-import {
-  Box,
-  Button,
-  FormControl,
-  FormErrorMessage,
-  FormLabel,
-  Input,
-  useToast,
-} from "@chakra-ui/react";
+import { Box, Button, FormControl, FormLabel, Input, useToast } from "@chakra-ui/react";
 import { TezosToolkit } from "@taquito/taquito";
 import React, { PropsWithChildren } from "react";
 import { useForm } from "react-hook-form";
@@ -22,6 +14,7 @@ import { useAsyncActionHandler } from "../../../utils/hooks/useAsyncActionHandle
 import { useSelectedNetwork } from "../../../utils/hooks/assetsHooks";
 import { makeToolkit } from "../../../utils/tezos";
 import { MIN_LENGTH } from "../../Onboarding/masterPassword/password/EnterAndConfirmPassword";
+import { FormErrorMessage } from "../../FormErrorMessage";
 
 export const SignWithGoogleButton: React.FC<
   PropsWithChildren<{

--- a/src/components/sendForm/steps/FillStep.tsx
+++ b/src/components/sendForm/steps/FillStep.tsx
@@ -4,7 +4,6 @@ import {
   Divider,
   Flex,
   FormControl,
-  FormErrorMessage,
   FormLabel,
   Heading,
   Input,
@@ -46,6 +45,7 @@ import { SendNFTRecapTile } from "../components/SendNFTRecapTile";
 import { toOperation, FormOperations, SendFormMode, makeFormOperations } from "../types";
 import { BatchRecap } from "./BatchRecap";
 import { Token } from "../../../types/Token";
+import { FormErrorMessage } from "../../FormErrorMessage";
 
 export const DelegateForm = ({
   onSubmit,


### PR DESCRIPTION
## Proposed changes

That's the only way to unify it and define a custom text colour

## Types of changes

- [x] New feature
## Steps to reproduce

fill in a form incorrectly

## Screenshots

| Before | After |
| --- | --- |
| <img width="482" alt="Screenshot 2023-08-21 at 21 42 05" src="https://github.com/trilitech/umami-v2/assets/129749432/98666146-51b8-4d20-bc41-481dbc167f96"> | <img width="485" alt="Screenshot 2023-08-21 at 21 36 37" src="https://github.com/trilitech/umami-v2/assets/129749432/29dc78e3-1f91-4ae4-baf2-29e44b6c38c2"> |


## Checklist
- [x] Screenshots are added (if any UI changes have been made)
