### PR TITLE
Change decryption error message

### DIFF
--- a/src/utils/crypto/AES.test.ts
+++ b/src/utils/crypto/AES.test.ts
@@ -4,6 +4,8 @@ import { decrypt, encrypt } from "./AES";
 
 const password = "password";
 
+const DECRYPTION_ERROR_MESSAGE = "Error decrypting data: Invalid password";
+
 describe("AES", () => {
   it("encryption and decryption works", async () => {
     const encrypted = await encrypt(mnemonic1, password);
@@ -24,21 +26,21 @@ describe("AES", () => {
   it("V1 decryption fails with V2 encryption", async () => {
     const encrypted = await encrypt(mnemonic1, password);
 
-    await expect(decrypt(encrypted, password, "V1")).rejects.toThrowError("Error decrypting data");
+    await expect(decrypt(encrypted, password, "V1")).rejects.toThrowError(DECRYPTION_ERROR_MESSAGE);
   });
 
   it("decryption fails with cyclic password", async () => {
     // Used to work in V1. Now it fails.
     const encrypted = await encrypt(mnemonic1, "abc");
 
-    await expect(decrypt(encrypted, "abcabc")).rejects.toThrowError("Error decrypting data");
+    await expect(decrypt(encrypted, "abcabc")).rejects.toThrowError(DECRYPTION_ERROR_MESSAGE);
   });
 
   it("decryption fails with wrong password", async () => {
     const encrypted = await encrypt(mnemonic1, password);
 
     await expect(decrypt(encrypted, `wrong ${password}`)).rejects.toThrowError(
-      "Error decrypting data"
+      DECRYPTION_ERROR_MESSAGE
     );
   });
 });

--- a/src/utils/crypto/AES.ts
+++ b/src/utils/crypto/AES.ts
@@ -54,6 +54,6 @@ export const decrypt = async (
     );
     return Buffer.from(decrypted).toString("utf-8");
   } catch (error: any) {
-    throw new Error(`Error decrypting data: ${error.message || error}`);
+    throw new Error(`Error decrypting data: Invalid password`);
   }
 };


### PR DESCRIPTION
## Change decryption error message

We change the decryption error message to a more user friendly message "invalid password" since most likely that is the case.

## Types of changes

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] UI fix

## Steps to reproduce

## Screenshots
<img width="608" alt="Screenshot 2023-09-11 at 10 36 16" src="https://github.com/trilitech/umami-v2/assets/128799322/5b507388-978f-49c4-bd95-579c0756a887">
