### PR TITLE
Make NFTs section of account tile clickable

### DIFF
--- a/src/components/AccountTile/AccountTile.tsx
+++ b/src/components/AccountTile/AccountTile.tsx
@@ -80,14 +80,14 @@ export const AccountTile: React.FC<{
       borderRadius="8px"
       px="21px"
       border={`1px solid ${selected ? colors.orangeL : colors.gray[800]}`}
+      onClick={onClick}
+      cursor="pointer"
     >
       <AccountTileBase
         data-testid={`account-tile-${address}` + (selected ? "-selected" : "")}
         p={0}
         mb={0}
         align="bottom"
-        onClick={onClick}
-        cursor="pointer"
         border="none"
         icon={<AccountTileIcon addressKind={addressKind} />}
         leftElement={<LabelAndAddress pkh={address} label={addressKind.label} />}


### PR DESCRIPTION
## Proposed changes

This is a part of account tile and should also open the drawer on click

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] UI fix
