### PR TITLE
Add timeout to GAuth & ledger

### DIFF
--- a/src/GoogleAuth.tsx
+++ b/src/GoogleAuth.tsx
@@ -4,6 +4,7 @@ import CustomAuth from "@toruslabs/customauth";
 import { FcGoogle } from "react-icons/fc";
 import colors from "./style/colors";
 import { useAsyncActionHandler } from "./utils/hooks/useAsyncActionHandler";
+import { withTimeout } from "./utils/withTimeout";
 
 // These parameters are built by
 // https://github.com/torusresearch/CustomAuth/blob/master/serviceworker/redirect.html
@@ -43,16 +44,6 @@ export type GoogleAuthProps = {
   onSuccessfulAuth: (sk: string, email: string) => void;
   isDisabled?: boolean;
 };
-
-const withTimeout = <T,>(fn: () => Promise<T>, timeout: number, errorMessage?: string) =>
-  Promise.race([
-    new Promise((_, reject) =>
-      setTimeout(() => {
-        reject(new Error(errorMessage || "The operation has timed out"));
-      }, timeout)
-    ),
-    fn(),
-  ]);
 
 const LOGIN_TIMEOUT = 60 * 1000; // 1 minute
 

--- a/src/utils/withTimeout.ts
+++ b/src/utils/withTimeout.ts
@@ -1,0 +1,10 @@
+// allows to kill a promise if it takes more than the specified timeout
+export const withTimeout = <T>(fn: () => Promise<T>, timeout: number, errorMessage?: string) =>
+  Promise.race([
+    fn(),
+    new Promise((_, reject) =>
+      setTimeout(() => {
+        reject(new Error(errorMessage || "The operation has timed out"));
+      }, timeout)
+    ),
+  ]);


### PR DESCRIPTION
## Proposed changes

[Task link](https://app.asana.com/0/1205770721172203/1205771213581877/f)

GAuth onboard & sign now have a timeout (if a user closes the the page, in 1 minute the button is available again)
Ledger onboard also has a 1 minute timeout
Ledger sign is too tricky to add a timeout to because it's deep inside taquito. it's possible, but too many crutches for such a niche use case

## Types of changes

- [ ] Bugfix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] UI fix

## Steps to reproduce

## Screenshots

<img width="513" alt="Screenshot 2023-11-16 at 10 00 34" src="https://github.com/trilitech/umami-v2/assets/129749432/5b2c605a-0672-4b40-a987-a9272f850bbb">
<img width="592" alt="Screenshot 2023-11-16 at 12 44 17" src="https://github.com/trilitech/umami-v2/assets/129749432/7aa0dc60-d7b5-4817-a1b7-2a1ed4b30d8f">
<img width="666" alt="Screenshot 2023-11-16 at 12 45 14" src="https://github.com/trilitech/umami-v2/assets/129749432/eff95800-6666-4672-8d5f-ac1827aceeef">

## Checklist

- [ ] Tests that prove my fix is effective or that my feature works have been added
- [ ] Documentation has been added (if appropriate)
- [x] Screenshots are added (if any UI changes have been made)
- [ ] All TODOs have a corresponding task created (and the link is attached to it)
