### PR TITLE
Remove unnecessary calls to operations

### DIFF
--- a/src/utils/hooks/assetsHooks.ts
+++ b/src/utils/hooks/assetsHooks.ts
@@ -146,7 +146,3 @@ export const useIsLoading = () => {
 export const useLastTimeUpdated = () => {
   return useAppSelector(state => state.assets.lastTimeUpdated);
 };
-
-export const useGetLatestOperations = () => {
-  return useAppSelector(state => state.assets.latestOperations);
-};

--- a/src/utils/redux/slices/assetsSlice.test.ts
+++ b/src/utils/redux/slices/assetsSlice.test.ts
@@ -24,7 +24,6 @@ describe("assetsSlice", () => {
       refetchTrigger: 0,
       lastTimeUpdated: null,
       isLoading: false,
-      latestOperations: [],
     });
   });
 
@@ -46,7 +45,6 @@ describe("assetsSlice", () => {
       refetchTrigger: 0,
       lastTimeUpdated: null,
       isLoading: false,
-      latestOperations: [],
     });
 
     store.dispatch(
@@ -72,7 +70,6 @@ describe("assetsSlice", () => {
       refetchTrigger: 0,
       lastTimeUpdated: null,
       isLoading: false,
-      latestOperations: [],
     });
   });
 
@@ -106,7 +103,6 @@ describe("assetsSlice", () => {
       refetchTrigger: 0,
       lastTimeUpdated: null,
       isLoading: false,
-      latestOperations: [],
     });
   });
 
@@ -134,7 +130,6 @@ describe("assetsSlice", () => {
       refetchTrigger: 0,
       lastTimeUpdated: null,
       isLoading: false,
-      latestOperations: [],
     });
   });
 
@@ -160,7 +155,6 @@ describe("assetsSlice", () => {
       refetchTrigger: 0,
       lastTimeUpdated: null,
       isLoading: false,
-      latestOperations: [],
     });
   });
 

--- a/src/utils/redux/slices/assetsSlice.ts
+++ b/src/utils/redux/slices/assetsSlice.ts
@@ -3,7 +3,7 @@ import { DelegationOperation } from "@tzkt/sdk-api";
 import { compact, groupBy, mapValues } from "lodash";
 import accountsSlice from "./accountsSlice";
 import { TezTransfer, TokenTransfer } from "../../../types/Transfer";
-import { TzktAccount, TzktCombinedOperation } from "../../tezos";
+import { TzktAccount } from "../../tezos";
 import { fromRaw, RawTokenBalance, TokenBalance } from "../../../types/TokenBalance";
 import { Delegate } from "../../../types/Delegate";
 import { RawPkh } from "../../../types/Address";
@@ -22,7 +22,6 @@ type State = {
     tez: Record<string, TezTransfer[] | undefined>;
     tokens: Record<TransactionId, TokenTransfer | undefined>;
   };
-  latestOperations: TzktCombinedOperation[];
   bakers: Delegate[];
   conversionRate: number | null; // XTZ/USD conversion rate
   refetchTrigger: number;
@@ -45,7 +44,6 @@ const initialState: State = {
   },
   transfers: { tez: {}, tokens: {} },
   delegationLevels: {},
-  latestOperations: [],
   bakers: [],
   conversionRate: null,
   refetchTrigger: 0,
@@ -108,9 +106,6 @@ const assetsSlice = createSlice({
     },
     setLastTimeUpdated: (state, { payload: lastTimeUpdated }: { payload: string }) => {
       state.lastTimeUpdated = lastTimeUpdated;
-    },
-    updateOperations: (state, { payload }: { payload: TzktCombinedOperation[] }) => {
-      state.latestOperations = payload;
     },
   },
 });

--- a/src/utils/useAssetsPolling.ts
+++ b/src/utils/useAssetsPolling.ts
@@ -11,11 +11,9 @@ import { tokensActions } from "./redux/slices/tokensSlice";
 import {
   getAccounts,
   getBakers,
-  getCombinedOperations,
   getLatestBlockLevel,
   getTezosPriceInUSD,
   getTokenBalances,
-  getTokenTransfers,
 } from "./tezos";
 import errorsSlice from "./redux/slices/errorsSlice";
 import getErrorContext from "./getErrorContext";
@@ -51,35 +49,6 @@ const updateTokenBalances = async (dispatch: AppDispatch, network: Network, pkhs
   dispatch(assetsActions.updateTokenBalance(tokenBalances.flat()));
 };
 
-// TODO: check if needed at all because
-// we load them manually on drawer opening
-// and on operations page opening
-export const fetchOperationsAndUpdateTokensInfo = async (
-  dispatch: AppDispatch,
-  network: Network,
-  addresses: RawPkh[],
-  options?: {
-    lastId?: number;
-    limit?: number;
-    sort?: "asc" | "desc";
-  }
-) => {
-  const operations = await getCombinedOperations(addresses, network, options);
-  const tokenTransfers = await getTokenTransfers(
-    operations.map(op => op.id),
-    network
-  );
-
-  dispatch(assetsActions.updateTokenTransfers(tokenTransfers));
-  dispatch(tokensActions.addTokens({ network, tokens: tokenTransfers.map(t => t.token) }));
-  return operations;
-};
-
-const updateOperations = async (dispatch: AppDispatch, network: Network, pkhs: RawPkh[]) => {
-  const operations = await fetchOperationsAndUpdateTokensInfo(dispatch, network, pkhs);
-  dispatch(assetsActions.updateOperations(operations));
-};
-
 const updateAccountAssets = async (
   dispatch: AppDispatch,
   network: Network,
@@ -104,7 +73,6 @@ const updateAccountAssets = async (
       updatePendingOperations(dispatch, network, multisigs),
       updateTezBalances(dispatch, network, allAccountAddresses),
       updateTokenBalances(dispatch, network, allAccountAddresses),
-      updateOperations(dispatch, network, allAccountAddresses),
     ]);
     dispatch(assetsActions.setLastTimeUpdated(new Date().toUTCString()));
   } finally {


### PR DESCRIPTION
## Proposed changes

Since we don't use the latest operations anymore and load the operations just in time when they are needed we can skip polling them each 15 seconds saving 3reqs/15 seconds

## Types of changes

- [ ] Bugfix
- [ ] New feature
- [x] Refactor
- [ ] Breaking change
- [ ] UI fix

## Checklist

- [ ] Tests that prove my fix is effective or that my feature works have been added
- [ ] Documentation has been added (if appropriate)
- [ ] Screenshots are added (if any UI changes have been made)
- [ ] All TODOs have a corresponding task created (and the link is attached to it)
