### PR TITLE
Fix yarn version error on CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.x
+          node-version: 18.15.x
           cache: "yarn"
 
       - name: Register yarn 1.x cache folder


### PR DESCRIPTION
## Proposed changes

This should help avoid the errors like [this one](https://github.com/trilitech/umami-v2/actions/runs/6904404125)

The reason of it is that we use yarn install cache to drastically speedup CI jobs. It doesn't matter which yarn version we use for the cache itself because the packages are the same. For now, this crutch will silence the error, but we need to migrate to the latest version of yarn at some point.

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] UI fix

## Steps to reproduce
Run test CI jobs
