### PR TITLE
fix electron:start

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "engines": {
     "node": ">=18.15.0 <19.0.0"
   },
+  "main": "public/electron.js",
   "scripts": {
     "build-storybook": "storybook build",
     "build": "yarn generate-ts-types && react-app-rewired build",


### PR DESCRIPTION
## Fix electron:start

The electron:start was broken and we couldnn't run the app on electron locally

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] UI fix

## Steps to reproduce

yarn start 
yarn electron:start on another terminal

## Screenshots

Add the screenshots of how the app used to look like and how it looks now

| Before | Now |
| ------ | --- |
| <img width="549" alt="Screenshot 2023-09-05 at 14 09 41" src="https://github.com/trilitech/umami-v2/assets/128799322/ebe9ce4b-6182-4bcb-a2d9-ed73f0805eed">  |  <img width="1416" alt="Screenshot 2023-09-05 at 14 10 03" src="https://github.com/trilitech/umami-v2/assets/128799322/d73fa8e2-005e-48a4-b3d8-284fd8521788">   |


## Checklist

- [ ] Tests that prove my fix is effective or that my feature works have been added
- [ ] Documentation has been added (if appropriate)
- [ ] Screenshots are added (if any UI changes have been made)
- [ ] All TODOs have a corresponding task created (and the link is attached to it)
