### PR TITLE
Check multisig account name on validation

### DIFF
--- a/src/components/ContactModal.tsx
+++ b/src/components/ContactModal.tsx
@@ -18,7 +18,7 @@ import { useForm } from "react-hook-form";
 import colors from "../style/colors";
 import { isAddressValid } from "../types/Address";
 import { Contact } from "../types/Contact";
-import { useGetOwnedAccountSafe, useImplicitAccounts } from "../utils/hooks/accountHooks";
+import { useAllAccounts, useGetOwnedAccountSafe } from "../utils/hooks/accountHooks";
 import { useContactExists } from "../utils/hooks/contactsHooks";
 import { useAppDispatch } from "../utils/redux/hooks";
 import { contactsActions } from "../utils/redux/slices/contactsSlice";
@@ -60,7 +60,7 @@ export const UpsertContactModal: FC<{
 
   const isEdit = contact !== undefined;
 
-  const accounts = useImplicitAccounts();
+  const accounts = useAllAccounts();
   const validateName = (name: string) => {
     if (accounts.map(account => account.label).includes(name)) {
       return "Name already used in accounts";


### PR DESCRIPTION
## Check multisig account name on validation
 the address book edit contact modal should validate if the multisig account name is already used or not.

[Task link]()

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] UI fix

## Steps to reproduce
Go to addrss book and try edit the name to one of the multisig accoun's name.
## Screenshots

https://github.com/trilitech/umami-v2/assets/128799322/9137a766-eb4e-434c-b914-4307f304d7f3

