### PR TITLE
Fixed multisig signer tile

### DIFF
--- a/src/components/AccountDrawer/AssetsPanel/MultisigPendingAccordion/MultisigSignerTileDisplay.test.tsx
+++ b/src/components/AccountDrawer/AssetsPanel/MultisigPendingAccordion/MultisigSignerTileDisplay.test.tsx
@@ -8,8 +8,8 @@ const pkh = mockImplicitAccount(0).address.pkh;
 const label = "my label";
 
 describe("<MultisigSignerTileDisplay />", () => {
+  const shrinkedAddress = formatPkh(pkh);
   it("renders the right icon with a shrinked address and label l for known addresses", () => {
-    const shrinkedAddress = formatPkh(pkh);
     render(
       <MultisigSignerTileDisplay
         kind="contact"
@@ -66,7 +66,7 @@ describe("<MultisigSignerTileDisplay />", () => {
     expect(screen.getByText(label)).toBeInTheDocument();
   });
 
-  it("renders the right icon with a full address and no label for unknown addresses", () => {
+  it("renders the right icon with no label for unknown addresses", () => {
     render(
       <MultisigSignerTileDisplay
         kind="unknown"
@@ -77,7 +77,7 @@ describe("<MultisigSignerTileDisplay />", () => {
       />
     );
     expect(screen.getByTestId("unknown-contact-icon")).toBeInTheDocument();
-    expect(screen.getByText(pkh)).toBeInTheDocument();
+    expect(screen.getByText(shrinkedAddress)).toBeInTheDocument();
     expect(screen.queryByText(label)).not.toBeInTheDocument();
   });
 });

--- a/src/components/AccountDrawer/AssetsPanel/MultisigPendingAccordion/MultisigSignerTileDisplay.tsx
+++ b/src/components/AccountDrawer/AssetsPanel/MultisigPendingAccordion/MultisigSignerTileDisplay.tsx
@@ -16,13 +16,7 @@ export const MultisigSignerTileDisplay: React.FC<{
   return (
     <AccountTileBase
       icon={getIcon(kind, pkh)}
-      leftElement={
-        <LabelAndAddress
-          label={kind === "unknown" ? undefined : label}
-          pkh={pkh}
-          fullPkh={kind === "unknown"}
-        />
-      }
+      leftElement={<LabelAndAddress label={kind === "unknown" ? undefined : label} pkh={pkh} />}
       rightElement={<MultisigActionButton isLoading={isLoading} {...rest} />}
     />
   );

--- a/src/components/AccountTile/AccountTileDisplay.tsx
+++ b/src/components/AccountTile/AccountTileDisplay.tsx
@@ -42,17 +42,13 @@ export const AccountTileBase: React.FC<
   );
 };
 
-export const LabelAndAddress: React.FC<{ label?: string; pkh: string; fullPkh?: boolean }> = ({
-  label,
-  pkh,
-  fullPkh = false,
-}) => {
+export const LabelAndAddress: React.FC<{ label?: string; pkh: string }> = ({ label, pkh }) => {
   return (
     <Box m={4} data-testid="account-identifier">
       {label && <Heading size="md">{label}</Heading>}
       <Flex alignItems="center">
         <Text size="sm" color="text.dark">
-          {fullPkh ? pkh : formatPkh(pkh)}
+          {formatPkh(pkh)}
         </Text>
       </Flex>
     </Box>


### PR DESCRIPTION
## Fixed multisig signer tile

The Multisig signer tile's UI breaks when the address is unknown. This PR fixes this issue 

[Task link]()

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] UI fix

## Steps to reproduce

## Screenshots

Add the screenshots of how the app used to look like and how it looks now

| Before | Now |
| ------ | --- |
| <img width="385" alt="Screenshot 2023-09-21 at 16 34 00" src="https://github.com/trilitech/umami-v2/assets/128799322/9bd585f6-6a37-4c5b-9be0-72bba18ea667">| <img width="471" alt="Screenshot 2023-09-21 at 16 33 06" src="https://github.com/trilitech/umami-v2/assets/128799322/5730c757-1747-4d3f-bacb-746ff71256a4">    |

## Checklist

- [ ] Tests that prove my fix is effective or that my feature works have been added
- [ ] Documentation has been added (if appropriate)
- [ ] Screenshots are added (if any UI changes have been made)
- [ ] All TODOs have a corresponding task created (and the link is attached to it)
