### PR TITLE
Undelegate send flow

### DIFF
--- a/src/components/AccountCard/AccountCard.test.tsx
+++ b/src/components/AccountCard/AccountCard.test.tsx
@@ -13,7 +13,7 @@ import { mockDelegationOperation } from "../../mocks/delegations";
 import { hedgehoge, tzBtsc } from "../../mocks/fa12Tokens";
 import { uUSD } from "../../mocks/fa2Tokens";
 import { multisigOperation, multisigs } from "../../mocks/multisig";
-import { act, fireEvent, render, screen, within } from "../../mocks/testUtils";
+import { act, fireEvent, render, screen, waitFor, within } from "../../mocks/testUtils";
 import { mockTzktTezTransfer } from "../../mocks/transfers";
 import { formatPkh, prettyTezAmount } from "../../utils/format";
 import { multisigToAccount } from "../../utils/multisig/helpers";
@@ -217,7 +217,7 @@ describe("<AccountCard />", () => {
       expect(modal).toHaveTextContent(/delegate/i);
     });
 
-    it("Given an account has an active delegation, it show display the delegation and CTA buttons to change delegate or undelegate", () => {
+    it("Given an account has an active delegation, it show display the delegation and CTA buttons to change delegate or undelegate", async () => {
       store.dispatch(
         updateDelegations([
           {
@@ -255,8 +255,10 @@ describe("<AccountCard />", () => {
       expect(removeDelegateBtn).toBeInTheDocument();
 
       fireEvent.click(changeDelegateBtn);
-      const modal = screen.getByRole("dialog");
-      expect(modal).toHaveTextContent(/delegate/i);
+      await waitFor(() => {
+        const modal = screen.getByRole("dialog");
+        expect(modal).toHaveTextContent(/delegate/i);
+      });
     });
   });
 

--- a/src/components/AccountCard/AssetsPanel/AssetPanel.test.tsx
+++ b/src/components/AccountCard/AssetsPanel/AssetPanel.test.tsx
@@ -13,8 +13,6 @@ describe("<AssetPanel/>", () => {
         tokens={[]}
         operationDisplays={[]}
         network={TezosNetwork.MAINNET}
-        delegation={null}
-        onDelegate={() => {}}
       />
     );
 

--- a/src/components/AccountCard/AssetsPanel/AssetsPanel.tsx
+++ b/src/components/AccountCard/AssetsPanel/AssetsPanel.tsx
@@ -3,18 +3,18 @@ import React from "react";
 import { FiExternalLink } from "react-icons/fi";
 import { Account, AccountType } from "../../../types/Account";
 import { FA12TokenBalance, FA2TokenBalance, NFTBalance } from "../../../types/TokenBalance";
-import { Delegation } from "../../../types/Delegation";
+import { makeDelegation } from "../../../types/Delegation";
 import { OperationDisplay } from "../../../types/Transfer";
 import { buildTzktAddressUrl } from "../../../utils/tzkt/helpers";
 import { OperationListDisplay } from "../../../views/home/OpertionList/OperationListDisplay";
 import { IconAndTextBtnLink } from "../../IconAndTextBtn";
-import { DelegationMode } from "../../sendForm/types";
 import SmallTab from "../../SmallTab";
 import { DelegationDisplay } from "./DelegationDisplay";
 import MultisigPendingAccordion from "./MultisigPendingAccordion";
 import { NFTsGrid } from "./NFTsGrid";
 import { TokenList } from "./TokenList";
 import { TezosNetwork } from "../../../types/TezosNetwork";
+import { useAllDelegations } from "../../../utils/hooks/assetsHooks";
 
 export const AssetsPanel: React.FC<{
   tokens: Array<FA12TokenBalance | FA2TokenBalance>;
@@ -22,10 +22,10 @@ export const AssetsPanel: React.FC<{
   account: Account;
   operationDisplays: OperationDisplay[];
   network: TezosNetwork;
-  delegation: Delegation | null;
-  onDelegate: (opts?: DelegationMode["data"]) => void;
-}> = ({ tokens, nfts, account, operationDisplays, network, delegation, onDelegate }) => {
+}> = ({ tokens, nfts, account, operationDisplays, network }) => {
   const isMultisig = account.type === AccountType.MULTISIG;
+  const rawDelegations = useAllDelegations()[account.address.pkh];
+  const delegation = rawDelegations ? makeDelegation(rawDelegations) : null;
 
   return (
     <Tabs
@@ -66,7 +66,7 @@ export const AssetsPanel: React.FC<{
         </TabPanel>
 
         <TabPanel data-testid="account-card-delegation-tab">
-          <DelegationDisplay delegation={delegation} onDelegate={onDelegate} />
+          <DelegationDisplay delegation={delegation} />
         </TabPanel>
 
         <TabPanel data-testid="account-card-nfts-tab" height="100%" overflow="hidden">

--- a/src/components/AccountCard/index.tsx
+++ b/src/components/AccountCard/index.tsx
@@ -1,8 +1,6 @@
 import { useContext } from "react";
 import { Account } from "../../types/Account";
-import { makeDelegation } from "../../types/Delegation";
 import {
-  useAllDelegations,
   useGetAccountAllTokens,
   useGetAccountBalance,
   useGetAccountNFTs,
@@ -10,7 +8,6 @@ import {
   useGetDollarBalance,
   useSelectedNetwork,
 } from "../../utils/hooks/assetsHooks";
-import { useSendFormModal } from "../../views/home/useSendFormModal";
 import { DynamicModalContext } from "../DynamicModal";
 import { useReceiveModal } from "../ReceiveModal";
 import SendTezForm from "../SendFlow/Tez/FormPage";
@@ -20,20 +17,17 @@ export const AccountCard: React.FC<{ account: Account }> = ({ account }) => {
   const accountBalance = useGetAccountBalance();
   const getDollarBalance = useGetDollarBalance();
 
-  const delegation = useAllDelegations()[account.address.pkh];
   const getTokens = useGetAccountAllTokens();
   const getNFTs = useGetAccountNFTs();
   const getOperations = useGetAccountOperationDisplays();
   const network = useSelectedNetwork();
 
-  const { onOpen: onOpenSend, modalElement: sendModal } = useSendFormModal();
   const { onOpen: onOpenReceive, modalElement: receiveModal } = useReceiveModal();
   const { openWith } = useContext(DynamicModalContext);
 
   const balance = accountBalance(account.address.pkh);
   const dollarBalance = getDollarBalance(account.address.pkh);
 
-  const delegationOp = delegation ? makeDelegation(delegation) : null;
   const tokens = getTokens(account.address.pkh);
   const nfts = getNFTs(account.address.pkh);
   const operations = getOperations(account.address.pkh);
@@ -41,12 +35,6 @@ export const AccountCard: React.FC<{ account: Account }> = ({ account }) => {
     <>
       <AccountCardDisplay
         onSend={() => openWith(<SendTezForm sender={account} />)}
-        onDelegate={opts =>
-          onOpenSend({
-            mode: { type: "delegation", data: opts },
-            sender: account.address.pkh,
-          })
-        }
         pkh={account.address.pkh}
         label={account.label}
         balance={balance}
@@ -59,9 +47,7 @@ export const AccountCard: React.FC<{ account: Account }> = ({ account }) => {
         operationDisplays={operations}
         account={account}
         network={network}
-        delegation={delegationOp}
       />
-      {sendModal}
       {receiveModal}
     </>
   );

--- a/src/utils/tezos/params.ts
+++ b/src/utils/tezos/params.ts
@@ -26,12 +26,6 @@ export const operationsToBatchParams = (operations: Operation[]): ParamsWithKind
           source: operation.sender.pkh,
           delegate: undefined,
         };
-      case "undelegation":
-        return {
-          kind: OpKind.DELEGATION,
-          source: operation.sender.pkh,
-          delegate: undefined,
-        };
       case "fa1.2":
       case "fa2":
         return {


### PR DESCRIPTION
## Proposed changes

* Refactor AccountCard, AssetPannel. We don't pass the onDelegate or delegations props all the way down anymore
* Remove useSendForm and use FormPage and SignPage from #406 in AssetPannel, DelegationView

[Task link]()

## Types of changes

- [ ] Bugfix
- [x] New feature
- [x] Refactor
- [x] Breaking change
- [ ] UI fix

## Steps to reproduce

Go to delegation page or account card and cluck end delegation

## Screenshots

https://github.com/trilitech/umami-v2/assets/128799322/80296d71-21fd-4145-8380-fa2ae18d63ce



<img width="516" alt="Screenshot 2023-08-30 at 09 12 08" src="https://github.com/trilitech/umami-v2/assets/128799322/e5d69e39-b663-4665-9f92-594f378597a3">


