### PR TITLE
Fix errors display on adding existing non-mnemonic account

### DIFF
--- a/src/components/Onboarding/connectOrCreate/ConnectOrCreate.tsx
+++ b/src/components/Onboarding/connectOrCreate/ConnectOrCreate.tsx
@@ -1,5 +1,6 @@
 import { Button, Flex, VStack, Text, Divider, useToast } from "@chakra-ui/react";
 import { GoogleAuth } from "../../../GoogleAuth";
+import { useAsyncActionHandler } from "../../../utils/hooks/useAsyncActionHandler";
 import { useRestoreSocial } from "../../../utils/hooks/accountHooks";
 import { getPkAndPkhFromSk } from "../../../utils/tezos";
 import ModalContentWrapper from "../ModalContentWrapper";
@@ -14,15 +15,18 @@ const ConnectOrCreate = ({
   goToStep: (step: Step) => void;
   closeModal: () => void;
 }) => {
+  const { handleAsyncAction } = useAsyncActionHandler();
   const restoreSocial = useRestoreSocial();
   const toast = useToast();
 
-  const onSuccessfulSocialAuth = async (sk: string, email: string) => {
-    const { pk, pkh } = await getPkAndPkhFromSk(sk);
-    restoreSocial(pk, pkh, email);
-    toast({ title: `Successfully added ${email} account`, status: "success" });
-    closeModal();
-  };
+  const onSuccessfulSocialAuth = (sk: string, email: string) =>
+    handleAsyncAction(async () => {
+      const { pk, pkh } = await getPkAndPkhFromSk(sk);
+      restoreSocial(pk, pkh, email);
+      toast({ title: `Successfully added ${email} account`, status: "success" });
+      closeModal();
+    });
+
   return (
     <ModalContentWrapper icon={<WalletPlusIcon />} title="Connect or Create Account">
       <VStack w="100%" spacing="16px">

--- a/src/components/Onboarding/restoreLedger/RestoreLedger.tsx
+++ b/src/components/Onboarding/restoreLedger/RestoreLedger.tsx
@@ -60,11 +60,12 @@ const RestoreLedger = ({
             title: "Request pending",
             description: "Check your ledger...",
           };
-        } else if (error.name !== undefined) {
-          return { title: "Request cancelled", description: error.name };
         }
 
-        return { title: "Ledger Error", description: error.message };
+        return {
+          title: "Ledger error",
+          description: error.message || error.name,
+        };
       }
     );
 


### PR DESCRIPTION
## Proposed changes

[Task link](https://app.asana.com/0/1205770721172203/1205770721313096/f)

**Google account:**
Adding existing account was breaking UI.
HandleAsyncAction wrapper was added to catch the error and display it to user.

**Ledger account:**
Adding existing account displayed toast with just "Error".
Fixed bug in processing ledger errors. All uncategorised errors now show error description (if present) or error name.

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] UI fix

## Steps to reproduce
Add ledger / google account that was previously added for the user.

## Screenshots

**Google account before:**

<img width="1058" alt="Screenshot 2023-11-07 at 14 42 37" src="https://github.com/trilitech/umami-v2/assets/150050388/3efa683a-7b2c-4460-82c1-952b7c897099">
 
**Google account after:**

<img width="710" alt="Screenshot 2023-11-07 at 14 40 32" src="https://github.com/trilitech/umami-v2/assets/150050388/b0e6a091-3d46-4378-b5e8-2c9e4ca31f62">

## Checklist

- [ ] Tests that prove my fix is effective or that my feature works have been added
- [ ] Documentation has been added (if appropriate)
- [x] Screenshots are added (if any UI changes have been made)
- [x] All TODOs have a corresponding task created (and the link is attached to it)
