### PR TITLE
Display address alias

### DIFF
--- a/src/components/AddressPill/AddressPill.tsx
+++ b/src/components/AddressPill/AddressPill.tsx
@@ -24,9 +24,9 @@ export type AddressPillMode =
   | { type: "no_icons" };
 
 const AddressPill: React.FC<
-  { address: Address | TzktAlias; mode?: AddressPillMode; } & BoxProps
-> = ({ address:rawAddress, mode = { type: "default" }, ...rest }) => {
-  const isAlias = !("pkh" in rawAddress);
+  { address: Address | TzktAlias; mode?: AddressPillMode } & BoxProps
+> = ({ address: rawAddress, mode = { type: "default" }, ...rest }) => {
+  const isAlias = !("pkh" in rawAddress && "type" in rawAddress);
   const address = isAlias ? parsePkh(rawAddress.address) : rawAddress;
   const addressKind = useAddressKind(address);
   const showIcons = mode.type !== "no_icons";
@@ -92,7 +92,7 @@ const AddressPill: React.FC<
             <Button variant="unstyled" h="24px" _focus={{ boxShadow: "none" }}>
               <AddressPillText
                 data-testid="address-pill-text"
-                alias={isAlias ? rawAddress: undefined}
+                alias={isAlias && rawAddress.alias ? rawAddress.alias : undefined}
                 addressKind={addressKind}
                 showPkh={!showIcons}
                 cursor="pointer"

--- a/src/components/AddressPill/AddressPillText.test.tsx
+++ b/src/components/AddressPill/AddressPillText.test.tsx
@@ -36,9 +36,7 @@ describe("<AddressPillText />", () => {
   });
 
   it("shows alias", () => {
-    render(
-      <AddressPillText addressKind={mockFA2Address} showPkh={false} alias={{address:mockFA2Address.pkh,alias:"test alias"}} />
-    );
+    render(<AddressPillText addressKind={mockFA2Address} showPkh={false} alias="test alias" />);
     expect(screen.getByText("test alias")).toBeInTheDocument();
   });
 

--- a/src/components/AddressPill/AddressPillText.tsx
+++ b/src/components/AddressPill/AddressPillText.tsx
@@ -2,18 +2,17 @@ import { useGetContactName } from "../../utils/hooks/contactsHooks";
 import { formatPkh, truncate } from "../../utils/format";
 import { Text, TextProps } from "@chakra-ui/react";
 import { AddressKind } from "./types";
-import { TzktAlias } from "../../types/Address";
 
 const AddressPillText: React.FC<
   {
     addressKind: AddressKind;
     showPkh: boolean;
-    alias?: TzktAlias;
+    alias?: string;
   } & TextProps
 > = ({ addressKind: { pkh, label }, showPkh, alias, ...rest }) => {
   const getContactName = useGetContactName();
   const formattedPkh = formatPkh(pkh);
-  const nameOrLabel = getContactName(pkh) || label || alias?.alias;
+  const nameOrLabel = getContactName(pkh) || label || alias;
 
   if (showPkh) {
     return <Text {...rest}>{formattedPkh}</Text>;

--- a/src/components/OperationTile/OperationTile.tsx
+++ b/src/components/OperationTile/OperationTile.tsx
@@ -19,7 +19,6 @@ import {
   DelegationOperation,
   OriginationOperation,
 } from "../../utils/tezos";
-import { parsePkh } from "../../types/Address";
 import { prettyTezAmount } from "../../utils/format";
 import { useGetToken } from "../../utils/hooks/tokensHooks";
 import { thumbnailUri, tokenNameSafe, tokenPrettyAmount } from "../../types/Token";
@@ -37,6 +36,7 @@ import { useIsOwnedAddress } from "../../utils/hooks/accountHooks";
 import { OperationTypeWrapper } from "./OperationTypeWrapper";
 import { useShowAddress } from "./useShowAddress";
 import AddressPill from "../AddressPill/AddressPill";
+import { TzktAlias } from "../../types/Address";
 
 const TransactionTile: React.FC<{ operation: TransactionOperation }> = ({ operation }) => {
   const isOutgoing = useIsOwnedAddress(operation.sender.address);
@@ -73,9 +73,7 @@ const TransactionTile: React.FC<{ operation: TransactionOperation }> = ({ operat
                 <Text mr="6px" color={colors.gray[450]}>
                   To:
                 </Text>
-                <AddressPill
-                  address={{address:operation.target.address,alias:operation.target.alias}}
-                />
+                <AddressPill address={operation.target} />
               </Flex>
             )}
             {(showFromAddress || showAnyAddress) && (
@@ -83,9 +81,7 @@ const TransactionTile: React.FC<{ operation: TransactionOperation }> = ({ operat
                 <Text mr="6px" color={colors.gray[450]}>
                   From:
                 </Text>
-                <AddressPill
-                  address={{address:operation.sender.address,alias:operation.sender.alias}}
-                />
+                <AddressPill address={operation.sender} />
               </Flex>
             )}
           </Flex>
@@ -191,9 +187,7 @@ const TokenTransferTile: React.FC<{
                 <Text mr="6px" color={colors.gray[450]}>
                   To:
                 </Text>
-                <AddressPill
-                  address={{address:tokenTransfer.to.address,alias:tokenTransfer.to.alias}}
-                />
+                <AddressPill address={tokenTransfer.to} />
               </Flex>
             )}
             {(showFromAddress || showAnyAddress) && (
@@ -201,9 +195,7 @@ const TokenTransferTile: React.FC<{
                 <Text mr="6px" color={colors.gray[450]}>
                   From:
                 </Text>
-                <AddressPill
-                  address={{address:operation.sender.address,alias:operation.sender.alias}}
-                />
+                <AddressPill address={operation.sender} />
               </Flex>
             )}
           </Flex>
@@ -247,9 +239,7 @@ const ContractCallTile: React.FC<{
                 <Text mr="6px" color={colors.gray[450]}>
                   To:
                 </Text>
-                <AddressPill
-                  address={{address:operation.target.address,alias:operation.target.alias}}
-                />
+                <AddressPill address={operation.target} />
               </Flex>
             )}
             {(showFromAddress || showAnyAddress) && (
@@ -257,9 +247,7 @@ const ContractCallTile: React.FC<{
                 <Text mr="6px" color={colors.gray[450]}>
                   From:
                 </Text>
-                <AddressPill
-                  address={{address:operation.sender.address,alias:operation.sender.alias}}
-                />
+                <AddressPill address={operation.sender} />
               </Flex>
             )}
           </Flex>
@@ -300,10 +288,7 @@ const DelegationTile: React.FC<{ operation: DelegationOperation }> = ({ operatio
                 <Text mr="6px" color={colors.gray[450]}>
                   To:
                 </Text>
-                <AddressPill
-                  address={{address:operation.newDelegate?.address as string,alias:operation.newDelegate?.alias}}
-                  
-                />
+                <AddressPill address={operation.newDelegate as TzktAlias} />
               </Flex>
             )}
             {showFromAddress && (
@@ -311,9 +296,7 @@ const DelegationTile: React.FC<{ operation: DelegationOperation }> = ({ operatio
                 <Text mr="6px" color={colors.gray[450]}>
                   From:
                 </Text>
-                <AddressPill
-                  address={{address:operation.sender.address,alias:operation.sender.alias}}
-                />
+                <AddressPill address={operation.sender} />
               </Flex>
             )}
             {!isDelegating && !showFromAddress && <Text color={colors.gray[450]}>N/A</Text>}
@@ -362,7 +345,7 @@ const OriginationTile: React.FC<{ operation: OriginationOperation }> = ({ operat
                 <Text mr="6px" color={colors.gray[450]}>
                   From:
                 </Text>
-                <AddressPill address={parsePkh(operation.sender.address)} />
+                <AddressPill address={operation.sender} />
               </Flex>
             )}
           </Flex>


### PR DESCRIPTION
## Display address alias

[Task link](https://app.asana.com/0/1204165186238194/1205618046406600)

The address pill now shows the alias for the address if there is any. Kukai takes the same approach for their transaction page
Note that address pill will still allow users to add the address to the address book since it is still an unknown address
## Types of changes

- [ ] Bugfix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] UI fix

## Steps to reproduce

## Screenshots

Add the screenshots of how the app used to look like and how it looks now

| Before | Now |
| ------ | --- |
| <img width="1202" alt="before" src="https://github.com/trilitech/umami-v2/assets/128799322/0c9a17e1-aba0-40a2-8297-c62895765988"> | <img width="1189" alt="Screenshot 2023-10-23 at 12 00 31" src="https://github.com/trilitech/umami-v2/assets/128799322/a7b150e7-d8ba-4427-a1a3-37fd52525625">   |


## Checklist

- [x] Tests that prove my fix is effective or that my feature works have been added
- [ ] Documentation has been added (if appropriate)
- [ ] Screenshots are added (if any UI changes have been made)
- [ ] All TODOs have a corresponding task created (and the link is attached to it)
