### PR TITLE
Fix icon warning

### DIFF
--- a/src/components/SideNavbar.tsx
+++ b/src/components/SideNavbar.tsx
@@ -25,9 +25,9 @@ const MenuItem: React.FC<
     icon: IconType;
     to: string;
   } & FlexProps
-> = props => {
+> = ({ icon, label, to, ...flexProps }) => {
   return (
-    <Link to={props.to}>
+    <Link to={to}>
       <Flex
         _hover={{
           background: colors.gray[800],
@@ -40,10 +40,10 @@ const MenuItem: React.FC<
         alignItems="center"
         border={40}
         cursor="pointer"
-        {...props}
+        {...flexProps}
       >
-        <Icon w={6} h={6} ml={2} mr={4} as={props.icon} />
-        <Text size="sm">{props.label}</Text>
+        <Icon w={6} h={6} ml={2} mr={4} as={icon} />
+        <Text size="sm">{label}</Text>
       </Flex>
     </Link>
   );


### PR DESCRIPTION
## Fix icon warning

There was a console error due to how the props were applied in the MenuItem compoenent

<img width="1036" alt="Screenshot 2023-09-07 at 09 42 13" src="https://github.com/trilitech/umami-v2/assets/128799322/1620663a-edfc-4c5b-93a6-07e5e4f78ed6">

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] UI fix

