### PR TITLE
Fix form label margin

### DIFF
--- a/src/style/theme.ts
+++ b/src/style/theme.ts
@@ -83,7 +83,7 @@ const theme = extendTheme({
     FormLabel: {
       baseStyle: {
         fontWeight: "600",
-        marginBottom: "4px",
+        marginBottom: "12px",
         size: "md",
       },
       sizes,


### PR DESCRIPTION

The margin between the label and input should be 12px

## Types of changes

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] UI fix

## Steps to reproduce

## Screenshots

Add the screenshots of how the app used to look like and how it looks now

| Before | Now |
| ------ | --- |
|  <img width="443" alt="Screenshot 2023-09-27 at 02 48 30" src="https://github.com/trilitech/umami-v2/assets/128799322/211d0f25-10df-4829-a0fa-1aca52ef4444">|   <img width="460" alt="Screenshot 2023-09-27 at 02 48 09" src="https://github.com/trilitech/umami-v2/assets/128799322/ce37ad7c-95fb-4c52-a2df-c7815ae5c8fb">|

## Checklist

- [ ] Tests that prove my fix is effective or that my feature works have been added
- [ ] Documentation has been added (if appropriate)
- [ ] Screenshots are added (if any UI changes have been made)
- [ ] All TODOs have a corresponding task created (and the link is attached to it)
