### PR TITLE
Improve stack traces

### DIFF
--- a/config-overrides.js
+++ b/config-overrides.js
@@ -41,9 +41,6 @@ module.exports = function override(config) {
       ],
     });
   }
-  // keep sources as they are for error reporting
-  // source maps do not work without devtools enabled in electron
-  // TODO: find a better solution, check how rollbar & sentry handle this
-  config.optimization.minimize = false;
+
   return config;
 };


### PR DESCRIPTION
## Proposed changes

This allows us to save ~40MB on the app size

it was there just to have some tooling to read stack traces. for now we can stick to https://github.com/mifi/stacktracify, later on we'll just be uploading our sourcemaps to an error tracker and it'll take it from there