### PR TITLE
Mock chakra Modal & its descendants

### DIFF
--- a/src/components/BuyTez/BuyTezForm.tsx
+++ b/src/components/BuyTez/BuyTezForm.tsx
@@ -43,8 +43,12 @@ const BuyTezForm = () => {
         {isMainnet && (
           <>
             <Text textAlign="center">Please select the recipient account.</Text>
-            <ModalBody data-testid="buy-tez-selector">
-              <FormControl paddingY={5} isInvalid={!!errors.recipient}>
+            <ModalBody>
+              <FormControl
+                data-testid="buy-tez-selector"
+                paddingY={5}
+                isInvalid={!!errors.recipient}
+              >
                 <OwnedImplicitAccountsAutocomplete
                   label="Recipient Account"
                   inputName="recipient"

--- a/src/mocks/helpers.ts
+++ b/src/mocks/helpers.ts
@@ -16,11 +16,6 @@ export const fillPassword = (value: string) => {
   fireEvent.change(passwordInput, { target: { value } });
 };
 
-export const closeModal = () => {
-  const closeModalButton = screen.getByLabelText("Close");
-  fireEvent.click(closeModalButton);
-};
-
 export const dispatchMockAccounts = (accounts: ImplicitAccount[]) => {
   store.dispatch(accountsSlice.actions.addAccount(accounts));
 };

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -18,6 +18,7 @@ import { act } from "@testing-library/react";
 import { tokensActions } from "./utils/redux/slices/tokensSlice";
 import errorsSlice from "./utils/redux/slices/errorsSlice";
 import { mockUseToast } from "./mocks/toast";
+import React from "react";
 
 failOnConsole();
 
@@ -47,12 +48,38 @@ jest.mock("react-identicons", () => {
 // Add missing browser APIs
 Object.assign(window, { TextDecoder, TextEncoder, crypto: webcrypto, scrollTo: jest.fn() });
 
+const MockModal = ({ children, isOpen }: any) => {
+  return React.createElement("div", { "data-testid": "mock-modal" }, isOpen ? children : null);
+};
+const MockModalHeader = ({ children }: any) => {
+  return React.createElement("header", { id: "modal-header" }, children);
+};
+const MockModalContent = ({ children }: any) => {
+  return React.createElement(
+    "section",
+    { role: "dialog", "aria-labelledby": "modal-header", "aria-modal": true },
+    children
+  );
+};
+
+const MockModalInnerComponent = ({ children }: any) => React.createElement("div", {}, children);
+
+const MockModalCloseButton = ({ children }: any) =>
+  React.createElement("button", { "aria-label": "Close" }, children);
+
 jest.mock("@chakra-ui/react", () => {
   return {
     ...jest.requireActual("@chakra-ui/react"),
     // Mock taost since it has an erratic behavior in RTL
     // https://github.com/chakra-ui/chakra-ui/issues/2969
     useToast: mockUseToast,
+    Modal: MockModal,
+    ModalContent: MockModalContent,
+    ModalBody: MockModalInnerComponent,
+    ModalHeader: MockModalHeader,
+    ModalFooter: MockModalInnerComponent,
+    ModalOverlay: MockModalInnerComponent,
+    ModalCloseButton: MockModalCloseButton,
   };
 });
 

--- a/src/views/batch/BatchView.test.tsx
+++ b/src/views/batch/BatchView.test.tsx
@@ -1,12 +1,7 @@
 import { TezosToolkit } from "@taquito/taquito";
 import { makeFormOperations } from "../../components/sendForm/types";
 import { mockImplicitAccount, mockImplicitAddress } from "../../mocks/factories";
-import {
-  closeModal,
-  dispatchMockAccounts,
-  selectSender,
-  mockEstimatedFee,
-} from "../../mocks/helpers";
+import { dispatchMockAccounts, mockEstimatedFee } from "../../mocks/helpers";
 import { act, fireEvent, render, screen, waitFor, within } from "../../mocks/testUtils";
 import { TezosNetwork } from "../../types/TezosNetwork";
 import { useGetSecretKey } from "../../utils/hooks/accountUtils";
@@ -32,45 +27,6 @@ beforeEach(() => {
   jest.mocked(submitBatch).mockResolvedValue({ opHash: "foo" } as any);
 });
 
-const addToBatchViaUI = async (amount: number, senderLabel: string, recipientPkh: string) => {
-  const amountInput = screen.getByLabelText(/amount/i);
-  fireEvent.change(amountInput, { target: { value: Number(amount) } });
-  const recipientInput = screen.getByLabelText(/^to$/i);
-  fireEvent.change(recipientInput, { target: { value: recipientPkh } });
-
-  selectSender(senderLabel);
-
-  const addToBatchButton = screen.getByRole("button", {
-    name: /insert into batch/i,
-  });
-
-  await waitFor(() => {
-    expect(addToBatchButton).toBeEnabled();
-  });
-
-  fireEvent.click(addToBatchButton);
-};
-
-// Can't run in beforeEach because it requires a render
-// Also if you were to do it by different means, it slows down the whole test suite by 20s
-const addItemsToBatchViaUI = async () => {
-  const sendButton = screen.getByText(/send/i);
-  fireEvent.click(sendButton);
-  fireEvent.click(sendButton);
-
-  await waitFor(() => {
-    expect(screen.getByLabelText(/amount/i)).toBeInTheDocument();
-  });
-  await addToBatchViaUI(33, mockImplicitAccount(1).label, mockImplicitAddress(9).pkh);
-  await addToBatchViaUI(55, mockImplicitAccount(1).label, mockImplicitAddress(4).pkh);
-  await addToBatchViaUI(9, mockImplicitAccount(1).label, mockImplicitAddress(2).pkh);
-
-  await addToBatchViaUI(3, mockImplicitAccount(2).label, mockImplicitAddress(2).pkh);
-  await addToBatchViaUI(22, mockImplicitAccount(2).label, mockImplicitAddress(4).pkh);
-  await addToBatchViaUI(52, mockImplicitAccount(2).label, mockImplicitAddress(4).pkh);
-  closeModal();
-};
-
 describe("<BatchView />", () => {
   describe("Given no batch has beed added", () => {
     it("a message 'no batches are present' is displayed", () => {
@@ -78,14 +34,6 @@ describe("<BatchView />", () => {
 
       expect(screen.getByText(/0 pending/i)).toBeInTheDocument();
       expect(screen.getByText(/your batch is currently empty/i)).toBeInTheDocument();
-    });
-
-    test("user can add transactions to batches and it displays batches of all accounts by default", async () => {
-      render(fixture());
-      await addItemsToBatchViaUI();
-
-      expect(screen.queryByText(/your batch is currently empty/i)).not.toBeInTheDocument();
-      expect(await screen.findAllByTestId(/batch-table/i)).toHaveLength(2);
     });
   });
 


### PR DESCRIPTION
## Proposed changes

In tests we don't need any functionality related to modals themselves. All we need is a container to place our components into

This gives up to 15x speedup in runtime in some test cases

All in all it gives ~1.5x speedup both locally and on CI

Before changes [job run](https://github.com/trilitech/umami-v2/actions/runs/6021424555/job/16334444213)
After changes [job run](https://github.com/trilitech/umami-v2/actions/runs/6024318474/job/16342966495) 

I removed the closeModal functionality in tests just because the test itself was rather an e2e test, didn't add much value, but did add much overhead for the mocks themselves


## Types of changes

- [x] Refactor

## Steps to reproduce

## Screenshots

| Before | Now |
| ------ | --- |
|  <img width="929" alt="Screenshot 2023-08-30 at 09 48 09" src="https://github.com/trilitech/umami-v2/assets/129749432/7b657405-6da8-4065-8800-6bd4d977239f">  |  <img width="385" alt="Screenshot 2023-08-30 at 12 32 06" src="https://github.com/trilitech/umami-v2/assets/129749432/89f53995-728d-40e6-8eed-8d17991928a0">  |

## Checklist

- [x] Tests that prove my fix is effective or that my feature works have been added
- [x] Screenshots are added (if any UI changes have been made)
