### PR TITLE
Use FormPage in Address book

### DIFF
--- a/src/components/SendFlow/Tez/FormPage.test.tsx
+++ b/src/components/SendFlow/Tez/FormPage.test.tsx
@@ -14,9 +14,8 @@ import { dynamicModalContextMock } from "../../../mocks/dynamicModal";
 import { estimate } from "../../../utils/tezos";
 import { mockEstimatedFee } from "../../../mocks/helpers";
 import { FormPageProps } from "../utils";
-import { RawPkh } from "../../../types/Address";
 
-const fixture = (props: FormPageProps<FormValues> & { recipient?: RawPkh } = {}) => (
+const fixture = (props: FormPageProps<FormValues> = {}) => (
   <Modal isOpen={true} onClose={() => {}}>
     <FormPage {...props} />
   </Modal>
@@ -79,17 +78,21 @@ describe("<Form />", () => {
       expect(screen.getByLabelText("Amount")).toHaveValue(1);
     });
 
-    it("renders a form with recipient and disables recipient if it's provided", async () => {
+    it("renders a form with prefilled recipient", async () => {
       render(
         fixture({
-          recipient: mockImplicitAccount(1).address.pkh,
+          form: {
+            sender: "",
+            prettyAmount: "",
+            recipient: mockImplicitAccount(1).address.pkh,
+          },
         })
       );
 
       await waitFor(() => {
         expect(screen.getByLabelText("To")).toHaveValue(mockImplicitAccount(1).address.pkh);
       });
-      expect(screen.getByLabelText("To")).toBeDisabled();
+      expect(screen.getByLabelText("To")).toBeEnabled();
     });
   });
 

--- a/src/components/SendFlow/Tez/FormPage.tsx
+++ b/src/components/SendFlow/Tez/FormPage.tsx
@@ -43,18 +43,7 @@ const toOperation = (formValues: FormValues): TezOperation => ({
   recipient: parsePkh(formValues.recipient),
 });
 
-type TezFormPageProps = FormPageProps<FormValues> & { recipient?: RawPkh };
-
-const tezFormDefaultValues = (props: TezFormPageProps) => ({
-  ...formDefaultValues(props),
-  // use the recipient from the form as fallback in case the recipient is not known
-  // (e.g. when going back from the sign page)
-  recipient: props.recipient || props.form?.recipient,
-});
-
-const FormPage: React.FC<TezFormPageProps> = props => {
-  const { sender, recipient } = props;
-
+const FormPage: React.FC<FormPageProps<FormValues>> = props => {
   const openSignPage = useOpenSignPageFormAction({
     SignPage,
     signPageExtraData: undefined,
@@ -72,7 +61,7 @@ const FormPage: React.FC<TezFormPageProps> = props => {
 
   const form = useForm<FormValues>({
     mode: "onBlur",
-    defaultValues: tezFormDefaultValues(props),
+    defaultValues: formDefaultValues(props),
   });
   const {
     formState: { isValid, errors },
@@ -89,7 +78,7 @@ const FormPage: React.FC<TezFormPageProps> = props => {
             <FormControl mb={2} isInvalid={!!errors.sender}>
               <OwnedAccountsAutocomplete
                 label="From"
-                isDisabled={!!sender}
+                isDisabled={!!props.sender}
                 inputName="sender"
                 allowUnknown={false}
               />
@@ -100,12 +89,7 @@ const FormPage: React.FC<TezFormPageProps> = props => {
               )}
             </FormControl>
             <FormControl mb={2} isInvalid={!!errors.recipient}>
-              <KnownAccountsAutocomplete
-                label="To"
-                inputName="recipient"
-                allowUnknown
-                isDisabled={!!recipient}
-              />
+              <KnownAccountsAutocomplete label="To" inputName="recipient" allowUnknown />
               {errors.recipient && (
                 <FormErrorMessage data-testid="recipient-error">
                   {errors.recipient.message}

--- a/src/views/addressBook/ContactTable.tsx
+++ b/src/views/addressBook/ContactTable.tsx
@@ -42,7 +42,13 @@ const ContactTable: React.FC<{ contacts: Contact[] }> = ({ contacts }) => {
                         <IconAndTextBtn
                           icon={MdArrowOutward}
                           label="Send"
-                          onClick={() => openWith(<FormPage recipient={contact.pkh} />)}
+                          onClick={() =>
+                            openWith(
+                              <FormPage
+                                form={{ sender: "", recipient: contact.pkh, prettyAmount: "" }}
+                              />
+                            )
+                          }
                         />
                       </Flex>
                       <ContactMenu contact={contact} />


### PR DESCRIPTION
## Use FormPage in Address book

Changed the FormPage in Tez to allow prefilled recipient value. This is used in AddressBook component. if the field "recipient" is provided, the form should disable the input with the prefilled input (just like sender in the form page props).
Note that the recipient still need to fall back to value in the form.recipient for going back from the signpage to show the selected recipient value again on the form page.

## Types of changes

_Put an `x` in the boxes that apply_

- [ ] Bugfix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] Documentation Update

## Steps
Go to send through the homepage, account tile and addrss book to make sure nothing is broken 

## Screenshots

https://github.com/trilitech/umami-v2/assets/128799322/877ac57e-3d31-407e-b5e6-737f878c07d8



## Checklist

- [x] Tests that prove my fix is effective or that my feature works have been added
- [x] Documentation has been added (if appropriate)
- [ ] Screenshots are added (if any UI changes have been made)
- [ ] All TODOs have a corresponding task created (and the link is attached to it)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
