### PR TITLE
Fix module mapping for tzkt-api in jest settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,7 +157,8 @@
   "jest": {
     "moduleNameMapper": {
       "axios": "axios/dist/node/axios.cjs",
-      "@ledgerhq/devices/hid-framing": "@ledgerhq/devices/lib/hid-framing"
+      "@ledgerhq/devices/hid-framing": "@ledgerhq/devices/lib/hid-framing",
+      "@tzkt/oazapfts/runtime": "@tzkt/oazapfts/lib/runtime"
     },
     "watchPathIgnorePatterns": [
       "src/integration"

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -95,8 +95,3 @@ afterEach(() => {
     store.dispatch(batchesActions.reset());
   });
 });
-
-// Fixes: Cannot find module '@tzkt/oazapfts/runtime' from 'node_modules/@tzkt/sdk-api/build/main/index.js'
-jest.mock("@tzkt/sdk-api", () => {
-  return {};
-});


### PR DESCRIPTION
## Proposed changes

jest doesn't have correct mapping for the package  

## Types of changes

- [ ] Bugfix
- [ ] New feature
- [x] Refactor
- [ ] Breaking change
- [ ] UI fix

## Steps to reproduce

remove these lines in setupTests on main and see how everything fails
