### PR TITLE
Fix pasteMnemonic in RestoreSeedPhase

### DIFF
--- a/src/components/Onboarding/restoreSeedphrase/RestoreSeedphrase.tsx
+++ b/src/components/Onboarding/restoreSeedphrase/RestoreSeedphrase.tsx
@@ -23,9 +23,12 @@ const RestoreSeedphrase = ({ goToStep }: { goToStep: (step: Step) => void }) => 
   const [mnemonicSize, setMnemonicSize] = useState("12");
 
   const pasteMnemonic = (mnemonic: string) => {
-    mnemonic.split(" ").forEach((word, i) => {
-      setFormValue(`word${i}`, word);
-    });
+    mnemonic
+      .split(" ")
+      .slice(0, Number(mnemonicSize))
+      .forEach((word, i) => {
+        setFormValue(`word${i}`, word);
+      });
     trigger();
   };
 


### PR DESCRIPTION
## Fix pasteMnemonic in RestoreSeedPhase

In the onboarding screen, users were able to paste 24words mnemonic and go to the next step when less than 24 words (e.g. 12 ) were selected in the selector. We shouldn't allow users to go to the next step and throw an error instead

## Types of changes

_Put an `x` in the boxes that apply_

- [x] Bugfix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation Update

## Steps to reproduce

Paste 24 words mnemonic in the onboarding screen when 12 words are selected

## Screenshots

https://github.com/trilitech/umami-v2/assets/128799322/7fcdcd36-e0bb-416f-a140-a22033919e03

