### PR TITLE
Make NFT cards not crop images and support video

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,6 +132,7 @@
     "react-native-safe-area-context": "3.4.1",
     "react-native-svg": "12.5.1",
     "react-native-web": "0.17.7",
+    "react-player": "^2.13.0",
     "react-qrcode-logo": "^2.9.0",
     "react-query": "^3.39.3",
     "react-redux": "8.0.5",

--- a/src/style/theme.ts
+++ b/src/style/theme.ts
@@ -4,6 +4,7 @@ import { tabsTheme } from "./theme/tabs";
 import { modalTheme } from "./theme/modal";
 import { buttonTheme } from "./theme/button";
 import { checkboxTheme } from "./theme/checkbox";
+import { drawerTheme } from "./theme/drawer";
 
 const config = {
   initialColorMode: "dark",
@@ -92,6 +93,7 @@ const theme = extendTheme({
       sizes,
     },
     Modal: modalTheme,
+    Drawer: drawerTheme,
   },
   config,
   colors: {

--- a/src/style/theme/drawer.ts
+++ b/src/style/theme/drawer.ts
@@ -1,0 +1,22 @@
+import { drawerAnatomy as parts } from "@chakra-ui/anatomy";
+import { createMultiStyleConfigHelpers } from "@chakra-ui/styled-system";
+import colors from "../colors";
+
+const { definePartsStyle, defineMultiStyleConfig } = createMultiStyleConfigHelpers(parts.keys);
+
+const baseStyle = definePartsStyle(props => ({
+  body: {
+    padding: "24px 30px 30px 30px",
+  },
+  dialog: {
+    bg: colors.gray[900],
+  },
+}));
+
+export const drawerTheme = defineMultiStyleConfig({
+  baseStyle,
+  sizes: { md: { dialog: { maxW: "594px" } } },
+  defaultProps: {
+    size: "md",
+  },
+});

--- a/src/views/home/AccountListWithDrawer.tsx
+++ b/src/views/home/AccountListWithDrawer.tsx
@@ -6,7 +6,6 @@ import { useAllAccounts } from "../../utils/hooks/accountHooks";
 import { AccountsList } from "./AccountsList";
 import { DrawerTopButtons } from "./DrawerTopButtons";
 import { useDynamicModal } from "../../components/DynamicModal";
-import colors from "../../style/colors";
 
 const AccountListWithDrawer: React.FC = () => {
   const [selected, setSelected] = useState<string | null>(null);
@@ -41,13 +40,14 @@ const AccountListWithDrawer: React.FC = () => {
         isOpen={isOpen}
         placement="right"
         onClose={closeDrawer}
-        size="md"
         autoFocus={false}
       >
         <DrawerOverlay />
-        <DrawerContent maxW="594px" bg={colors.gray[900]}>
-          <DrawerTopButtons onClose={closeDrawer} />
-          <DrawerBody>{account && <AccountCard account={account} />}</DrawerBody>
+        <DrawerContent>
+          <DrawerBody>
+            <DrawerTopButtons onClose={closeDrawer} />
+            {account && <AccountCard account={account} />}
+          </DrawerBody>
         </DrawerContent>
       </Drawer>
     </>

--- a/src/views/home/DrawerTopButtons.tsx
+++ b/src/views/home/DrawerTopButtons.tsx
@@ -2,12 +2,13 @@ import { Flex } from "@chakra-ui/react";
 import React from "react";
 import { BsArrowBarRight } from "react-icons/bs";
 import { IconAndTextBtn } from "../../components/IconAndTextBtn";
+import colors from "../../style/colors";
 
 export const DrawerTopButtons: React.FC<{
   onClose: () => void;
 }> = ({ onClose }) => {
   return (
-    <Flex justifyContent="flex-end" color="umami.gray.400" cursor="pointer" p={4}>
+    <Flex justifyContent="flex-end" color={colors.gray[400]} pb="30px" cursor="pointer">
       <IconAndTextBtn onClick={onClose} label="Close" icon={BsArrowBarRight} />
     </Flex>
   );

--- a/src/views/nfts/NFTCard.tsx
+++ b/src/views/nfts/NFTCard.tsx
@@ -1,4 +1,4 @@
-import { AspectRatio, Image, Card, CardBody, Heading, Text, Box } from "@chakra-ui/react";
+import { Image, Card, CardBody, Heading, Text, Box } from "@chakra-ui/react";
 import { NFTBalance } from "../../types/TokenBalance";
 import { getIPFSurl } from "../../utils/token/nftUtils";
 import { fullId, thumbnailUri } from "../../types/Token";
@@ -23,23 +23,28 @@ const NFTCard: React.FC<{
     <Card
       cursor="pointer"
       data-testid="nft-card"
-      minWidth="275"
-      maxWidth="275"
-      height="340"
       borderRadius="8px"
       onClick={onClick}
+      width="274px"
     >
       <CardBody
+        borderRadius="8px"
         bg={colors.gray[900]}
         border="1px solid"
         borderColor={isSelected ? colors.orangeL : "transparent"}
         _hover={{ bg: colors.gray[700], borderColor: `${colors.gray[500]}` }}
-        borderRadius="8px"
         p="16px"
       >
-        <AspectRatio width="100%" ratio={1}>
-          <Image data-testid="nft-image" width="100%" src={url} fallbackSrc={fallbackUrl} />
-        </AspectRatio>
+        <Box>
+          <Image
+            data-testid="nft-image"
+            objectFit="contain"
+            width="242px"
+            height="242px"
+            src={url}
+            fallbackSrc={fallbackUrl}
+          />
+        </Box>
         {/* TODO: make a separate component to be shared between this and the drawer NFT card */}
         {Number(nft.balance) > 1 && (
           <Text
@@ -51,7 +56,7 @@ const NFTCard: React.FC<{
             backgroundColor="rgba(33, 33, 33, 0.75)"
             display="inline"
             position="absolute"
-            marginTop="-40px"
+            marginTop="-36px"
             marginLeft="10px"
             fontSize="14px"
           >

--- a/src/views/nfts/NFTDrawerCard.tsx
+++ b/src/views/nfts/NFTDrawerCard.tsx
@@ -4,7 +4,6 @@ import {
   AccordionIcon,
   AccordionItem,
   AccordionPanel,
-  AspectRatio,
   Box,
   Button,
   Card,
@@ -23,15 +22,20 @@ import { DynamicModalContext } from "../../components/DynamicModal";
 import { useContext } from "react";
 import SendNFTForm from "../../components/SendFlow/NFT/FormPage";
 import { useGetOwnedAccount } from "../../utils/hooks/accountHooks";
-import { artifactUri } from "../../types/Token";
+import { artifactUri, mimeType } from "../../types/Token";
 import JsValueWrap from "../../components/AccountDrawer/JsValueWrap";
 import colors from "../../style/colors";
+import { tokenName } from "../../types/Token";
+import ReactPlayer from "react-player";
 
 const NFTDrawerCard = ({ nft, ownerPkh }: { nft: NFTBalance; ownerPkh: RawPkh }) => {
   const url = getIPFSurl(artifactUri(nft));
   const fallbackUrl = getIPFSurl(nft.displayUri);
   const getAccount = useGetOwnedAccount();
   const { openWith } = useContext(DynamicModalContext);
+  const isVideo = mimeType(nft)?.startsWith("video/");
+
+  const name = tokenName(nft);
 
   const accordionItemStyle = {
     border: "none",
@@ -40,11 +44,23 @@ const NFTDrawerCard = ({ nft, ownerPkh }: { nft: NFTBalance; ownerPkh: RawPkh })
   };
   return (
     <Box>
-      <Card bg="umami.gray.800">
-        <CardBody>
-          <AspectRatio width="100%" ratio={1}>
-            <Image data-testid="nft-image" width="100%" src={url} fallbackSrc={fallbackUrl} />
-          </AspectRatio>
+      <Card bg={colors.gray[800]} height="534px" width="534px">
+        <CardBody p="24px">
+          <Box height="486px" width="486px">
+            {isVideo ? (
+              <ReactPlayer url={url} playing loop height="100%" width="100%" />
+            ) : (
+              <Image
+                data-testid="nft-image"
+                objectFit="contain"
+                height="486px"
+                width="486px"
+                alt={name}
+                src={url}
+                fallbackSrc={fallbackUrl}
+              />
+            )}
+          </Box>
           {Number(nft.balance) > 1 && (
             <Text
               data-testid="nft-owned-count"
@@ -54,8 +70,8 @@ const NFTDrawerCard = ({ nft, ownerPkh }: { nft: NFTBalance; ownerPkh: RawPkh })
               backgroundColor="rgba(33, 33, 33, 0.75)"
               display="inline"
               position="absolute"
-              marginTop="-40px"
-              marginLeft="10px"
+              marginTop="-38px"
+              marginLeft="16px"
             >
               {"x" + nft.balance}
             </Text>
@@ -65,9 +81,9 @@ const NFTDrawerCard = ({ nft, ownerPkh }: { nft: NFTBalance; ownerPkh: RawPkh })
 
       <TagsSection nft={nft} />
 
-      {nft.metadata.name && (
+      {name && (
         <Heading data-testid="nft-name" mt={4} size="lg">
-          {nft.metadata.name}
+          {name}
         </Heading>
       )}
 

--- a/src/views/nfts/NFTGallery.tsx
+++ b/src/views/nfts/NFTGallery.tsx
@@ -10,7 +10,7 @@ export const NFTGallery: React.FC<{
   onSelect: (owner: RawPkh, nft: NFTBalance) => void;
 }> = ({ nftsByOwner, onSelect }) => {
   return (
-    <Wrap spacing="16px" overflowY="auto">
+    <Wrap spacing="16px" overflowY="auto" mb="16px">
       {Object.entries(nftsByOwner).flatMap(([owner, nfts]) => {
         return (nfts || []).map(nft => (
           <NFTCard

--- a/src/views/nfts/NftsView.tsx
+++ b/src/views/nfts/NftsView.tsx
@@ -67,12 +67,11 @@ const NFTsViewBase = () => {
             blockScrollOnMount={!isDynamicModalOpen}
             placement="right"
             onClose={openNFTsPage}
-            size="md"
             isOpen={!!drawerNFT}
             autoFocus={false}
           >
             <DrawerOverlay />
-            <DrawerContent maxW="594px" bg={colors.gray[900]}>
+            <DrawerContent>
               <DrawerBody>
                 {drawerNFT && (
                   <>
@@ -80,7 +79,7 @@ const NFTsViewBase = () => {
                       justifyContent="space-between"
                       color={colors.gray[400]}
                       cursor="pointer"
-                      p={4}
+                      paddingBottom="30px"
                     >
                       <AddressPill address={parsePkh(ownerPkh)} />
                       <IconAndTextBtn onClick={openNFTsPage} label="Close" icon={BsArrowBarRight} />

--- a/src/views/settings/BeaconDrawerCard.tsx
+++ b/src/views/settings/BeaconDrawerCard.tsx
@@ -27,12 +27,11 @@ export const BeaconDrawerCard = () => {
         isOpen={isOpen}
         placement="right"
         onClose={closeDrawer}
-        size="md"
       >
         <DrawerOverlay />
-        <DrawerContent maxW="594px" bg="umami.gray.900">
-          <DrawerTopButtons onClose={closeDrawer} />
+        <DrawerContent>
           <DrawerBody>
+            <DrawerTopButtons onClose={closeDrawer} />
             <BeaconDrawerBody />
           </DrawerBody>
         </DrawerContent>

--- a/src/views/settings/ErrorLogsDrawerCard.tsx
+++ b/src/views/settings/ErrorLogsDrawerCard.tsx
@@ -36,12 +36,11 @@ const ErrorLogsDrawerCard = () => {
         isOpen={isOpen}
         placement="right"
         onClose={handleClose}
-        size="md"
       >
         <DrawerOverlay />
-        <DrawerContent maxW="594px" bg="umami.gray.900">
-          <DrawerTopButtons onClose={handleClose} />
+        <DrawerContent>
           <DrawerBody>
+            <DrawerTopButtons onClose={handleClose} />
             <ErrorLogsDrawerBody />
           </DrawerBody>
         </DrawerContent>

--- a/yarn.lock
+++ b/yarn.lock
@@ -12150,7 +12150,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"deepmerge@npm:^4.2.2":
+"deepmerge@npm:^4.0.0, deepmerge@npm:^4.2.2":
   version: 4.3.1
   resolution: "deepmerge@npm:4.3.1"
   checksum: 2024c6a980a1b7128084170c4cf56b0fd58a63f2da1660dcfe977415f27b17dbe5888668b59d0b063753f3220719d5e400b7f113609489c90160bb9a5518d052
@@ -17337,6 +17337,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"load-script@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "load-script@npm:1.0.0"
+  checksum: 8458e3f07b4a86f8d9d66e47a987811491a5d013af23ba7b371c6d3c9dc899885b072ccf65abf7874c10cb197d4975eacd8a7a125bfb38dbbcb267539f5dc1e9
+  languageName: node
+  linkType: hard
+
 "loader-runner@npm:^4.2.0":
   version: 4.3.0
   resolution: "loader-runner@npm:4.3.0"
@@ -17752,6 +17759,13 @@ __metadata:
   dependencies:
     fs-monkey: ^1.0.4
   checksum: 18dfdeacad7c8047b976a6ccd58bc98ba76e122ad3ca0e50a21837fe2075fc0d9aafc58ab9cf2576c2b6889da1dd2503083f2364191b695273f40969db2ecc44
+  languageName: node
+  linkType: hard
+
+"memoize-one@npm:^5.1.1":
+  version: 5.2.1
+  resolution: "memoize-one@npm:5.2.1"
+  checksum: a3cba7b824ebcf24cdfcd234aa7f86f3ad6394b8d9be4c96ff756dafb8b51c7f71320785fbc2304f1af48a0467cbbd2a409efc9333025700ed523f254cb52e3d
   languageName: node
   linkType: hard
 
@@ -20569,6 +20583,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-fast-compare@npm:^3.0.1":
+  version: 3.2.2
+  resolution: "react-fast-compare@npm:3.2.2"
+  checksum: 2071415b4f76a3e6b55c84611c4d24dcb12ffc85811a2840b5a3f1ff2d1a99be1020d9437ee7c6e024c9f4cbb84ceb35e48cf84f28fcb00265ad2dfdd3947704
+  languageName: node
+  linkType: hard
+
 "react-focus-lock@npm:^2.9.4":
   version: 2.9.4
   resolution: "react-focus-lock@npm:2.9.4"
@@ -20713,6 +20734,21 @@ __metadata:
     react: ">=17.0.1"
     react-dom: ">=17.0.1"
   checksum: 9a32073d18e12f7d0e77befc0489f07a60e4aea9b7d6da9228387f488956b8f3e04eff02102f70bc427d8ee5047b6f393dc6cb4b3d34501504b9799344054e34
+  languageName: node
+  linkType: hard
+
+"react-player@npm:^2.13.0":
+  version: 2.13.0
+  resolution: "react-player@npm:2.13.0"
+  dependencies:
+    deepmerge: ^4.0.0
+    load-script: ^1.0.0
+    memoize-one: ^5.1.1
+    prop-types: ^15.7.2
+    react-fast-compare: ^3.0.1
+  peerDependencies:
+    react: ">=16.6.0"
+  checksum: 7e0e69e0ac37227ab5bfdda73991d4f5d4741585562f3ad9cfb787ae2c427510b69ddf6ef3f23f319d699b790af852fca57f3e9b1dae94f385d545a3db200d67
   languageName: node
   linkType: hard
 
@@ -23747,6 +23783,7 @@ __metadata:
     react-native-safe-area-context: 3.4.1
     react-native-svg: 12.5.1
     react-native-web: 0.17.7
+    react-player: ^2.13.0
     react-qrcode-logo: ^2.9.0
     react-query: ^3.39.3
     react-redux: 8.0.5


### PR DESCRIPTION
## Proposed changes

NFT images aren't cropped now, they just fit into container as much as possible and that's it. If an NFT has a video as the artifact it'll be used when a user opens the drawer. Paddings in the drawer have also been unified into a theme

## Types of changes

- [ ] Bugfix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] UI fix

## Steps to reproduce

## Screenshots

https://github.com/trilitech/umami-v2/assets/129749432/d8727be3-f836-4b3a-beb3-ccc50b9be6bd

## Checklist

- [ ] Tests that prove my fix is effective or that my feature works have been added
- [ ] Documentation has been added (if appropriate)
- [x] Screenshots are added (if any UI changes have been made)
- [ ] All TODOs have a corresponding task created (and the link is attached to it)
