### PR TITLE
Add open operations button & fix flickering operations drawer tab

### DIFF
--- a/src/assets/icons/RefreshClock.tsx
+++ b/src/assets/icons/RefreshClock.tsx
@@ -1,0 +1,25 @@
+import { Icon, IconProps } from "@chakra-ui/react";
+import colors from "../../style/colors";
+
+const RefreshClockIcon: React.FC<IconProps> = props => {
+  return (
+    <Icon
+      width="18"
+      height="18"
+      viewBox="0 0 18 18"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <path
+        d="M3 9C3 12.3137 5.68629 15 9 15C12.3137 15 15 12.3137 15 9C15 5.68629 12.3137 3 9 3C7.20796 3 5.59942 3.78563 4.5 5.03126C4.43696 5.10268 4.3756 5.17562 4.31597 5.25M9 6V9L10.875 10.875M4.31543 3.00293V5.25293H6.56543"
+        stroke={colors.gray[450]}
+        strokeWidth="1.2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </Icon>
+  );
+};
+
+export default RefreshClockIcon;

--- a/src/components/AccountDrawer/AssetsPanel/AssetsPanel.tsx
+++ b/src/components/AccountDrawer/AssetsPanel/AssetsPanel.tsx
@@ -26,7 +26,7 @@ export const AssetsPanel: React.FC<{
 }> = ({ tokens, nfts, account, delegation }) => {
   const isMultisig = account.type === AccountType.MULTISIG;
   const network = useSelectedNetwork();
-  const { operations, isLoading } = useGetOperations([account.address.pkh]);
+  const { operations, isFirstLoad: areOperationsLoading } = useGetOperations([account.address.pkh]);
 
   return (
     <Tabs
@@ -65,7 +65,7 @@ export const AssetsPanel: React.FC<{
           <OperationTileContext.Provider
             value={{ mode: "drawer", selectedAddress: account.address }}
           >
-            {isLoading ? (
+            {areOperationsLoading ? (
               <Text textAlign="center" color={colors.gray[500]}>
                 Loading...
               </Text>

--- a/src/views/home/OperationListDisplay.tsx
+++ b/src/views/home/OperationListDisplay.tsx
@@ -1,9 +1,11 @@
 import React from "react";
-import NestedScroll from "../../components/NestedScroll";
 import { NoOperations } from "../../components/NoItems";
 import { OperationTile } from "../../components/OperationTile";
 import { TzktCombinedOperation } from "../../utils/tezos";
-import { Box, Divider } from "@chakra-ui/react";
+import { Box, Center, Divider, Text } from "@chakra-ui/react";
+import { Link } from "react-router-dom";
+import RefreshClockIcon from "../../assets/icons/RefreshClock";
+import colors from "../../style/colors";
 
 export const OperationListDisplay: React.FC<{ operations: TzktCombinedOperation[] }> = ({
   operations,
@@ -12,14 +14,24 @@ export const OperationListDisplay: React.FC<{ operations: TzktCombinedOperation[
     return <NoOperations small />;
   }
 
+  const chunk = operations.slice(0, 20);
+
   return (
-    <NestedScroll>
-      {operations.slice(0, 20).map(operation => (
+    <>
+      {chunk.map((operation, i) => (
         <Box key={operation.id} height="90px">
           <OperationTile operation={operation} />
-          <Divider my="20px" />
+          {i < chunk.length - 1 && <Divider my="20px" />}
         </Box>
       ))}
-    </NestedScroll>
+      <Center>
+        <Link to="/operations">
+          <RefreshClockIcon display="inline" />{" "}
+          <Text display="inline" size="sm" color={colors.gray[300]}>
+            View All
+          </Text>
+        </Link>
+      </Center>
+    </>
   );
 };

--- a/src/views/operations/useGetOperations.tsx
+++ b/src/views/operations/useGetOperations.tsx
@@ -16,6 +16,7 @@ export const useGetOperations = (initialAddresses: RawPkh[]) => {
   const network = useSelectedNetwork();
   const [operations, setOperations] = useState<TzktCombinedOperation[]>([]);
   const [hasMore, setHasMore] = useState(true);
+  const [isFirstLoad, setIsFirstLoad] = useState(true);
   const { isLoading, handleAsyncAction } = useAsyncActionHandler();
 
   const [addresses, setAddresses] = useState<RawPkh[]>(initialAddresses);
@@ -54,6 +55,7 @@ export const useGetOperations = (initialAddresses: RawPkh[]) => {
   // that's needed to make sure we don't trigger the initial fetch twice
   const addressesJoined = addresses.join(",");
 
+  // initial load
   useEffect(() => {
     setOperations([]);
     setHasMore(true);
@@ -67,6 +69,8 @@ export const useGetOperations = (initialAddresses: RawPkh[]) => {
       setOperations(latestOperations);
       setHasMore(latestOperations.length > 0);
       setUpdatesTrigger(prev => prev + 1);
+    }).finally(() => {
+      setIsFirstLoad(false);
     });
     // handleAsyncAction gets constantly recreated, so we can't add it to the dependency array
     // otherwise, it will trigger the initial fetch infinitely
@@ -91,7 +95,7 @@ export const useGetOperations = (initialAddresses: RawPkh[]) => {
     });
   };
 
-  return { operations, isLoading, hasMore, loadMore, setAddresses };
+  return { operations, isFirstLoad, isLoading, hasMore, loadMore, setAddresses };
 };
 
 // TODO: Add tests


### PR DESCRIPTION
## Proposed changes

At the bottom of the operations drawer tab there must be a button to open the operations page.
also, when it's loading updates, it'd replace the whole block with the "Loading" text and it causes flickers, so now it happens only on the first load when there are not operations yet

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] UI fix

## Steps to reproduce

## Screenshots

<img width="583" alt="Screenshot 2023-10-11 at 14 11 52" src="https://github.com/trilitech/umami-v2/assets/129749432/16427cfa-75cb-4084-aade-2f0d232ec0b9">


## Checklist

- [ ] Tests that prove my fix is effective or that my feature works have been added
- [ ] Documentation has been added (if appropriate)
- [ ] Screenshots are added (if any UI changes have been made)
- [ ] All TODOs have a corresponding task created (and the link is attached to it)
