### PR TITLE
Persist batches between networks

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -22,7 +22,8 @@
     "jest/valid-expect": "warn",
     "@typescript-eslint/await-thenable": "warn",
     "@typescript-eslint/no-unnecessary-condition": "warn",
-    "unused-imports/no-unused-imports": "warn"
+    "unused-imports/no-unused-imports": "warn",
+    "@typescript-eslint/ban-ts-comment": ["warn", { "ts-ignore": "allow-with-description" }]
   },
   "overrides": [
     {

--- a/src/components/SendFlow/utils.tsx
+++ b/src/components/SendFlow/utils.tsx
@@ -6,7 +6,7 @@ import {
   useGetImplicitAccount,
   useGetOwnedAccount,
 } from "../../utils/hooks/accountHooks";
-import { useClearBatch } from "../../utils/hooks/assetsHooks";
+import { useClearBatch } from "../../utils/hooks/batchesHooks";
 import { DynamicModalContext } from "../DynamicModal";
 import { AccountOperations, makeAccountOperations } from "../sendForm/types";
 import BigNumber from "bignumber.js";

--- a/src/components/sendForm/SendForm.tsx
+++ b/src/components/sendForm/SendForm.tsx
@@ -4,7 +4,7 @@ import { useEffect, useRef, useState } from "react";
 import { RawPkh } from "../../types/Address";
 import { Operation } from "../../types/Operation";
 import { useGetBestSignerForAccount, useGetOwnedAccount } from "../../utils/hooks/accountHooks";
-import { useClearBatch } from "../../utils/hooks/assetsHooks";
+import { useClearBatch } from "../../utils/hooks/batchesHooks";
 import { useAsyncActionHandler } from "../../utils/hooks/useAsyncActionHandler";
 import { useAppDispatch } from "../../utils/redux/hooks";
 import { assetsActions } from "../../utils/redux/slices/assetsSlice";

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -19,6 +19,7 @@ import errorsSlice from "./utils/redux/slices/errorsSlice";
 import { mockUseToast } from "./mocks/toast";
 import React from "react";
 import { networksActions } from "./utils/redux/slices/networks";
+import { batchesActions } from "./utils/redux/slices/batches";
 
 failOnConsole();
 
@@ -91,6 +92,7 @@ afterEach(() => {
     store.dispatch(tokensActions.reset());
     store.dispatch(errorsSlice.actions.reset());
     store.dispatch(networksActions.reset());
+    store.dispatch(batchesActions.reset());
   });
 });
 

--- a/src/utils/hooks/assetsHooks.ts
+++ b/src/utils/hooks/assetsHooks.ts
@@ -13,12 +13,11 @@ import {
   sortOperationsByTimestamp,
 } from "../../views/operations/operationsUtils";
 import { mutezToTez } from "../format";
-import { useAppDispatch, useAppSelector } from "../redux/hooks";
+import { useAppSelector } from "../redux/hooks";
 import { useAllAccounts } from "./accountHooks";
 import { getTotalTezBalance } from "./accountUtils";
 import { useGetToken } from "./tokensHooks";
 import { RawPkh } from "../../types/Address";
-import assetsSlice from "../redux/slices/assetsSlice";
 import { Account } from "../../types/Account";
 import { Delegate } from "../../types/Delegate";
 import { useSelectedNetwork } from "./networkHooks";
