### PR TITLE
Update forms to use address tiles instead of disabled inputs

### DIFF
--- a/src/components/AddressAutocomplete/AddressAutocomplete.tsx
+++ b/src/components/AddressAutocomplete/AddressAutocomplete.tsx
@@ -3,7 +3,7 @@ import { get } from "lodash";
 import { useId, useState } from "react";
 import { FieldValues, Path, RegisterOptions, useFormContext } from "react-hook-form";
 import { Account } from "../../types/Account";
-import { isAddressValid } from "../../types/Address";
+import { isAddressValid, parsePkh } from "../../types/Address";
 import { Contact } from "../../types/Contact";
 import {
   useAllAccounts,
@@ -16,6 +16,7 @@ import { Suggestions } from "./Suggestions";
 import XMark from "../../assets/icons/XMark";
 import ChevronDownIcon from "../../assets/icons/ChevronDown";
 import colors from "../../style/colors";
+import AddressTile from "../AddressTile/AddressTile";
 
 // <T extends FieldValues> is needed to be compatible with the useForm's type parameter (FormData)
 // <U extends Path<T>> makes sure that we can pass in only valid inputName that exists in FormData
@@ -112,6 +113,10 @@ export const AddressAutocomplete = <T extends FieldValues, U extends Path<T>>({
     }
   };
 
+  if (isDisabled) {
+    return <AddressTile address={parsePkh(getValues(inputName))} />;
+  }
+
   return (
     <Box data-testid={`address-autocomplete-${inputName}`}>
       <FormLabel htmlFor={inputId}>{label}</FormLabel>
@@ -119,7 +124,6 @@ export const AddressAutocomplete = <T extends FieldValues, U extends Path<T>>({
         <Input
           {...style}
           id={inputId}
-          isDisabled={isDisabled}
           aria-label={inputName}
           value={rawValue}
           onFocus={() => {

--- a/src/components/BuyTez/BuyTezForm.test.tsx
+++ b/src/components/BuyTez/BuyTezForm.test.tsx
@@ -1,8 +1,8 @@
 import { Modal } from "@chakra-ui/react";
-import { act, render, screen, waitFor } from "../../mocks/testUtils";
+import { render, screen, waitFor } from "../../mocks/testUtils";
 import store from "../../utils/redux/store";
 import BuyTezForm from "./BuyTezForm";
-import { GHOSTNET, MAINNET } from "../../types/Network";
+import { GHOSTNET } from "../../types/Network";
 import { networksActions } from "../../utils/redux/slices/networks";
 import { RawPkh } from "../../types/Address";
 import { mockImplicitAccount } from "../../mocks/factories";
@@ -16,17 +16,16 @@ const fixture = (recipient?: RawPkh) => (
 describe("<BuyTezForm />", () => {
   describe("mainnet", () => {
     it("renders with default recipient", async () => {
-      store.dispatch(networksActions.setCurrent(MAINNET));
       render(fixture(mockImplicitAccount(0).address.pkh));
 
-      const result = screen.getByLabelText("Recipient Account");
-      await act(async () => {
-        expect(result).toBeDisabled();
+      await waitFor(() => {
+        expect(screen.getByTestId("address-tile")).toHaveTextContent(
+          mockImplicitAccount(0).address.pkh
+        );
       });
     });
 
     it("renders Buy Tez on mainnet", async () => {
-      store.dispatch(networksActions.setCurrent(MAINNET));
       render(fixture());
 
       await waitFor(() => {

--- a/src/components/SendFlow/Delegation/FormPage.test.tsx
+++ b/src/components/SendFlow/Delegation/FormPage.test.tsx
@@ -34,8 +34,9 @@ describe("<Form />", () => {
     it("renders a form with a prefilled sender", () => {
       render(fixture({ sender: mockImplicitAccount(0) }));
 
-      expect(screen.getByLabelText("From")).toHaveValue(mockImplicitAccount(0).address.pkh);
-      expect(screen.getByLabelText("From")).toBeDisabled();
+      expect(screen.getByTestId("address-tile")).toHaveTextContent(
+        mockImplicitAccount(0).address.pkh
+      );
     });
 
     it("renders a form with default form values", async () => {
@@ -66,9 +67,13 @@ describe("<Form />", () => {
       );
 
       await waitFor(() => {
-        expect(screen.getByLabelText("From")).toHaveValue(mockImplicitAccount(0).address.pkh);
+        expect(screen.getByLabelText("Baker")).toHaveValue(mockImplicitAccount(1).address.pkh);
       });
-      expect(screen.getByLabelText("From")).toBeDisabled();
+      expect(screen.getByLabelText("Baker")).toBeEnabled();
+
+      expect(screen.getByTestId("address-tile")).toHaveTextContent(
+        mockImplicitAccount(0).address.pkh
+      );
     });
 
     it("displays delegate for address who is not delegating", async () => {

--- a/src/components/SendFlow/NFT/FormPage.test.tsx
+++ b/src/components/SendFlow/NFT/FormPage.test.tsx
@@ -26,9 +26,11 @@ describe("<FormPage />", () => {
     it("renders a form with a prefilled sender", () => {
       render(fixture({ sender: mockImplicitAccount(1) }));
 
-      expect(screen.getByLabelText("From")).toHaveValue(mockImplicitAccount(1).address.pkh);
-      expect(screen.getByLabelText("From")).toBeDisabled();
+      expect(screen.getByTestId("address-tile")).toHaveTextContent(
+        mockImplicitAccount(1).address.pkh
+      );
     });
+
     it("renders a form with default form values", async () => {
       render(
         fixture({
@@ -42,7 +44,9 @@ describe("<FormPage />", () => {
       );
 
       await waitFor(() => {
-        expect(screen.getByLabelText("From")).toHaveValue(mockImplicitAccount(0).address.pkh);
+        expect(screen.getByTestId("address-tile")).toHaveTextContent(
+          mockImplicitAccount(0).address.pkh
+        );
       });
       expect(screen.getByLabelText("To")).toHaveValue(mockImplicitAccount(1).address.pkh);
       expect(screen.getByTestId("quantity-input")).toHaveValue(1);

--- a/src/components/SendFlow/OperationSignerSelector.test.tsx
+++ b/src/components/SendFlow/OperationSignerSelector.test.tsx
@@ -61,7 +61,9 @@ describe("OperationSignerSelector", () => {
         </FormProvider>
       );
       expect(screen.getByTestId("signer-selector")).toBeInTheDocument();
-      expect(screen.getByLabelText("signer")).toBeDisabled();
+      expect(screen.getByTestId("address-tile")).toHaveTextContent(
+        mockImplicitAccount(0).address.pkh
+      );
     });
 
     it("allows only owned multisig signers to be chosen", () => {

--- a/src/components/SendFlow/Tez/FormPage.test.tsx
+++ b/src/components/SendFlow/Tez/FormPage.test.tsx
@@ -35,8 +35,9 @@ describe("<Form />", () => {
     it("renders a form with a prefilled sender", () => {
       render(fixture({ sender: mockImplicitAccount(0) }));
 
-      expect(screen.getByLabelText("From")).toHaveValue(mockImplicitAccount(0).address.pkh);
-      expect(screen.getByLabelText("From")).toBeDisabled();
+      expect(screen.getByTestId("address-tile")).toHaveTextContent(
+        mockImplicitAccount(0).address.pkh
+      );
     });
 
     it("renders a form with default form values", async () => {
@@ -53,7 +54,6 @@ describe("<Form />", () => {
       await waitFor(() => {
         expect(screen.getByLabelText("From")).toHaveValue(mockImplicitAccount(0).address.pkh);
       });
-      expect(screen.getByLabelText("From")).toBeEnabled();
       expect(screen.getByLabelText("To")).toHaveValue(mockImplicitAccount(1).address.pkh);
       expect(screen.getByLabelText("Amount")).toHaveValue(1);
     });
@@ -71,9 +71,10 @@ describe("<Form />", () => {
       );
 
       await waitFor(() => {
-        expect(screen.getByLabelText("From")).toHaveValue(mockImplicitAccount(0).address.pkh);
+        expect(screen.getByTestId("address-tile")).toHaveTextContent(
+          mockImplicitAccount(0).address.pkh
+        );
       });
-      expect(screen.getByLabelText("From")).toBeDisabled();
       expect(screen.getByLabelText("To")).toHaveValue(mockImplicitAccount(1).address.pkh);
       expect(screen.getByLabelText("Amount")).toHaveValue(1);
     });

--- a/src/components/SendFlow/Token/FormPage.test.tsx
+++ b/src/components/SendFlow/Token/FormPage.test.tsx
@@ -33,9 +33,11 @@ describe("<FormPage />", () => {
     it("renders a form with a prefilled sender", () => {
       render(fixture({ sender: mockImplicitAccount(1) }));
 
-      expect(screen.getByLabelText("From")).toHaveValue(mockImplicitAccount(1).address.pkh);
-      expect(screen.getByLabelText("From")).toBeDisabled();
+      expect(screen.getByTestId("address-tile")).toHaveTextContent(
+        mockImplicitAccount(1).address.pkh
+      );
     });
+
     it("renders a form with default form values", async () => {
       render(
         fixture({
@@ -49,7 +51,7 @@ describe("<FormPage />", () => {
       );
 
       await waitFor(() => {
-        expect(screen.getByLabelText("From")).toHaveValue(mockAccount.address.pkh);
+        expect(screen.getByTestId("address-tile")).toHaveTextContent(mockAccount.address.pkh);
       });
       expect(screen.getByLabelText("To")).toHaveValue(mockImplicitAccount(1).address.pkh);
       expect(screen.getByLabelText("Amount")).toHaveValue(1);

--- a/src/components/SendFlow/Undelegation/FormPage.test.tsx
+++ b/src/components/SendFlow/Undelegation/FormPage.test.tsx
@@ -32,10 +32,10 @@ describe("<Form />", () => {
       render(fixture({ sender: mockImplicitAccount(0) }));
 
       await waitFor(() => {
-        expect(screen.getByLabelText("From")).toHaveValue(mockImplicitAccount(0).address.pkh);
+        expect(screen.getByTestId("address-tile")).toHaveTextContent(
+          mockImplicitAccount(0).address.pkh
+        );
       });
-
-      expect(screen.getByLabelText("From")).toBeDisabled();
     });
 
     it("shows sender baker's tile", async () => {


### PR DESCRIPTION
## Proposed changes

[Task link](https://app.asana.com/0/1204165186238194/1205343763538608/f)

## Types of changes

- [ ] Bugfix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] UI fix

## Screenshots

Add the screenshots of how the app used to look like and how it looks now

| Before | Now |
| ------ | --- |
|    <img width="619" alt="Screenshot 2023-10-10 at 23 31 08" src="https://github.com/trilitech/umami-v2/assets/129749432/7517a99e-4cdb-43bd-a720-016b9c728b12">    |  <img width="710" alt="Screenshot 2023-10-10 at 23 30 56" src="https://github.com/trilitech/umami-v2/assets/129749432/115a53c8-16a8-44c3-a6a3-53f9d95859e4">   |

## Checklist

- [ ] Tests that prove my fix is effective or that my feature works have been added
- [ ] Documentation has been added (if appropriate)
- [x] Screenshots are added (if any UI changes have been made)
- [ ] All TODOs have a corresponding task created (and the link is attached to it)
