### PR TITLE
Fix flaky CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,8 +28,7 @@ jobs:
       - name: Setup yarn 3.x
         run: |
           corepack enable
-          corepack prepare yarn@stable --activate
-          yarn --version
+          yarn set version 3.5.0
 
       - name: Install packages
         env:
@@ -50,7 +49,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.x
+          node-version: 18.15.x
           cache: "yarn"
 
       - name: Register yarn 1.x cache folder
@@ -62,8 +61,7 @@ jobs:
       - name: Setup yarn 3.x
         run: |
           corepack enable
-          corepack prepare yarn@stable --activate
-          yarn --version
+          yarn set version 3.5.0
 
       - name: Install packages
         env:

--- a/package.json
+++ b/package.json
@@ -225,7 +225,6 @@
       ]
     }
   },
-  "packageManager": "yarn@3.5.0",
   "resolutions": {
     "nwsapi": "2.2.2"
   }


### PR DESCRIPTION
CI jobs fail because of this parameter because initially the
runners have 1.22 installed
once 1.22 sees the packageManager version it throws complaining that it's outdated