@@ -159,20 +158,6 @@ export const useGetAccountBalance = () => {
 
 export const useAllDelegations = () => {
   return useAppSelector(s => s.assets.delegations);
-};
-
-export const useBatches = () => useAppSelector(s => s.assets.batches);
-
-export const useClearBatch = () => {
-  const dispatch = useAppDispatch();
-  return (account: Account) =>
-    dispatch(assetsSlice.actions.clearBatch({ pkh: account.address.pkh }));
-};
-
-export const useRemoveBatchItem = () => {
-  const dispatch = useAppDispatch();
-  return (account: Account, index: number) =>
-    dispatch(assetsSlice.actions.removeBatchItem({ pkh: account.address.pkh, index }));
 };
 
 export const useBakerList = (): Delegate[] => {

--- a/src/utils/hooks/batchesHooks.ts
+++ b/src/utils/hooks/batchesHooks.ts
@@ -1,0 +1,25 @@
+import { Account } from "../../types/Account";
+import { useAppDispatch, useAppSelector } from "../redux/hooks";
+import { batchesActions } from "../redux/slices/batches";
+import { useSelectedNetwork } from "./networkHooks";
+
+export const useBatches = () => {
+  const network = useSelectedNetwork();
+  return useAppSelector(s => s.batches[network.name] || []);
+};
+
+export const useClearBatch = () => {
+  const dispatch = useAppDispatch();
+  const network = useSelectedNetwork();
+
+  return (account: Account) =>
+    dispatch(batchesActions.clear({ pkh: account.address.pkh, network }));
+};
+
+export const useRemoveBatchItem = () => {
+  const dispatch = useAppDispatch();
+  const network = useSelectedNetwork();
+
+  return (account: Account, index: number) =>
+    dispatch(batchesActions.removeItem({ pkh: account.address.pkh, index, network }));
+};

--- a/src/utils/redux/reducer.ts
+++ b/src/utils/redux/reducer.ts
@@ -8,6 +8,7 @@ import contactsSlice from "./slices/contactsSlice";
 import multisigsSlice from "./slices/multisigsSlice";
 import errorsSlice from "./slices/errorsSlice";
 import { networksSlice } from "./slices/networks";
+import { batchesSlice } from "./slices/batches";
 
 const rootPersistConfig = {
   key: "root",
@@ -29,6 +30,7 @@ const rootReducers = combineReducers({
   tokens: tokensSlice.reducer,
   errors: errorsSlice.reducer,
   networks: networksSlice.reducer,
+  batches: batchesSlice.reducer,
 });
 
 export default persistReducer(rootPersistConfig, rootReducers);

--- a/src/utils/redux/slices/batches.test.ts
+++ b/src/utils/redux/slices/batches.test.ts
@@ -1,0 +1,192 @@
+import { ImplicitOperations, makeAccountOperations } from "../../../components/sendForm/types";
+import {
+  mockDelegationOperation,
+  mockImplicitAccount,
+  mockNftOperation,
+  mockTezOperation,
+} from "../../../mocks/factories";
+import { waitFor } from "../../../mocks/testUtils";
+import { DefaultNetworks, Network } from "../../../types/Network";
+import { Operation } from "../../../types/Operation";
+import store from "../store";
+import { batchesActions } from "./batches";
+
+const { add, clear, removeItem } = batchesActions;
+
+describe("batchesSlice", () => {
+  describe.each(DefaultNetworks)("on $name", network => {
+    const anotherNetwork = DefaultNetworks.find(n => n.name !== network.name) as Network;
+
+    describe("add", () => {
+      it("can add operations to a non-existing batch", async () => {
+        const accountOperations = makeAccountOperations(
+          mockImplicitAccount(1),
+          mockImplicitAccount(1),
+          [mockTezOperation(0)]
+        );
+        store.dispatch(add({ operations: accountOperations, network }));
+        await waitFor(() => {
+          expect(store.getState().batches[network.name]).toEqual([accountOperations]);
+        });
+      });
+
+      it("can add new operations to the same account", async () => {
+        const transfers: Operation[] = [];
+
+        for (const operation of [
+          mockTezOperation(1),
+          mockDelegationOperation(1),
+          mockNftOperation(1),
+        ]) {
+          const accountOperations = makeAccountOperations(
+            mockImplicitAccount(1),
+            mockImplicitAccount(1),
+            [operation]
+          );
+          store.dispatch(add({ operations: accountOperations, network }));
+          transfers.push(operation);
+
+          await waitFor(() => {
+            expect(store.getState().batches[network.name]).toEqual([
+              makeAccountOperations(mockImplicitAccount(1), mockImplicitAccount(1), transfers),
+            ]);
+          });
+        }
+      });
+
+      it("can add operations to different sender accounts", async () => {
+        const accountOperations = makeAccountOperations(
+          mockImplicitAccount(1),
+          mockImplicitAccount(1),
+          [mockTezOperation(0)]
+        ) as ImplicitOperations;
+        store.dispatch(add({ operations: accountOperations, network }));
+        const anotherAccountFormOperations = {
+          ...accountOperations,
+          sender: mockImplicitAccount(2),
+        };
+        store.dispatch(add({ operations: anotherAccountFormOperations, network }));
+        await waitFor(() => {
+          expect(store.getState().batches[network.name]).toEqual([
+            accountOperations,
+            anotherAccountFormOperations,
+          ]);
+        });
+      });
+    });
+
+    describe("clear", () => {
+      it("removes everything under a given account", async () => {
+        const accountOperations = makeAccountOperations(
+          mockImplicitAccount(1),
+          mockImplicitAccount(1),
+          [mockTezOperation(0), mockDelegationOperation(0), mockNftOperation(0)]
+        );
+        const pkh = mockImplicitAccount(1).address.pkh;
+        store.dispatch(add({ operations: accountOperations, network }));
+        await waitFor(() => {
+          expect(store.getState().batches[network.name]).toEqual([accountOperations]);
+        });
+        store.dispatch(clear({ pkh, network }));
+        await waitFor(() => {
+          expect(store.getState().batches[network.name]).toEqual([]);
+        });
+      });
+
+      it("does nothing if the batch is on another network", async () => {
+        const accountOperations = makeAccountOperations(
+          mockImplicitAccount(1),
+          mockImplicitAccount(1),
+          [mockTezOperation(0), mockDelegationOperation(0), mockNftOperation(0)]
+        );
+        const pkh = mockImplicitAccount(1).address.pkh;
+        store.dispatch(add({ operations: accountOperations, network }));
+        store.dispatch(add({ operations: accountOperations, network: anotherNetwork }));
+
+        await waitFor(() => {
+          expect(store.getState().batches[network.name]).toEqual([accountOperations]);
+        });
+        expect(store.getState().batches[anotherNetwork.name]).toEqual([accountOperations]);
+        store.dispatch(clear({ pkh, network }));
+        await waitFor(() => {
+          expect(store.getState().batches[network.name]).toEqual([]);
+        });
+        expect(store.getState().batches[anotherNetwork.name]).toEqual([accountOperations]);
+      });
+    });
+
+    describe("removeItem", () => {
+      it("removes the whole batch if there is just one operation", async () => {
+        const accountOperations = makeAccountOperations(
+          mockImplicitAccount(1),
+          mockImplicitAccount(1),
+          [mockTezOperation(0)]
+        );
+        const pkh = mockImplicitAccount(1).address.pkh;
+        store.dispatch(add({ operations: accountOperations, network }));
+        await waitFor(() => {
+          expect(store.getState().batches[network.name]).toEqual([accountOperations]);
+        });
+        store.dispatch(removeItem({ pkh, index: 0, network }));
+        await waitFor(() => {
+          expect(store.getState().batches[network.name]).toEqual([]);
+        });
+      });
+
+      it("removes the operation at the given index", async () => {
+        const accountOperations = makeAccountOperations(
+          mockImplicitAccount(1),
+          mockImplicitAccount(1),
+          [mockTezOperation(0), mockDelegationOperation(0), mockNftOperation(0)]
+        );
+        const pkh = mockImplicitAccount(1).address.pkh;
+        store.dispatch(add({ operations: accountOperations, network }));
+        await waitFor(() => {
+          expect(store.getState().batches[network.name]).toEqual([accountOperations]);
+        });
+        store.dispatch(removeItem({ pkh, index: 1, network }));
+        const newFormOperations = {
+          ...accountOperations,
+          operations: [mockTezOperation(0), mockNftOperation(0)],
+        };
+        await waitFor(() => {
+          expect(store.getState().batches[network.name]).toEqual([newFormOperations]);
+        });
+      });
+
+      it("does nothing if the index is out of bounds", async () => {
+        const accountOperations = makeAccountOperations(
+          mockImplicitAccount(1),
+          mockImplicitAccount(1),
+          [mockTezOperation(0)]
+        );
+        const pkh = mockImplicitAccount(1).address.pkh;
+        store.dispatch(add({ operations: accountOperations, network }));
+        await waitFor(() => {
+          expect(store.getState().batches[network.name]).toEqual([accountOperations]);
+        });
+        store.dispatch(removeItem({ pkh, index: 5, network }));
+        await waitFor(() => {
+          expect(store.getState().batches[network.name]).toEqual([accountOperations]);
+        });
+      });
+
+      it("does nothing if the batch does not exist", async () => {
+        const accountOperations = makeAccountOperations(
+          mockImplicitAccount(1),
+          mockImplicitAccount(1),
+          [mockTezOperation(0)]
+        );
+        store.dispatch(add({ operations: accountOperations, network }));
+        await waitFor(() => {
+          expect(store.getState().batches[network.name]).toEqual([accountOperations]);
+        });
+
+        store.dispatch(removeItem({ pkh: mockImplicitAccount(2).address.pkh, index: 5, network }));
+        await waitFor(() => {
+          expect(store.getState().batches[network.name]).toEqual([accountOperations]);
+        });
+      });
+    });
+  });
+});

--- a/src/utils/redux/slices/batches.ts
+++ b/src/utils/redux/slices/batches.ts
@@ -1,0 +1,70 @@
+import { createSlice } from "@reduxjs/toolkit";
+import { AccountOperations } from "../../../components/sendForm/types";
+import { DefaultNetworks, Network, NetworkName } from "../../../types/Network";
+import { findIndex, fromPairs } from "lodash";
+import { RawPkh } from "../../../types/Address";
+
+type State = Record<NetworkName, AccountOperations[] | undefined>;
+
+const initialState: State = fromPairs(DefaultNetworks.map(network => [network, []]));
+
+export const batchesSlice = createSlice({
+  name: "batches",
+  initialState,
+  // @ts-ignore: TS2589 Type instantiation is excessively deep and possibly infinite
+  reducers: {
+    reset: () => initialState,
+    // Don't use this action directly. Use thunk estimateAndUpdateBatch
+    add: (
+      state,
+      {
+        payload: { operations, network },
+      }: { payload: { operations: AccountOperations; network: Network } }
+    ) => {
+      if (!(network.name in state)) {
+        state[network.name] = [];
+      }
+      const batches = state[network.name] as AccountOperations[];
+      const existing = batches.find(
+        batch => batch.sender.address.pkh === operations.sender.address.pkh
+      );
+      if (existing) {
+        existing.operations.push(...operations.operations);
+        return;
+      }
+      batches.push(operations);
+    },
+    clear: (
+      state,
+      { payload: { pkh, network } }: { type: string; payload: { pkh: RawPkh; network: Network } }
+    ) => {
+      const batches = state[network.name] || [];
+      const index = findIndex(batches, batch => batch.sender.address.pkh === pkh);
+      if (index === -1) {
+        return;
+      }
+      batches.splice(index, 1);
+    },
+    removeItem: (
+      state,
+      {
+        payload: { pkh, index, network },
+      }: { payload: { pkh: RawPkh; index: number; network: Network } }
+    ) => {
+      const batches = state[network.name] || [];
+      const batchIndex = findIndex(batches, batch => batch.sender.address.pkh === pkh);
+      if (batchIndex === -1) {
+        return;
+      }
+      const existingBatch = batches[batchIndex];
+      if (index < existingBatch.operations.length) {
+        existingBatch.operations.splice(index, 1);
+      }
+      if (existingBatch.operations.length === 0) {
+        batches.splice(batchIndex, 1);
+      }
+    },
+  },
+});
+
+export const batchesActions = batchesSlice.actions;

--- a/src/utils/redux/thunks/estimateAndUpdateBatch.test.ts
+++ b/src/utils/redux/thunks/estimateAndUpdateBatch.test.ts
@@ -27,7 +27,7 @@ describe("estimateAndUpdateBatch", () => {
       store.dispatch(action);
       expect(jest.mocked(estimate)).toHaveBeenCalledWith(accountOperations, network);
       await waitFor(() => {
-        expect(store.getState().assets.batches).toEqual([accountOperations]);
+        expect(store.getState().batches[network.name]).toEqual([accountOperations]);
       });
     });
 
@@ -44,7 +44,7 @@ describe("estimateAndUpdateBatch", () => {
       store.dispatch(estimateAndUpdateBatch(accountOperations, network));
 
       await waitFor(() => {
-        expect(store.getState().assets.batches).toEqual([accountOperations]);
+        expect(store.getState().batches[network.name]).toEqual([accountOperations]);
       });
 
       const failedOperation = mockDelegationOperation(0);
@@ -54,7 +54,7 @@ describe("estimateAndUpdateBatch", () => {
 
       await expect(() => store.dispatch(action)).rejects.toThrowError("Estimation failed");
       expect(jest.mocked(estimate)).toHaveBeenCalledWith(accountOperations, network);
-      expect(store.getState().assets.batches).toEqual([accountOperations]);
+      expect(store.getState().batches[network.name]).toEqual([accountOperations]);
     });
   });
 });

--- a/src/utils/redux/thunks/estimateAndUpdateBatch.ts
+++ b/src/utils/redux/thunks/estimateAndUpdateBatch.ts
@@ -2,8 +2,8 @@ import { AnyAction, ThunkAction } from "@reduxjs/toolkit";
 import { AccountOperations } from "../../../components/sendForm/types";
 import { Network } from "../../../types/Network";
 import { estimate } from "../../tezos";
-import assetsSlice from "../slices/assetsSlice";
 import { RootState } from "../store";
+import { batchesActions } from "../slices/batches";
 
 export const estimateAndUpdateBatch = (
   operations: AccountOperations,
@@ -12,6 +12,6 @@ export const estimateAndUpdateBatch = (
   return async dispatch => {
     // check that the operation can be executed at least on its own
     await estimate(operations, network);
-    dispatch(assetsSlice.actions.addToBatch(operations));
+    dispatch(batchesActions.add({ operations, network }));
   };
 };

--- a/src/views/batch/BatchPage.test.tsx
+++ b/src/views/batch/BatchPage.test.tsx
@@ -6,7 +6,8 @@ import { useGetSecretKey } from "../../utils/hooks/accountUtils";
 import store from "../../utils/redux/store";
 import { executeOperations } from "../../utils/tezos";
 import BatchPage from "./BatchPage";
-import { assetsActions } from "../../utils/redux/slices/assetsSlice";
+import { batchesActions } from "../../utils/redux/slices/batches";
+import { MAINNET } from "../../types/Network";
 
 jest.mock("../../utils/hooks/accountUtils");
 jest.mock("../../utils/tezos");
@@ -37,24 +38,26 @@ describe("<BatchPage />", () => {
 
     it("shows the number of different pending batches", () => {
       store.dispatch(
-        assetsActions.addToBatch(
-          makeAccountOperations(mockImplicitAccount(1), mockImplicitAccount(1), [
+        batchesActions.add({
+          network: MAINNET,
+          operations: makeAccountOperations(mockImplicitAccount(1), mockImplicitAccount(1), [
             mockTezOperation(0),
             mockTezOperation(0),
-          ])
-        )
+          ]),
+        })
       );
       render(<BatchPage />);
 
       expect(screen.getByText(/1 pending/i)).toBeInTheDocument();
       act(() => {
         store.dispatch(
-          assetsActions.addToBatch(
-            makeAccountOperations(mockImplicitAccount(2), mockImplicitAccount(2), [
+          batchesActions.add({
+            network: MAINNET,
+            operations: makeAccountOperations(mockImplicitAccount(2), mockImplicitAccount(2), [
               mockTezOperation(0),
               mockTezOperation(0),
-            ])
-          )
+            ]),
+          })
         );
       });
       expect(screen.getByText(/2 pending/i)).toBeInTheDocument();
@@ -63,20 +66,22 @@ describe("<BatchPage />", () => {
 
   it("renders all the batches", () => {
     store.dispatch(
-      assetsActions.addToBatch(
-        makeAccountOperations(mockImplicitAccount(1), mockImplicitAccount(1), [
+      batchesActions.add({
+        network: MAINNET,
+        operations: makeAccountOperations(mockImplicitAccount(1), mockImplicitAccount(1), [
           mockTezOperation(0),
           mockTezOperation(0),
-        ])
-      )
+        ]),
+      })
     );
     store.dispatch(
-      assetsActions.addToBatch(
-        makeAccountOperations(mockImplicitAccount(2), mockImplicitAccount(2), [
+      batchesActions.add({
+        network: MAINNET,
+        operations: makeAccountOperations(mockImplicitAccount(2), mockImplicitAccount(2), [
           mockTezOperation(0),
           mockTezOperation(0),
-        ])
-      )
+        ]),
+      })
     );
 
     render(<BatchPage />);
@@ -87,12 +92,13 @@ describe("<BatchPage />", () => {
   describe("action buttons", () => {
     beforeEach(() => {
       store.dispatch(
-        assetsActions.addToBatch(
-          makeAccountOperations(mockImplicitAccount(2), mockImplicitAccount(2), [
+        batchesActions.add({
+          network: MAINNET,
+          operations: makeAccountOperations(mockImplicitAccount(2), mockImplicitAccount(2), [
             mockTezOperation(0),
             mockTezOperation(0),
-          ])
-        )
+          ]),
+        })
       );
     });
 

--- a/src/views/batch/BatchPage.tsx
+++ b/src/views/batch/BatchPage.tsx
@@ -11,7 +11,7 @@ import NoItems from "../../components/NoItems";
 import { DynamicModalContext } from "../../components/DynamicModal";
 import SendTezForm from "../../components/SendFlow/Tez/FormPage";
 import CSVFileUploadForm from "../../components/CSVFileUploader/CSVFileUploadForm";
-import { useBatches } from "../../utils/hooks/assetsHooks";
+import { useBatches } from "../../utils/hooks/batchesHooks";
 
 export const FilterController: React.FC<{ batchPending: number }> = props => {
   return (

--- a/src/views/batch/BatchView.tsx
+++ b/src/views/batch/BatchView.tsx
@@ -2,7 +2,6 @@ import { Box, Button, Divider, Flex, IconButton, Text } from "@chakra-ui/react";
 import React, { useContext } from "react";
 import { AccountOperations } from "../../components/sendForm/types";
 import { Operation } from "../../types/Operation";
-import { useClearBatch, useRemoveBatchItem } from "../../utils/hooks/assetsHooks";
 import { AccountSmallTile } from "../../components/AccountSelector/AccountSmallTile";
 import colors from "../../style/colors";
 import pluralize from "pluralize";
@@ -18,6 +17,7 @@ import { Account } from "../../types/Account";
 import { OperationView } from "./OperationView";
 import { OperationRecipient } from "./OperationRecipient";
 import { useSendFormModal } from "../home/useSendFormModal";
+import { useClearBatch, useRemoveBatchItem } from "../../utils/hooks/batchesHooks";
 
 const RightHeader = ({ operations: accountOperations }: { operations: AccountOperations }) => {
   const { type: operationsType, sender, operations } = accountOperations;


### PR DESCRIPTION
## Proposed changes

Now batches are not erased when you switch networks

## Types of changes

- [x] Bugfix
- [x] Breaking change

## Screenshots

https://github.com/trilitech/umami-v2/assets/129749432/0ec3c727-c87e-488c-97cf-5331d273a87d


