### PR TITLE
Add tests for operation tile

### DIFF
--- a/src/components/AccountDrawer/AccountDrawerDisplay.test.tsx
+++ b/src/components/AccountDrawer/AccountDrawerDisplay.test.tsx
@@ -205,10 +205,10 @@ describe("<AccountCard />", () => {
   it("should display accounts operations under operations tab if any", async () => {
     render(<AccountCard account={selectedAccount} />);
     await waitFor(() => {
-      expect(screen.getAllByTestId("operation-tile")).toHaveLength(2);
+      expect(screen.getAllByTestId(/^operation-tile/)).toHaveLength(2);
     });
     expect(screen.getByTestId("account-card-operations-tab")).toBeInTheDocument();
-    const operations = screen.getAllByTestId("operation-tile");
+    const operations = screen.getAllByTestId(/^operation-tile/);
     expect(operations[0]).toHaveTextContent("- 1.000000 ꜩ");
     expect(operations[1]).toHaveTextContent("+ 2.000000 ꜩ");
   });
@@ -343,10 +343,10 @@ describe("<AccountCard />", () => {
 
       render(<AccountCard account={multisigAccount} />);
       await waitFor(() => {
-        expect(screen.getAllByTestId("operation-tile")).toHaveLength(2);
+        expect(screen.getAllByTestId(/^operation-tile/)).toHaveLength(2);
       });
       expect(screen.getByTestId("account-card-operations-tab")).toBeInTheDocument();
-      const operations = screen.getAllByTestId("operation-tile");
+      const operations = screen.getAllByTestId(/^operation-tile/);
       expect(operations[0]).toHaveTextContent("- 1.000000 ꜩ");
       expect(operations[1]).toHaveTextContent("- 2.000000 ꜩ");
     });

--- a/src/components/OperationTile/ContractCallTile.tsx
+++ b/src/components/OperationTile/ContractCallTile.tsx
@@ -19,7 +19,7 @@ export const ContractCallTile: React.FC<{
   const showAnyAddress = !showToAddress && !showFromAddress;
 
   return (
-    <Flex direction="column" data-testid="operation-tile" w="100%">
+    <Flex direction="column" data-testid="operation-tile-contract-call" w="100%">
       <Flex justifyContent="space-between" mb="10px">
         <Center>
           <ContractIcon mr="8px" />

--- a/src/components/OperationTile/DelegationTile.tsx
+++ b/src/components/OperationTile/DelegationTile.tsx
@@ -17,7 +17,7 @@ export const DelegationTile: React.FC<{ operation: DelegationOperation }> = ({ o
   const showFromAddress = useShowAddress(operation.sender.address);
 
   return (
-    <Flex direction="column" data-testid="operation-tile" w="100%">
+    <Flex direction="column" data-testid="operation-tile-delegation" w="100%">
       <Flex justifyContent="space-between" mb="10px">
         <Center>
           <BakerIcon stroke={colors.gray[450]} mr="8px" />

--- a/src/components/OperationTile/OperationTile.test.tsx
+++ b/src/components/OperationTile/OperationTile.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen } from "../../mocks/testUtils";
+import { assetsActions } from "../../utils/redux/slices/assetsSlice";
+import store from "../../utils/redux/store";
+import { TzktCombinedOperation } from "../../utils/tezos";
+import { OperationTile } from "./OperationTile";
+import { OperationTileContext } from "./OperationTileContext";
+import {
+  contractCallFixture,
+  delegationFixture,
+  originationFixture,
+  tokenTransferFixture,
+  transactionFixture,
+} from "./testUtils";
+
+const fixture = (operation: TzktCombinedOperation) => (
+  <OperationTileContext.Provider value={{ mode: "page" }}>
+    <OperationTile operation={operation} />
+  </OperationTileContext.Provider>
+);
+
+describe("<OperationTile />", () => {
+  it("renders Delegation", () => {
+    render(fixture(delegationFixture({})));
+    expect(screen.getByTestId("operation-tile-delegation")).toBeInTheDocument();
+  });
+
+  it("renders Origination", () => {
+    render(fixture(originationFixture({})));
+    expect(screen.getByTestId("operation-tile-origination")).toBeInTheDocument();
+  });
+
+  it("renders ContractCall", () => {
+    render(fixture(contractCallFixture({})));
+    expect(screen.getByTestId("operation-tile-contract-call")).toBeInTheDocument();
+  });
+
+  it("renders Transaction", () => {
+    render(fixture(transactionFixture({})));
+    expect(screen.getByTestId("operation-tile-transaction")).toBeInTheDocument();
+  });
+
+  describe("token transfer", () => {
+    const tokenTransferTransaction = contractCallFixture({
+      parameter: {
+        entrypoint: "transfer",
+        value: {},
+      },
+    });
+
+    it("renders ContractCall if token transfer info is missing", () => {
+      render(fixture(tokenTransferTransaction));
+      expect(screen.getByTestId("operation-tile-contract-call")).toBeInTheDocument();
+    });
+
+    it("renders Transaction if token info is missing/incorrect", () => {
+      jest.spyOn(console, "warn").mockImplementation();
+      store.dispatch(
+        assetsActions.updateTokenTransfers([tokenTransferFixture({ token: {} as any })])
+      );
+
+      render(fixture(tokenTransferTransaction));
+      expect(screen.getByTestId("operation-tile-transaction")).toBeInTheDocument();
+    });
+
+    it("renders TokenTransfer", () => {
+      store.dispatch(assetsActions.updateTokenTransfers([tokenTransferFixture({})]));
+
+      render(fixture(tokenTransferTransaction));
+      expect(screen.getByTestId("operation-tile-token-transfer")).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/OperationTile/OriginationTile.tsx
+++ b/src/components/OperationTile/OriginationTile.tsx
@@ -21,7 +21,7 @@ export const OriginationTile: React.FC<{ operation: OriginationOperation }> = ({
   const showFromAddress = useShowAddress(operation.sender.address);
 
   return (
-    <Flex direction="column" data-testid="operation-tile" w="100%">
+    <Flex direction="column" data-testid="operation-tile-origination" w="100%">
       <Flex justifyContent="space-between" mb="10px">
         <Center>
           <ContractIcon mr="8px" />

--- a/src/components/OperationTile/TransactionTile.tsx
+++ b/src/components/OperationTile/TransactionTile.tsx
@@ -25,7 +25,7 @@ export const TransactionTile: React.FC<{ operation: TransactionOperation }> = ({
   const sign = isOutgoing ? "-" : "+";
 
   return (
-    <Flex direction="column" data-testid="operation-tile" w="100%">
+    <Flex direction="column" data-testid="operation-tile-transaction" w="100%">
       <Flex justifyContent="space-between" mb="10px">
         <Center>
           <TransactionDirectionIcon isOutgoing={isOutgoing} mr="8px" />

--- a/src/components/OperationTile/testUtils.ts
+++ b/src/components/OperationTile/testUtils.ts
@@ -1,9 +1,11 @@
+import { uUSD } from "../../mocks/fa2Tokens";
 import {
   mockContractAddress,
   mockImplicitAccount,
   mockImplicitAddress,
   mockLedgerAccount,
 } from "../../mocks/factories";
+import { TokenTransfer } from "../../types/Transfer";
 import { CODE_HASH, TYPE_HASH } from "../../utils/multisig/fetch";
 import { DelegationOperation, OriginationOperation, TransactionOperation } from "../../utils/tezos";
 
@@ -54,5 +56,13 @@ export const delegationFixture = (props: Partial<DelegationOperation>): Delegati
   newDelegate: {
     address: mockImplicitAddress(1).pkh,
   },
+  ...props,
+});
+
+export const tokenTransferFixture = (props: Partial<TokenTransfer>): TokenTransfer => ({
+  amount: "5",
+  transactionId: 56789,
+  to: { address: mockImplicitAccount(1).address.pkh },
+  token: uUSD(mockLedgerAccount(0).address).token,
   ...props,
 });

--- a/src/types/Token.ts
+++ b/src/types/Token.ts
@@ -46,7 +46,7 @@ export type Metadata = {
 // All the fields in TzKT are optional and it doesn't differ from the type `any`
 // meaning that you can pass in anything as RawTokenInfo and it will be accepted
 // but no token can exist without a contract. It provides at least some type safety
-export type RawTokenInfo = Omit<tzktApi.TokenInfo, "contract" | "metadata" | "tokenId"> & {
+export type RawTokenInfo = tzktApi.TokenInfo & {
   contract: TzktAlias;
   metadata?: Metadata;
   tokenId: string;


### PR DESCRIPTION
I moved conditional rendering logic from the inside of token transfer tile into operation tile to simplify its logic and testing
also, since we already have the token in the token transfer object I use it instead of from the state because it might not be available yet there