### PR TITLE
Fix short seedphrases onboarding

### DIFF
--- a/src/components/Onboarding/restoreMnemonic/RestoreMnemonic.tsx
+++ b/src/components/Onboarding/restoreMnemonic/RestoreMnemonic.tsx
@@ -60,7 +60,7 @@ const RestoreMnemonic = ({ goToStep }: { goToStep: (step: Step) => void }) => {
   const onSubmit = (data: FieldValues) =>
     handleAsyncAction(
       async () => {
-        const mnemonic = Object.values(data).join(" ");
+        const mnemonic = Object.values(data).join(" ").trim();
         if (!validateMnemonic(mnemonic)) {
           throw new Error(`"${mnemonic}" is not a valid mnemonic`);
         }


### PR DESCRIPTION
## Proposed changes

The issue was that shorter versions would add a whitespace in the end making the seedphrase invalid

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] UI fix

## Steps to reproduce
- try to onboard with < 24 words seedphrase
