### PR TITLE
Fix multisig operations

### DIFF
--- a/src/components/sendForm/SendForm.test.tsx
+++ b/src/components/sendForm/SendForm.test.tsx
@@ -41,8 +41,6 @@ import { estimate, executeOperations, makeToolkit } from "../../utils/tezos";
 // These tests might take long in the CI
 jest.setTimeout(10000);
 
-jest.mock("../../multisig/multisigUtils");
-
 jest.mock("../../GoogleAuth", () => ({
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   GoogleAuth: require("../../mocks/GoogleAuthMock").GoogleAuthMock,

--- a/src/utils/tezos/estimate.ts
+++ b/src/utils/tezos/estimate.ts
@@ -4,10 +4,10 @@ import { makeToolkit, operationsToBatchParams, sumTez } from "./helpers";
 import BigNumber from "bignumber.js";
 
 export const estimate = async (
-  { operations, signer }: AccountOperations,
+  operations: AccountOperations,
   network: TezosNetwork
 ): Promise<BigNumber> => {
-  const tezosToolkit = await makeToolkit({ type: "fake", signer: signer, network });
+  const tezosToolkit = await makeToolkit({ type: "fake", signer: operations.signer, network });
 
   const estimations = await tezosToolkit.estimate.batch(operationsToBatchParams(operations));
   // The way taquito works we need to take the max of suggestedFeeMutez and totalCost

--- a/src/utils/tezos/execute.ts
+++ b/src/utils/tezos/execute.ts
@@ -1,17 +1,13 @@
 import { TezosToolkit } from "@taquito/taquito";
-import { makeMultisigProposeOperation } from "../../types/Operation";
 import { AccountOperations } from "../../components/sendForm/types";
 import { operationsToWalletParams } from "./helpers";
 
 export const executeOperations = async (
-  { type, operations, sender }: AccountOperations,
+  operations: AccountOperations,
   tezosToolkit: TezosToolkit
 ): Promise<{
   opHash: string;
 }> => {
-  const ops =
-    type === "implicit" ? operations : [makeMultisigProposeOperation(sender.address, operations)];
-
-  const params = operationsToWalletParams(ops);
+  const params = operationsToWalletParams(operations);
   return tezosToolkit.wallet.batch(params).send();
 };

--- a/src/utils/tezos/helpers.ts
+++ b/src/utils/tezos/helpers.ts
@@ -4,7 +4,12 @@ import { Curves, InMemorySigner } from "@taquito/signer";
 import { ParamsWithKind, TezosToolkit, WalletParamsWithKind } from "@taquito/taquito";
 import axios from "axios";
 import { shuffle } from "lodash";
-import { FA12Transfer, FA2Transfer, Operation } from "../../types/Operation";
+import {
+  FA12Transfer,
+  FA2Transfer,
+  Operation,
+  makeMultisigProposeOperation,
+} from "../../types/Operation";
 import { SignerConfig } from "../../types/SignerConfig";
 import { TezosNetwork } from "../../types/TezosNetwork";
 import { PublicKeyPair } from "../mnemonic";
@@ -13,6 +18,7 @@ import { nodeUrls, tzktUrls } from "./consts";
 import { FakeSigner } from "./fakeSigner";
 import BigNumber from "bignumber.js";
 import { OpKind, TransactionOperationParameter } from "@taquito/rpc";
+import { AccountOperations } from "../../components/sendForm/types";
 
 export const addressExists = async (
   pkh: string,
@@ -233,9 +239,18 @@ export const operationToTaquitoOperation = (operation: Operation): ParamsWithKin
   }
 };
 
-export const operationsToBatchParams = (operations: Operation[]): ParamsWithKind[] =>
-  operations.map(operationToTaquitoOperation);
+export const operationsToBatchParams = ({
+  type: operationsType,
+  operations: originalOperations,
+  sender,
+}: AccountOperations): ParamsWithKind[] => {
+  const operations =
+    operationsType === "implicit"
+      ? originalOperations
+      : [makeMultisigProposeOperation(sender.address, originalOperations)];
+  return operations.map(operationToTaquitoOperation);
+};
 
 export const operationsToWalletParams = operationsToBatchParams as (
-  operations: Operation[]
+  operations: AccountOperations
 ) => WalletParamsWithKind[];


### PR DESCRIPTION
## Proposed changes

we couldn't estimate any multisig operations because they were considered implicit operations. I made the code that decides the approach (execute vs propose) a part of `operationsToBatchParams` so that both `execute` and `estimate` have the same underlying implementation

## Types of changes

- [x] Bugfix

## Steps to reproduce

estimate any multisig operation

## Screenshots

### before

https://github.com/trilitech/umami-v2/assets/129749432/4ebf1391-5340-4d89-b566-3670365cacb8


### after
https://github.com/trilitech/umami-v2/assets/129749432/8e91f002-c849-46fe-8e0c-44b401b8198c



## Checklist

- [x] Tests that prove my fix is effective or that my feature works have been added
- [x] Screenshots are added (if any UI changes have been made)
