### PR TITLE
Forbid shorthands for chakra props

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -10,7 +10,8 @@
     "jest",
     "react",
     "react-hooks",
-    "testing-library"
+    "testing-library",
+    "chakra-ui"
   ],
   "extends": [
     "eslint:recommended",
@@ -40,7 +41,10 @@
     "react/jsx-key": [
       "warn",
       { "checkFragmentShorthand": true, "checkKeyMustBeforeSpread": true, "warnOnDuplicates": true }
-    ]
+    ],
+    "chakra-ui/props-order": "warn",
+    "chakra-ui/props-shorthand": ["warn", { "noShorthand": true }],
+    "chakra-ui/require-specific-component": "warn"
   },
   "overrides": [
     {

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "electron-builder": "^24.9.1",
     "electronmon": "^2.0.2",
     "eslint": "^8.54.0",
+    "eslint-plugin-chakra-ui": "^0.10.1",
     "eslint-plugin-jest": "^27.6.0",
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^4.6.0",

--- a/src/GoogleAuth.tsx
+++ b/src/GoogleAuth.tsx
@@ -95,17 +95,17 @@ export const GoogleAuth: React.FC<GoogleAuthProps> = ({ onSuccessfulAuth, isDisa
   // TODO: correct the BG colours when we have the design ready
   return (
     <IconButton
-      bg="white"
-      borderRadius="full"
-      size="lg"
       width="48px"
-      aria-label="Google SSO"
-      onClick={() => getCredentials(onSuccessfulAuth)}
-      isLoading={isLoading}
-      isDisabled={isDisabled}
-      variant="outline"
+      background="white"
+      borderRadius="full"
       _disabled={{ bg: colors.gray[900] }}
+      aria-label="Google SSO"
       icon={<FcGoogle size="24px" />}
+      isDisabled={isDisabled}
+      isLoading={isLoading}
+      onClick={() => getCredentials(onSuccessfulAuth)}
+      size="lg"
+      variant="outline"
     />
   );
 };

--- a/src/ImportSeed.tsx
+++ b/src/ImportSeed.tsx
@@ -28,33 +28,33 @@ function ImportSeed() {
   }, []);
 
   return (
-    <Center bgImage={BackgroundImage} bgSize="cover" height="100vh" padding="60px">
+    <Center height="100vh" padding="60px" backgroundImage={BackgroundImage} backgroundSize="cover">
       {showSlider && (
-        <SimpleGrid bg={colors.gray[800]} columns={[1, 1, 2]} borderRadius="30px">
+        <SimpleGrid background={colors.gray[800]} borderRadius="30px" columns={[1, 1, 2]}>
           <Center>
-            <VStack spacing="0" maxW="400px" padding="32px">
+            <VStack maxWidth="400px" padding="32px" spacing="0">
               <MakiLogo size="48px" mb="24px" />
-              <Heading size="3xl" mb="16px">
+              <Heading marginBottom="16px" size="3xl">
                 Welcome to Umami
               </Heading>
-              <Divider maxWidth="400px" mb="16px" />
-              <Text color={colors.gray[450]} mb="32px">
+              <Divider maxWidth="400px" marginBottom="16px" />
+              <Text marginBottom="32px" color={colors.gray[450]}>
                 A powerful Tezos wallet
               </Text>
-              <Button w="100%" size="lg" mb="24px" onClick={openModal}>
+              <Button width="100%" marginBottom="24px" onClick={openModal} size="lg">
                 Get started
               </Button>
               <AppVersion fontSize="13px" />
             </VStack>
           </Center>
           <Box
+            display={["none", "none", "initial"]}
+            overflow="hidden"
             width="100%"
+            height="665px"
+            background="black"
             borderTopRightRadius="30px"
             borderBottomRightRadius="30px"
-            height="665px"
-            overflow="hidden"
-            bg="black"
-            display={["none", "none", "initial"]}
           >
             <Slider>
               {slideItems.map((item, index) => {

--- a/src/assets/icons/Accounts.tsx
+++ b/src/assets/icons/Accounts.tsx
@@ -6,9 +6,9 @@ const AccountsIcon: React.FC<IconProps> = props => {
     <Icon
       width="24px"
       height="24px"
-      viewBox="0 0 24 24"
       fill="none"
       textAlign="center"
+      viewBox="0 0 24 24"
       xmlns="http://www.w3.org/2000/svg"
       {...props}
     >

--- a/src/assets/icons/AddAccount.tsx
+++ b/src/assets/icons/AddAccount.tsx
@@ -6,10 +6,10 @@ const AddAccountIcon: React.FC<IconProps> = props => {
     <Icon
       width="18px"
       height="18px"
-      viewBox="0 0 18 18"
       fill="none"
-      xmlns="http://www.w3.org/2000/svg"
       stroke={colors.gray[450]}
+      viewBox="0 0 18 18"
+      xmlns="http://www.w3.org/2000/svg"
       {...props}
     >
       <path

--- a/src/assets/icons/AddContact.tsx
+++ b/src/assets/icons/AddContact.tsx
@@ -2,7 +2,7 @@ import { Icon, IconProps } from "@chakra-ui/react";
 
 const AddContactIcon: React.FC<IconProps> = props => {
   return (
-    <Icon viewBox="0 0 13 17" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+    <Icon fill="none" viewBox="0 0 13 17" xmlns="http://www.w3.org/2000/svg" {...props}>
       <path
         d="M13 12.5L10.75 12.5M10.75 12.5L8.5 12.5M10.75 12.5V10.25M10.75 12.5V14.75M6.25 14.75H1C1 11.8505 3.35051 9.5 6.25 9.5C6.77123 9.5 7.27472 9.57596 7.75 9.71741M9.25 4.25C9.25 5.90685 7.90685 7.25 6.25 7.25C4.59315 7.25 3.25 5.90685 3.25 4.25C3.25 2.59315 4.59315 1.25 6.25 1.25C7.90685 1.25 9.25 2.59315 9.25 4.25Z"
         strokeWidth="1.2"

--- a/src/assets/icons/AddressBook.tsx
+++ b/src/assets/icons/AddressBook.tsx
@@ -6,8 +6,8 @@ const AddressBookIcon: React.FC<IconProps> = props => {
     <Icon
       width="24px"
       height="24px"
-      viewBox="0 0 24 24"
       fill="none"
+      viewBox="0 0 24 24"
       xmlns="http://www.w3.org/2000/svg"
       {...props}
     >

--- a/src/assets/icons/Baker.tsx
+++ b/src/assets/icons/Baker.tsx
@@ -3,11 +3,11 @@ import { Icon, IconProps } from "@chakra-ui/react";
 const BakerIcon: React.FC<IconProps> = props => {
   return (
     <Icon
-      data-testid="baker-icon"
       width="18px"
       height="18px"
-      viewBox="0 0 18 18"
       fill="none"
+      data-testid="baker-icon"
+      viewBox="0 0 18 18"
       xmlns="http://www.w3.org/2000/svg"
       {...props}
     >

--- a/src/assets/icons/Batch.tsx
+++ b/src/assets/icons/Batch.tsx
@@ -6,8 +6,8 @@ const BatchIcon: React.FC<IconProps> = props => {
     <Icon
       width="24px"
       height="24px"
-      viewBox="0 0 24 24"
       fill="none"
+      viewBox="0 0 24 24"
       xmlns="http://www.w3.org/2000/svg"
       {...props}
     >

--- a/src/assets/icons/Checkmark.tsx
+++ b/src/assets/icons/Checkmark.tsx
@@ -5,8 +5,8 @@ const CheckmarkIcon: React.FC<IconProps> = props => {
     <Icon
       width="18px"
       height="18px"
-      viewBox="0 0 18 18"
       fill="none"
+      viewBox="0 0 18 18"
       xmlns="http://www.w3.org/2000/svg"
       {...props}
     >

--- a/src/assets/icons/ChevronDown.tsx
+++ b/src/assets/icons/ChevronDown.tsx
@@ -6,10 +6,10 @@ const ChevronDownIcon: React.FC<IconProps> = props => {
     <Icon
       width="18px"
       height="18px"
-      viewBox="0 0 18 18"
       fill="none"
-      xmlns="http://www.w3.org/2000/svg"
       stroke={colors.gray[450]}
+      viewBox="0 0 18 18"
+      xmlns="http://www.w3.org/2000/svg"
       {...props}
     >
       <path

--- a/src/assets/icons/ChevronRight.tsx
+++ b/src/assets/icons/ChevronRight.tsx
@@ -5,10 +5,10 @@ const ChevronRightIcon: React.FC<IconProps> = props => (
   <Icon
     width="18px"
     height="18px"
-    viewBox="0 0 18 18"
     fill="none"
-    xmlns="http://www.w3.org/2000/svg"
     stroke={colors.gray[450]}
+    viewBox="0 0 18 18"
+    xmlns="http://www.w3.org/2000/svg"
     {...props}
   >
     <path d="M7 14L11.5 9.5L7 5" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round" />

--- a/src/assets/icons/Coin.tsx
+++ b/src/assets/icons/Coin.tsx
@@ -6,8 +6,8 @@ const CoinIcon: React.FC<IconProps> = props => {
     <Icon
       width="24px"
       height="24px"
-      viewBox="0 0 24 24"
       fill="none"
+      viewBox="0 0 24 24"
       xmlns="http://www.w3.org/2000/svg"
       {...props}
     >

--- a/src/assets/icons/Contact.tsx
+++ b/src/assets/icons/Contact.tsx
@@ -3,11 +3,11 @@ import { Icon, IconProps } from "@chakra-ui/react";
 const ContactIcon: React.FC<IconProps> = props => {
   return (
     <Icon
-      data-testid="contact-icon"
       width="18px"
       height="18px"
-      viewBox="0 0 18 18"
       fill="none"
+      data-testid="contact-icon"
+      viewBox="0 0 18 18"
       xmlns="http://www.w3.org/2000/svg"
       {...props}
     >

--- a/src/assets/icons/Contract.tsx
+++ b/src/assets/icons/Contract.tsx
@@ -6,8 +6,8 @@ const ContractIcon: React.FC<IconProps> = props => {
     <Icon
       width="18px"
       height="18px"
-      viewBox="0 0 18 18"
       fill="none"
+      viewBox="0 0 18 18"
       xmlns="http://www.w3.org/2000/svg"
       {...props}
     >

--- a/src/assets/icons/CrossedCircle.tsx
+++ b/src/assets/icons/CrossedCircle.tsx
@@ -5,8 +5,8 @@ const CrossedCircleIcon: React.FC<IconProps> = props => {
     <Icon
       width="18px"
       height="18px"
-      viewBox="0 0 18 18"
       fill="none"
+      viewBox="0 0 18 18"
       xmlns="http://www.w3.org/2000/svg"
       {...props}
     >

--- a/src/assets/icons/Diamond.tsx
+++ b/src/assets/icons/Diamond.tsx
@@ -6,8 +6,8 @@ const DiamondIcon: React.FC<IconProps> = props => {
     <Icon
       width="24px"
       height="24px"
-      viewBox="0 0 24 24"
       fill="none"
+      viewBox="0 0 24 24"
       xmlns="http://www.w3.org/2000/svg"
       {...props}
     >

--- a/src/assets/icons/Document.tsx
+++ b/src/assets/icons/Document.tsx
@@ -6,10 +6,10 @@ const DocumentIcon: React.FC<IconProps> = props => {
     <Icon
       width="24px"
       height="24px"
-      viewBox="0 0 24 24"
       fill="none"
-      xmlns="http://www.w3.org/2000/svg"
       stroke={colors.gray[450]}
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
       {...props}
     >
       <path

--- a/src/assets/icons/DoubleCheckmark.tsx
+++ b/src/assets/icons/DoubleCheckmark.tsx
@@ -6,10 +6,10 @@ const DoubleCheckmarkIcon: React.FC<IconProps> = props => {
     <Icon
       width="24px"
       height="24px"
-      viewBox="0 0 24 24"
       fill="none"
-      xmlns="http://www.w3.org/2000/svg"
       stroke={colors.gray[450]}
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
       {...props}
     >
       <path

--- a/src/assets/icons/Download.tsx
+++ b/src/assets/icons/Download.tsx
@@ -6,10 +6,10 @@ const DownloadIcon: React.FC<IconProps> = props => {
     <Icon
       width="16px"
       height="16px"
-      viewBox="0 0 16 16"
       fill="none"
-      xmlns="http://www.w3.org/2000/svg"
       stroke={colors.gray[450]}
+      viewBox="0 0 16 16"
+      xmlns="http://www.w3.org/2000/svg"
       {...props}
     >
       <path

--- a/src/assets/icons/EditAccount.tsx
+++ b/src/assets/icons/EditAccount.tsx
@@ -6,10 +6,10 @@ const EditAccountIcon: React.FC<IconProps> = props => {
     <Icon
       width="24px"
       height="24px"
-      viewBox="0 0 24 24"
       fill="none"
-      xmlns="http://www.w3.org/2000/svg"
       stroke={colors.gray[450]}
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
       {...props}
     >
       <path

--- a/src/assets/icons/Exclamation.tsx
+++ b/src/assets/icons/Exclamation.tsx
@@ -6,10 +6,10 @@ const ExclamationIcon: React.FC<IconProps> = props => {
     <Icon
       width="12px"
       height="12px"
-      viewBox="0 0 12 12"
       fill="none"
-      xmlns="http://www.w3.org/2000/svg"
       stroke={colors.orange}
+      viewBox="0 0 12 12"
+      xmlns="http://www.w3.org/2000/svg"
       {...props}
     >
       <path

--- a/src/assets/icons/ExitArrow.tsx
+++ b/src/assets/icons/ExitArrow.tsx
@@ -6,10 +6,10 @@ const ExitArrowIcon: React.FC<IconProps> = props => {
     <Icon
       width="18px"
       height="18px"
-      viewBox="0 0 18 18"
       fill="none"
-      xmlns="http://www.w3.org/2000/svg"
       stroke={colors.gray[450]}
+      viewBox="0 0 18 18"
+      xmlns="http://www.w3.org/2000/svg"
       {...props}
     >
       <path

--- a/src/assets/icons/ExternalLink.tsx
+++ b/src/assets/icons/ExternalLink.tsx
@@ -6,10 +6,10 @@ const ExternalLinkIcon: React.FC<IconProps> = props => {
     <Icon
       width="18px"
       height="18px"
-      viewBox="0 0 18 18"
       fill="none"
-      xmlns="http://www.w3.org/2000/svg"
       stroke={colors.gray[450]}
+      viewBox="0 0 18 18"
+      xmlns="http://www.w3.org/2000/svg"
       {...props}
     >
       <path

--- a/src/assets/icons/Eye.tsx
+++ b/src/assets/icons/Eye.tsx
@@ -6,8 +6,8 @@ const EyeIcon: React.FC<IconProps> = props => {
     <Icon
       width="16px"
       height="12px"
-      viewBox="0 0 16 12"
       fill="none"
+      viewBox="0 0 16 12"
       xmlns="http://www.w3.org/2000/svg"
       {...props}
     >

--- a/src/assets/icons/EyeSlash.tsx
+++ b/src/assets/icons/EyeSlash.tsx
@@ -6,8 +6,8 @@ const EyeSlashIcon: React.FC<IconProps> = props => {
     <Icon
       width="18px"
       height="18px"
-      viewBox="0 0 18 18"
       fill="none"
+      viewBox="0 0 18 18"
       xmlns="http://www.w3.org/2000/svg"
       {...props}
     >

--- a/src/assets/icons/FA1.2.tsx
+++ b/src/assets/icons/FA1.2.tsx
@@ -6,8 +6,8 @@ const FA12Icon: React.FC<IconProps> = props => {
     <Icon
       width="30px"
       height="15px"
-      viewBox="1 1 30 15"
       fill={colors.gray[450]}
+      viewBox="1 1 30 15"
       xmlns="http://www.w3.org/2000/svg"
       {...props}
     >

--- a/src/assets/icons/FA2.tsx
+++ b/src/assets/icons/FA2.tsx
@@ -6,8 +6,8 @@ const FA2Icon: React.FC<IconProps> = props => {
     <Icon
       width="23px"
       height="18px"
-      viewBox="0 0 23 18"
       fill={colors.gray[450]}
+      viewBox="0 0 23 18"
       xmlns="http://www.w3.org/2000/svg"
       {...props}
     >

--- a/src/assets/icons/Fetching.tsx
+++ b/src/assets/icons/Fetching.tsx
@@ -6,9 +6,9 @@ const FetchingIcon: React.FC<IconProps> = props => {
     <Icon
       width="19px"
       height="19px"
-      viewBox="0 0 19 19"
-      stroke={colors.gray[400]}
       fill="none"
+      stroke={colors.gray[400]}
+      viewBox="0 0 19 19"
       xmlns="http://www.w3.org/2000/svg"
       {...props}
     >

--- a/src/assets/icons/FileArrowDown.tsx
+++ b/src/assets/icons/FileArrowDown.tsx
@@ -6,9 +6,9 @@ const FileArrowDownIcon: React.FC<IconProps> = props => {
     <Icon
       width="18px"
       height="18px"
-      viewBox="0 0 18 18"
       fill="none"
       stroke={colors.gray[450]}
+      viewBox="0 0 18 18"
       xmlns="http://www.w3.org/2000/svg"
       {...props}
     >

--- a/src/assets/icons/FileCopy.tsx
+++ b/src/assets/icons/FileCopy.tsx
@@ -5,8 +5,8 @@ const FileCopyIcon: React.FC<IconProps> = props => {
     <Icon
       width="18px"
       height="18px"
-      viewBox="0 0 18 18"
       fill="none"
+      viewBox="0 0 18 18"
       xmlns="http://www.w3.org/2000/svg"
       {...props}
     >

--- a/src/assets/icons/FlipForwardEnergy.tsx
+++ b/src/assets/icons/FlipForwardEnergy.tsx
@@ -5,10 +5,10 @@ const FlipForwardEnergy: React.FC<IconProps> = props => {
     <Icon
       width="18px"
       height="18px"
-      viewBox="0 0 18 18"
       fill="none"
-      xmlns="http://www.w3.org/2000/svg"
       stroke="black"
+      viewBox="0 0 18 18"
+      xmlns="http://www.w3.org/2000/svg"
       {...props}
     >
       <path

--- a/src/assets/icons/Gear.tsx
+++ b/src/assets/icons/Gear.tsx
@@ -6,8 +6,8 @@ const GearIcon: React.FC<IconProps> = props => {
     <Icon
       width="24px"
       height="24px"
-      viewBox="0 0 24 24"
       fill="none"
+      viewBox="0 0 24 24"
       xmlns="http://www.w3.org/2000/svg"
       {...props}
     >

--- a/src/assets/icons/Help.tsx
+++ b/src/assets/icons/Help.tsx
@@ -6,8 +6,8 @@ const HelpIcon: React.FC<IconProps> = props => {
     <Icon
       width="24px"
       height="24px"
-      viewBox="0 0 24 24"
       fill="none"
+      viewBox="0 0 24 24"
       xmlns="http://www.w3.org/2000/svg"
       {...props}
     >

--- a/src/assets/icons/Hourglass.tsx
+++ b/src/assets/icons/Hourglass.tsx
@@ -5,8 +5,8 @@ const HourglassIcon: React.FC<IconProps> = props => {
     <Icon
       width="18px"
       height="18px"
-      viewBox="0 0 18 18"
       fill="none"
+      viewBox="0 0 18 18"
       xmlns="http://www.w3.org/2000/svg"
       {...props}
     >

--- a/src/assets/icons/Key.tsx
+++ b/src/assets/icons/Key.tsx
@@ -3,11 +3,11 @@ import { Icon, IconProps } from "@chakra-ui/react";
 const KeyIcon: React.FC<IconProps> = props => {
   return (
     <Icon
-      data-testid="key-icon"
       width="18px"
       height="18px"
-      viewBox="0 0 18 18"
       fill="none"
+      data-testid="key-icon"
+      viewBox="0 0 18 18"
       xmlns="http://www.w3.org/2000/svg"
       {...props}
     >

--- a/src/assets/icons/Ledger.tsx
+++ b/src/assets/icons/Ledger.tsx
@@ -5,9 +5,9 @@ const LedgerIcon: React.FC<IconProps> = props => {
   return (
     <Icon
       as={MdUsb}
-      data-testid="ledger-icon"
       width="18px"
       height="18px"
+      data-testid="ledger-icon"
       viewBox="0 0 18 18"
       xmlns="http://www.w3.org/2000/svg"
       {...props}

--- a/src/assets/icons/Link.tsx
+++ b/src/assets/icons/Link.tsx
@@ -6,10 +6,10 @@ const LinkIcon: React.FC<IconProps> = props => {
     <Icon
       width="24px"
       height="24px"
-      viewBox="0 0 24 24"
       fill="none"
-      xmlns="http://www.w3.org/2000/svg"
       stroke={colors.gray[450]}
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
       {...props}
     >
       <path

--- a/src/assets/icons/Lock.tsx
+++ b/src/assets/icons/Lock.tsx
@@ -6,10 +6,10 @@ const LockIcon: React.FC<IconProps> = props => {
     <Icon
       width="24px"
       height="24px"
-      viewBox="0 0 24 24"
       fill="none"
-      xmlns="http://www.w3.org/2000/svg"
       stroke={colors.gray[450]}
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
       {...props}
     >
       <path

--- a/src/assets/icons/Notice.tsx
+++ b/src/assets/icons/Notice.tsx
@@ -6,10 +6,10 @@ const NoticeIcon: React.FC<IconProps> = props => {
     <Icon
       width="24px"
       height="24px"
-      viewBox="0 0 24 24"
       fill="none"
-      xmlns="http://www.w3.org/2000/svg"
       stroke={colors.gray[450]}
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
       {...props}
     >
       <path

--- a/src/assets/icons/OutgoingArrow.tsx
+++ b/src/assets/icons/OutgoingArrow.tsx
@@ -6,9 +6,9 @@ const OutgoingArrow: React.FC<IconProps> = props => {
     <Icon
       width="18px"
       height="18px"
-      viewBox="0 0 18 18"
       fill="none"
       stroke={colors.gray[450]}
+      viewBox="0 0 18 18"
       xmlns="http://www.w3.org/2000/svg"
       {...props}
     >

--- a/src/assets/icons/Pen.tsx
+++ b/src/assets/icons/Pen.tsx
@@ -6,10 +6,10 @@ const PenIcon: React.FC<IconProps> = props => {
     <Icon
       width="18px"
       height="18px"
-      viewBox="0 0 18 18"
       fill="none"
-      xmlns="http://www.w3.org/2000/svg"
       stroke={colors.gray[450]}
+      viewBox="0 0 18 18"
+      xmlns="http://www.w3.org/2000/svg"
       {...props}
     >
       <path

--- a/src/assets/icons/Plus.tsx
+++ b/src/assets/icons/Plus.tsx
@@ -6,9 +6,9 @@ const PlusIcon: React.FC<IconProps> = props => {
     <Icon
       width="24px"
       height="24px"
-      viewBox="0 0 24 24"
       fill="none"
       stroke={colors.gray[300]}
+      viewBox="0 0 24 24"
       xmlns="http://www.w3.org/2000/svg"
       {...props}
     >

--- a/src/assets/icons/RefreshClock.tsx
+++ b/src/assets/icons/RefreshClock.tsx
@@ -6,8 +6,8 @@ const RefreshClockIcon: React.FC<IconProps> = props => {
     <Icon
       width="18"
       height="18"
-      viewBox="0 0 18 18"
       fill="none"
+      viewBox="0 0 18 18"
       xmlns="http://www.w3.org/2000/svg"
       {...props}
     >

--- a/src/assets/icons/Rotate.tsx
+++ b/src/assets/icons/Rotate.tsx
@@ -4,13 +4,13 @@ import colors from "../../style/colors";
 const RotateIcon: React.FC<IconProps> = props => {
   return (
     <Icon
-      data-testid="rotate-icon"
       width="24px"
       height="24px"
-      viewBox="0 0 24 24"
       fill="none"
-      xmlns="http://www.w3.org/2000/svg"
       stroke={colors.gray[450]}
+      data-testid="rotate-icon"
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
       {...props}
     >
       <path

--- a/src/assets/icons/Slash.tsx
+++ b/src/assets/icons/Slash.tsx
@@ -6,10 +6,10 @@ const SlashIcon: React.FC<IconProps> = props => {
     <Icon
       width="24px"
       height="24px"
-      viewBox="0 0 24 24"
       fill="none"
-      xmlns="http://www.w3.org/2000/svg"
       stroke={colors.gray[450]}
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
       {...props}
     >
       <path d="M16 3L8 21" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round" />

--- a/src/assets/icons/Token.tsx
+++ b/src/assets/icons/Token.tsx
@@ -4,7 +4,7 @@ import icon from "../coin-front.svg";
 import { RawPkh } from "../../types/Address";
 
 const TokenIconBase: React.FC<{ url: string } & ImageProps> = ({ url, ...props }) => {
-  return <Image src={url} fallbackSrc={icon} {...props} />;
+  return <Image fallbackSrc={icon} src={url} {...props} />;
 };
 
 const TokenIcon: React.FC<{ contract: RawPkh } & ImageProps> = ({ contract, ...props }) => {

--- a/src/assets/icons/Trash.tsx
+++ b/src/assets/icons/Trash.tsx
@@ -6,10 +6,10 @@ const TrashIcon: React.FC<IconProps> = props => {
     <Icon
       width="18px"
       height="18px"
-      viewBox="0 0 18 18"
       fill="none"
-      xmlns="http://www.w3.org/2000/svg"
       stroke={colors.gray[450]}
+      viewBox="0 0 18 18"
+      xmlns="http://www.w3.org/2000/svg"
       {...props}
     >
       <path

--- a/src/assets/icons/USB.tsx
+++ b/src/assets/icons/USB.tsx
@@ -6,10 +6,10 @@ const USBIcon: React.FC<IconProps> = props => {
     <Icon
       width="24px"
       height="24px"
-      viewBox="0 0 24 24"
       fill="none"
-      xmlns="http://www.w3.org/2000/svg"
       stroke={colors.gray[450]}
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
       {...props}
     >
       <path

--- a/src/assets/icons/UnknownContact.tsx
+++ b/src/assets/icons/UnknownContact.tsx
@@ -3,11 +3,11 @@ import { Icon, IconProps } from "@chakra-ui/react";
 const UnknownContactIcon: React.FC<IconProps> = props => {
   return (
     <Icon
-      data-testid="unknown-contact-icon"
       width="18px"
       height="18px"
-      viewBox="0 0 18 18"
       fill="none"
+      data-testid="unknown-contact-icon"
+      viewBox="0 0 18 18"
       xmlns="http://www.w3.org/2000/svg"
       {...props}
     >

--- a/src/assets/icons/Verified.tsx
+++ b/src/assets/icons/Verified.tsx
@@ -6,10 +6,10 @@ const CheckIcon: React.FC<IconProps> = props => {
     <Icon
       width="7px"
       height="5px"
-      viewBox="0 0 7 5"
       fill="none"
-      xmlns="http://www.w3.org/2000/svg"
       stroke="white"
+      viewBox="0 0 7 5"
+      xmlns="http://www.w3.org/2000/svg"
       {...props}
     >
       <path
@@ -26,9 +26,9 @@ const StarIcon: React.FC<IconProps> = props => {
     <Icon
       width="14px"
       height="14px"
+      fill={colors.gray[450]}
       viewBox="0 0 14 14"
       xmlns="http://www.w3.org/2000/svg"
-      fill={colors.gray[450]}
       {...props}
     >
       <path
@@ -42,9 +42,14 @@ const StarIcon: React.FC<IconProps> = props => {
 
 const VerifiedIcon: React.FC = () => {
   return (
-    <Flex data-testid="verified-icon" align="center" justify="center" position="relative">
+    <Flex
+      position="relative"
+      alignItems="center"
+      justifyContent="center"
+      data-testid="verified-icon"
+    >
       <StarIcon />
-      <Flex position="absolute" align="center" justify="center">
+      <Flex position="absolute" alignItems="center" justifyContent="center">
         <CheckIcon />
       </Flex>
     </Flex>

--- a/src/assets/icons/WalletPlus.tsx
+++ b/src/assets/icons/WalletPlus.tsx
@@ -6,10 +6,10 @@ const WalletPlusIcon: React.FC<IconProps> = props => {
     <Icon
       width="24px"
       height="24px"
-      viewBox="0 0 24 24"
       fill="none"
-      xmlns="http://www.w3.org/2000/svg"
       stroke={colors.gray[450]}
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
       {...props}
     >
       <path

--- a/src/assets/icons/Warning.tsx
+++ b/src/assets/icons/Warning.tsx
@@ -5,8 +5,8 @@ const WarningIcon: React.FC<IconProps> = props => {
     <Icon
       width="36"
       height="32"
-      viewBox="0 0 36 32"
       fill="none"
+      viewBox="0 0 36 32"
       xmlns="http://www.w3.org/2000/svg"
       {...props}
     >

--- a/src/assets/icons/XMark.tsx
+++ b/src/assets/icons/XMark.tsx
@@ -5,8 +5,8 @@ const XMark: React.FC<IconProps> = props => {
     <Icon
       width="18px"
       height="18px"
-      viewBox="0 0 18 18"
       fill="none"
+      viewBox="0 0 18 18"
       xmlns="http://www.w3.org/2000/svg"
       {...props}
     >

--- a/src/components/AccountBalance.tsx
+++ b/src/components/AccountBalance.tsx
@@ -19,7 +19,7 @@ export const AccountBalance: React.FC<{ address: RawPkh; size?: "md" | "lg" } & 
   const balanceInTez = prettyTezAmount(balance);
 
   return (
-    <Box data-testid="account-balance" textAlign="right" overflow="hidden" {...props}>
+    <Box overflow="hidden" textAlign="right" data-testid="account-balance" {...props}>
       <PrettyNumber number={balanceInTez} size={size} />
     </Box>
   );

--- a/src/components/AccountDrawer/AccountDrawerDisplay.tsx
+++ b/src/components/AccountDrawer/AccountDrawerDisplay.tsx
@@ -39,13 +39,13 @@ const RoundButton: React.FC<{
   onClick?: () => void;
 }> = ({ icon, label, onClick = () => {} }) => {
   return (
-    <Box textAlign="center" mx="24px">
+    <Box textAlign="center" marginX="24px">
       <IconButton
+        marginBottom="8px"
+        aria-label="button"
+        icon={icon}
         onClick={onClick}
         size="lg"
-        icon={icon}
-        mb="8px"
-        aria-label="button"
         variant="circle"
       />
       <Text size="sm">{label}</Text>
@@ -85,20 +85,20 @@ export const AccountDrawerDisplay: React.FC<Props> = ({
 
   return (
     <Flex
-      direction="column"
       alignItems="center"
+      flexDirection="column"
       data-testid={`account-card-${account.address.pkh}`}
     >
       <AccountTileIcon addressKind={addressKind} />
-      <Heading mt="24px" size="md">
+      <Heading marginTop="24px" size="md">
         {account.label}
       </Heading>
-      <Flex alignItems="center" mt="8px" mb="30px">
+      <Flex alignItems="center" marginTop="8px" marginBottom="30px">
         <AddressPill address={account.address} mode={{ type: "no_icons" }} mr="4px" />
         <RenameRemoveMenuSwitch account={account} />
       </Flex>
       {balance && <TezRecapDisplay center balance={balance} dollarBalance={dollarBalance} />}
-      <Center mt="34px">
+      <Center marginTop="34px">
         <RoundButton
           onClick={onSend}
           label="Send"

--- a/src/components/AccountDrawer/AssetsPanel/AssetsPanel.tsx
+++ b/src/components/AccountDrawer/AssetsPanel/AssetsPanel.tsx
@@ -30,12 +30,12 @@ export const AssetsPanel: React.FC<{
 
   return (
     <Tabs
-      height="100%"
-      display="flex"
       flexDirection="column"
-      mt="60px"
+      display="flex"
+      width="100%"
+      height="100%"
+      marginTop="60px"
       data-testid="asset-panel"
-      w="100%"
     >
       <TabList justifyContent="space-between" data-testid="asset-panel-tablist">
         <Flex>
@@ -47,8 +47,8 @@ export const AssetsPanel: React.FC<{
         </Flex>
 
         <ExternalLink href={buildTzktAddressUrl(network, account.address.pkh)}>
-          <Button variant="CTAWithIcon" paddingRight={0}>
-            <Text mr="7px" size="sm">
+          <Button paddingRight={0} variant="CTAWithIcon">
+            <Text marginRight="7px" size="sm">
               View on Tzkt
             </Text>
             <ExternalLinkIcon stroke="currentcolor" />
@@ -57,17 +57,17 @@ export const AssetsPanel: React.FC<{
       </TabList>
       <TabPanels height="100%">
         {isMultisig && (
-          <TabPanel p="24px 0 60px 0" data-testid="account-card-pending-tab-panel">
+          <TabPanel padding="24px 0 60px 0" data-testid="account-card-pending-tab-panel">
             <MultisigPendingAccordion account={account} />
           </TabPanel>
         )}
 
-        <TabPanel p="24px 0 60px 0" data-testid="account-card-operations-tab">
+        <TabPanel padding="24px 0 60px 0" data-testid="account-card-operations-tab">
           <OperationTileContext.Provider
             value={{ mode: "drawer", selectedAddress: account.address }}
           >
             {areOperationsLoading ? (
-              <Text textAlign="center" color={colors.gray[500]}>
+              <Text color={colors.gray[500]} textAlign="center">
                 Loading...
               </Text>
             ) : (
@@ -76,20 +76,20 @@ export const AssetsPanel: React.FC<{
           </OperationTileContext.Provider>
         </TabPanel>
 
-        <TabPanel p="24px 0 60px 0" data-testid="account-card-delegation-tab">
+        <TabPanel padding="24px 0 60px 0" data-testid="account-card-delegation-tab">
           <DelegationDisplay account={account} delegation={delegation} />
         </TabPanel>
 
         <TabPanel
-          p="24px 0 60px 0"
-          data-testid="account-card-nfts-tab"
-          height="100%"
           overflow="hidden"
+          height="100%"
+          padding="24px 0 60px 0"
+          data-testid="account-card-nfts-tab"
         >
           <NFTsGrid nftsByOwner={{ [account.address.pkh]: nfts }} columns={3} spacing={5} />
         </TabPanel>
 
-        <TabPanel p="24px 0 60px 0" data-testid="account-card-tokens-tab">
+        <TabPanel padding="24px 0 60px 0" data-testid="account-card-tokens-tab">
           <TokenList tokens={tokens} />
         </TabPanel>
       </TabPanels>

--- a/src/components/AccountDrawer/AssetsPanel/DelegationDisplay.tsx
+++ b/src/components/AccountDrawer/AssetsPanel/DelegationDisplay.tsx
@@ -20,9 +20,9 @@ const Row: React.FC<
   } & FlexProps
 > = ({ label, value, ...props }) => {
   return (
-    <Flex data-testid={label} h="50px" p="16px" alignItems="center" {...props}>
+    <Flex alignItems="center" height="50px" padding="16px" data-testid={label} {...props}>
       <Box flex={1}>
-        <Heading size="sm" color={colors.gray[400]}>
+        <Heading color={colors.gray[400]} size="sm">
           {label}
         </Heading>
       </Box>
@@ -81,23 +81,23 @@ export const DelegationDisplay: React.FC<{
         value={<AddressPill address={parsePkh(delegation.delegate.address)} />}
       />
 
-      <Flex mt="24px">
+      <Flex marginTop="24px">
         <Button
           flex={1}
-          mr="16px"
-          variant="warning"
+          marginRight="16px"
           onClick={() =>
             openWith(<UndelegationFormPage sender={senderAccount} form={{ sender, baker }} />)
           }
+          variant="warning"
         >
           End Delegation
         </Button>
         <Button
           flex={1}
-          variant="tertiary"
           onClick={() => {
             openWith(<DelegationFormPage sender={senderAccount} form={{ sender, baker }} />);
           }}
+          variant="tertiary"
         >
           Change Baker
         </Button>

--- a/src/components/AccountDrawer/AssetsPanel/MultisigPendingAccordion/MultisigActionButton.tsx
+++ b/src/components/AccountDrawer/AssetsPanel/MultisigPendingAccordion/MultisigActionButton.tsx
@@ -45,8 +45,8 @@ export const MultisigActionButton: React.FC<{
       return (
         <Button
           data-testid="multisig-signer-button"
-          onClick={onClickApproveExecute}
           isLoading={isLoading}
+          onClick={onClickApproveExecute}
         >
           Execute
         </Button>
@@ -57,8 +57,8 @@ export const MultisigActionButton: React.FC<{
       return (
         <Button
           data-testid="multisig-signer-button"
-          onClick={onClickApproveExecute}
           isLoading={isLoading}
+          onClick={onClickApproveExecute}
         >
           Approve
         </Button>

--- a/src/components/AccountDrawer/AssetsPanel/MultisigPendingAccordion/MultisigDecodedOperationItem.tsx
+++ b/src/components/AccountDrawer/AssetsPanel/MultisigPendingAccordion/MultisigDecodedOperationItem.tsx
@@ -13,13 +13,13 @@ const MultisigDecodedOperationItem: React.FC<{
   switch (operation.type) {
     case "delegation":
       return (
-        <Box marginY={6} pl={5} m={1} data-testid="decoded-item-delegate">
+        <Box margin={1} paddingLeft={5} data-testid="decoded-item-delegate" marginY={6}>
           Delegate to <AddressPill address={operation.recipient} />
         </Box>
       );
     case "undelegation":
       return (
-        <Box marginY={6} pl={5} m={1} data-testid="decoded-item-undelegate">
+        <Box margin={1} paddingLeft={5} data-testid="decoded-item-undelegate" marginY={6}>
           End Delegation
         </Box>
       );
@@ -29,8 +29,8 @@ const MultisigDecodedOperationItem: React.FC<{
       return (
         <Box marginY={6}>
           <MultisigOperationAmount operation={operation} />
-          <Flex alignItems="center" pl={5} m={1}>
-            <Heading color={colors.gray[400]} size="sm" mr={2}>
+          <Flex alignItems="center" margin={1} paddingLeft={5}>
+            <Heading marginRight={2} color={colors.gray[400]} size="sm">
               Send to :
             </Heading>
             <AddressPill address={operation.recipient} />
@@ -52,8 +52,8 @@ const MultisigOperationAmount: React.FC<{
     case "tez":
       return (
         <Flex alignItems="center" data-testid="decoded-tez-amount">
-          <Icon h={5} w={5} as={FiArrowUpRight} color={colors.gray[400]}></Icon>
-          <Text textAlign="center" ml={1}>
+          <Icon as={FiArrowUpRight} width={5} height={5} color={colors.gray[400]}></Icon>
+          <Text marginLeft={1} textAlign="center">
             -{prettyTezAmount(operation.amount)}
           </Text>
         </Flex>
@@ -71,13 +71,13 @@ const MultisigOperationAmount: React.FC<{
 
       return (
         <Flex alignItems="center" data-testid="decoded-fa-amount">
-          <Icon h={5} w={5} as={FiArrowUpRight} color={colors.gray[400]}></Icon>
+          <Icon as={FiArrowUpRight} width={5} height={5} color={colors.gray[400]}></Icon>
           {isNFT ? (
-            <Text textAlign="center" ml={1}>
+            <Text marginLeft={1} textAlign="center">
               {operation.amount} {name}
             </Text>
           ) : (
-            <Text textAlign="center" ml={1}>
+            <Text marginLeft={1} textAlign="center">
               -{tokenPrettyAmount(operation.amount, asset, { showSymbol: true })}
             </Text>
           )}

--- a/src/components/AccountDrawer/AssetsPanel/MultisigPendingAccordion/MultisigDecodedOperations.tsx
+++ b/src/components/AccountDrawer/AssetsPanel/MultisigPendingAccordion/MultisigDecodedOperations.tsx
@@ -39,17 +39,17 @@ const UnrecognizedOperationAccordion: React.FC<{ unrecoginizedRawActions: string
   unrecoginizedRawActions,
 }) => {
   return (
-    <Accordion allowMultiple={true} w="70%" mb={2}>
-      <AccordionItem bg="umami.gray.800" border="none" borderRadius="8px" mb="2">
+    <Accordion width="70%" marginBottom={2} allowMultiple={true}>
+      <AccordionItem marginBottom="2" background="umami.gray.800" border="none" borderRadius="8px">
         <h2>
           <AccordionButton>
-            <Box as="span" pl={1} flex="1" textAlign="left">
+            <Box as="span" flex="1" paddingLeft={1} textAlign="left">
               Unrecognized operation
             </Box>
             <AccordionIcon />
           </AccordionButton>
         </h2>
-        <AccordionPanel pb={3} h="400px" overflowY="scroll">
+        <AccordionPanel overflowY="scroll" height="400px" paddingBottom={3}>
           <JsValueWrap value={JSON.parse(unrecoginizedRawActions)} space={1} />
         </AccordionPanel>
       </AccordionItem>

--- a/src/components/AccountDrawer/AssetsPanel/MultisigPendingAccordion/MultisigPendingAccordionItem.tsx
+++ b/src/components/AccountDrawer/AssetsPanel/MultisigPendingAccordion/MultisigPendingAccordionItem.tsx
@@ -23,27 +23,27 @@ export const MultisigPendingAccordionItem: React.FC<{
   const pendingApprovals = Math.max(threshold - operation.approvals.length, 0);
   return (
     <Box
-      bg={colors.gray[800]}
-      p={3}
+      padding={3}
+      paddingBottom={0}
+      background={colors.gray[800]}
       borderRadius={6}
-      marginY={3}
-      pb={0}
       data-testid={"multisig-pending-operation-" + operation.id}
+      marginY={3}
     >
       <AccordionItem border="none" borderRadius="8px">
         <h2>
-          <AccordionButton flex="1" textAlign="left" pb={0} mb={0}>
-            <Heading w="100%" size="sm">
+          <AccordionButton flex="1" marginBottom={0} paddingBottom={0} textAlign="left">
+            <Heading width="100%" size="sm">
               Pending #{operation.id}
             </Heading>
             <AccordionIcon />
           </AccordionButton>
         </h2>
         <AccordionPanel>
-          <Flex marginY={2} justifyContent="space-between" alignItems="end">
+          <Flex alignItems="end" justifyContent="space-between" marginY={2}>
             <MultisigDecodedOperations rawActions={operation.rawActions} sender={sender} />
-            <Flex alignItems="center" mb="6">
-              <Heading color={colors.gray[400]} size="sm" mr={1}>
+            <Flex alignItems="center" marginBottom="6">
+              <Heading marginRight={1} color={colors.gray[400]} size="sm">
                 Pending Approvals:
               </Heading>
               <Text color="w" data-testid="pending-approvals-count">

--- a/src/components/AccountDrawer/AssetsPanel/MultisigPendingAccordion/index.tsx
+++ b/src/components/AccountDrawer/AssetsPanel/MultisigPendingAccordion/index.tsx
@@ -15,7 +15,7 @@ export const MultisigPendingAccordion: React.FC<{
     return <NoItems title="No multisig pending operations" small />;
   }
   return (
-    <Box w="100%">
+    <Box width="100%">
       <Accordion allowMultiple={true} defaultIndex={range(pendingOperations.length)}>
         {pendingOperations.map(operation => (
           <MultisigPendingAccordionItem key={operation.id} operation={operation} sender={account} />

--- a/src/components/AccountDrawer/AssetsPanel/NFTsGrid.tsx
+++ b/src/components/AccountDrawer/AssetsPanel/NFTsGrid.tsx
@@ -33,24 +33,24 @@ export const NFTsGrid: FC<
           const fallbackUrl = getIPFSurl(nft.displayUri);
           return (
             <Link to={`/home/${owner}/${fullId(nft)}`} key={`${owner}:${fullId(nft)}`}>
-              <Card bg={colors.gray[800]}>
-                <CardBody p="8px">
+              <Card background={colors.gray[800]}>
+                <CardBody padding="8px">
                   <AspectRatio width="100%" ratio={1}>
-                    <Image width="100%" height={40} src={url} fallbackSrc={fallbackUrl} />
+                    <Image width="100%" height={40} fallbackSrc={fallbackUrl} src={url} />
                   </AspectRatio>
                   {/* TODO: make a separate component to be shared between this and the drawer NFT card */}
                   {Number(nft.balance) > 1 && (
                     <Text
-                      data-testid="nft-owned-count"
-                      borderRadius="100px"
-                      padding="0 8px"
-                      height="20px"
-                      size="xs"
-                      backgroundColor="rgba(33, 33, 33, 0.75)"
-                      display="inline"
                       position="absolute"
+                      display="inline"
+                      height="20px"
                       marginTop="-24px"
                       marginLeft="4px"
+                      padding="0 8px"
+                      borderRadius="100px"
+                      backgroundColor="rgba(33, 33, 33, 0.75)"
+                      data-testid="nft-owned-count"
+                      size="xs"
                     >
                       {"x" + nft.balance}
                     </Text>

--- a/src/components/AccountDrawer/AssetsPanel/TokenList.tsx
+++ b/src/components/AccountDrawer/AssetsPanel/TokenList.tsx
@@ -10,15 +10,15 @@ const TokenTile = ({ token }: { token: FA12TokenBalance | FA2TokenBalance }) => 
   const prettyAmount = tokenPrettyAmount(token.balance, token, { showSymbol: false });
   return (
     <Flex
-      justifyContent="space-around"
       alignItems="center"
+      justifyContent="space-around"
+      height={20}
       borderBottom={`1px solid ${colors.gray[800]}`}
-      h={20}
       data-testid="token-tile"
     >
-      <Flex flex={1} alignItems="center">
+      <Flex alignItems="center" flex={1}>
         <TokenIcon w="38px" contract={token.contract} bg={colors.gray[500]} borderRadius="4px" />
-        <Box ml="16px">
+        <Box marginLeft="16px">
           <TokenNameWithIcon token={token} fontWeight={600} data-testid="token-name" />
         </Box>
       </Flex>

--- a/src/components/AccountDrawer/JsValueWrap.tsx
+++ b/src/components/AccountDrawer/JsValueWrap.tsx
@@ -4,7 +4,7 @@ import colors from "../../style/colors";
 // Wrapper for any JavaScript value
 const JsValueWrap: React.FC<{ value: any; space?: number }> = ({ value, space = 2 }) => {
   return (
-    <Card bg={colors.gray[700]} borderRadius="5px">
+    <Card background={colors.gray[700]} borderRadius="5px">
       <CardBody>
         <pre
           style={{

--- a/src/components/AccountDrawer/MultisigApprovers.tsx
+++ b/src/components/AccountDrawer/MultisigApprovers.tsx
@@ -18,22 +18,28 @@ const MultisigApprovers: React.FC<{
   signers: ImplicitAddress[];
 }> = ({ signers }) => {
   return (
-    <Box w="100%" bg={colors.gray[800]} p="15px" borderRadius="8px" mt="60px">
+    <Box
+      width="100%"
+      marginTop="60px"
+      padding="15px"
+      background={colors.gray[800]}
+      borderRadius="8px"
+    >
       <Accordion allowToggle defaultIndex={0}>
-        <AccordionItem bg={colors.gray[800]} border="none" borderRadius="8px">
+        <AccordionItem background={colors.gray[800]} border="none" borderRadius="8px">
           <h2>
             <AccordionButton as="span" flex="1" textAlign="left">
-              <Heading w="100%" size="sm">
+              <Heading width="100%" size="sm">
                 Approvers
               </Heading>
               <AccordionIcon cursor="pointer" />
             </AccordionButton>
           </h2>
           <AccordionPanel>
-            <Wrap mt="3" data-testid="multisig-tag-section">
+            <Wrap marginTop="3" data-testid="multisig-tag-section">
               {signers.map(signer => {
                 return (
-                  <WrapItem key={signer.pkh} borderRadius="100px" padding="3px 8px">
+                  <WrapItem key={signer.pkh} padding="3px 8px" borderRadius="100px">
                     <AddressPill address={signer} />
                   </WrapItem>
                 );

--- a/src/components/AccountDrawer/RenameAccountModal.tsx
+++ b/src/components/AccountDrawer/RenameAccountModal.tsx
@@ -60,7 +60,7 @@ export const RenameAccountModal: FC<{
         <FormPageHeader title="Edit Name" subTitle="Edit your account name here." />
         <ModalCloseButton />
         <ModalBody>
-          <FormControl marginY="20px" isInvalid={!!errors.name}>
+          <FormControl isInvalid={!!errors.name} marginY="20px">
             <FormLabel>Account name</FormLabel>
             <Input
               type="text"
@@ -77,7 +77,7 @@ export const RenameAccountModal: FC<{
         </ModalBody>
 
         <ModalFooter>
-          <Button width="100%" size="lg" type="submit" mb="8px" isDisabled={!isValid}>
+          <Button width="100%" marginBottom="8px" isDisabled={!isValid} size="lg" type="submit">
             Save
           </Button>
         </ModalFooter>

--- a/src/components/AccountSelector/AccountListDisplay.tsx
+++ b/src/components/AccountSelector/AccountListDisplay.tsx
@@ -9,22 +9,28 @@ export const AccountListDisplay: React.FC<{
   onSelect: (account: Account) => void;
 }> = ({ accounts, onSelect }) => {
   return (
-    <MenuList bg={colors.gray[900]} maxHeight="300px" p={0} overflowY="scroll" zIndex="docked">
+    <MenuList
+      zIndex="docked"
+      overflowY="scroll"
+      maxHeight="300px"
+      padding={0}
+      background={colors.gray[900]}
+    >
       {accounts.map(account => {
         return (
           <MenuItem
-            value={account.address.pkh}
+            key={account.address.pkh}
+            width="100%"
+            minHeight="48px"
+            padding="5px"
+            background={colors.gray[700]}
             aria-label={account.label}
             onClick={() => {
               onSelect(account);
             }}
-            key={account.address.pkh}
-            minH="48px"
-            w="100%"
-            padding="5px"
             // TODO implement hover color that disappeared
             // https://app.asana.com/0/1204165186238194/1204412123679802/f
-            bg={colors.gray[700]}
+            value={account.address.pkh}
           >
             <AddressTile
               cursor="pointer"

--- a/src/components/AccountSelector/AccountSmallTileDisplay.tsx
+++ b/src/components/AccountSelector/AccountSmallTileDisplay.tsx
@@ -24,13 +24,13 @@ export const AccountSmallTileDisplay = ({
   label?: string;
   balance: string | undefined;
 } & FlexProps) => (
-  <Flex data-testid="account-small-tile" alignItems="space-between" cursor="pointer" {...flexProps}>
+  <Flex alignItems="space-between" cursor="pointer" data-testid="account-small-tile" {...flexProps}>
     <Identicon height="30px" identiconSize={20} p="5px" address={pkh} mr="12px" />
-    <Flex height="20px" alignSelf="center">
-      <Heading size="sm" mr="10px">
+    <Flex alignSelf="center" height="20px">
+      <Heading marginRight="10px" size="sm">
         {label}
       </Heading>
-      <Text size="xs" color={colors.gray[300]} mr="35px">
+      <Text marginRight="35px" color={colors.gray[300]} size="xs">
         {formatPkh(pkh)}
       </Text>
       {balance && <Heading size="sm">{prettyTezAmount(balance)}</Heading>}

--- a/src/components/AccountTile/AccountTile.tsx
+++ b/src/components/AccountTile/AccountTile.tsx
@@ -21,17 +21,17 @@ export const AccountTileBase: React.FC<
 > = ({ icon, leftElement, rightElement, ...flexProps }) => {
   return (
     <Flex
-      mb={4}
-      p={4}
-      bg={colors.gray[900]}
-      h={90}
-      borderRadius={4}
-      border={`1px solid ${colors.gray[800]}`}
       alignItems="center"
+      height={90}
+      marginBottom={4}
+      padding={4}
+      background={colors.gray[900]}
+      border={`1px solid ${colors.gray[800]}`}
+      borderRadius={4}
       {...flexProps}
     >
       {icon}
-      <Flex flex={1} justifyContent="space-between" alignItems="center">
+      <Flex alignItems="center" justifyContent="space-between" flex={1}>
         {leftElement}
         {rightElement}
       </Flex>
@@ -44,10 +44,10 @@ export const LabelAndAddress: React.FC<{ label: string | null; pkh: string }> = 
   pkh,
 }) => {
   return (
-    <Box m={4} data-testid="account-identifier">
+    <Box margin={4} data-testid="account-identifier">
       {label && <Heading size="md">{label}</Heading>}
       <Flex alignItems="center">
-        <Text size="sm" color="text.dark">
+        <Text color="text.dark" size="sm">
           {formatPkh(pkh)}
         </Text>
       </Flex>
@@ -73,15 +73,15 @@ export const AccountTile: React.FC<{
 
   return (
     <Box
-      bg={colors.gray[900]}
+      background={colors.gray[900]}
+      border={`1px solid ${selected ? colors.orangeL : colors.gray[800]}`}
+      borderRadius="8px"
       _hover={{
         border,
       }}
-      borderRadius="8px"
-      px="21px"
-      border={`1px solid ${selected ? colors.orangeL : colors.gray[800]}`}
-      onClick={onClick}
       cursor="pointer"
+      onClick={onClick}
+      paddingX="21px"
     >
       <AccountTileBase
         data-testid={`account-tile-${address}` + (selected ? "-selected" : "")}
@@ -93,7 +93,7 @@ export const AccountTile: React.FC<{
         leftElement={<LabelAndAddress pkh={address} label={addressKind.label} />}
         rightElement={
           <Flex flexDirection="column">
-            <Text align="right" fontWeight={700} color={colors.gray[450]} size="sm">
+            <Text align="right" color={colors.gray[450]} fontWeight={700} size="sm">
               {/* crutch to make some the same padding at the top */}
               {/* TODO: split it into separate components instead of right/left elements */}
               {isDelegating ? "Delegated" : <>&nbsp;</>}
@@ -109,15 +109,20 @@ export const AccountTile: React.FC<{
       {nfts.length > 0 && (
         <Flex flexDirection="column">
           <Divider />
-          <Flex my="21px">
+          <Flex marginY="21px">
             {nfts.slice(0, MAX_NFT_COUNT).map((nft, i) => {
               const url = getIPFSurl(thumbnailUri(nft));
 
               if (i === MAX_NFT_COUNT - 1) {
                 return (
                   <Link to="/nfts" key="last">
-                    <Box borderRadius="4px" bg={colors.gray[600]} ml="4px" height="32px">
-                      <Text color={colors.gray[450]} fontWeight={700} width="32px" align="center">
+                    <Box
+                      height="32px"
+                      marginLeft="4px"
+                      background={colors.gray[600]}
+                      borderRadius="4px"
+                    >
+                      <Text align="center" width="32px" color={colors.gray[450]} fontWeight={700}>
                         ...
                       </Text>
                     </Box>
@@ -130,7 +135,7 @@ export const AccountTile: React.FC<{
                   to={`/home/${address}/${fullId(nft)}`}
                   key={fullId(nft)}
                 >
-                  <AspectRatio w="32px" h="32px" ratio={1} ml={i > 0 ? "4px" : 0}>
+                  <AspectRatio width="32px" height="32px" marginLeft={i > 0 ? "4px" : 0} ratio={1}>
                     <Image borderRadius="4px" src={url} />
                   </AspectRatio>
                 </Link>

--- a/src/components/AccountTile/AccountTileIcon.tsx
+++ b/src/components/AccountTile/AccountTileIcon.tsx
@@ -17,7 +17,13 @@ const AccountTileIcon: React.FC<{ addressKind: AddressKind }> = ({ addressKind }
     case "baker": {
       const bg = addressKind.type === "social" ? "white" : colors.gray[500];
       return (
-        <Flex bg={bg} borderRadius="4px" p="4px" justifyContent="center" alignItems="center">
+        <Flex
+          alignItems="center"
+          justifyContent="center"
+          padding="4px"
+          background={bg}
+          borderRadius="4px"
+        >
           <AddressTileIcon addressKind={addressKind} size="lg" />
         </Flex>
       );

--- a/src/components/AddressAutocomplete/AddressAutocomplete.tsx
+++ b/src/components/AddressAutocomplete/AddressAutocomplete.tsx
@@ -144,14 +144,14 @@ export const AddressAutocomplete = <T extends FieldValues, U extends Path<T>>({
       {state === "disabled_tile" && <AddressTile address={parsePkh(currentRealValue)} />}
       {state === "selected_tile" && (
         <Box
-          data-testid={`selected-address-tile-${currentRealValue}`}
-          borderRadius="4px"
+          height="48px"
+          background={colors.gray[800]}
           border="1px solid"
           borderColor={colors.gray[500]}
-          bg={colors.gray[800]}
-          height="48px"
+          borderRadius="4px"
+          data-testid={`selected-address-tile-${currentRealValue}`}
           onClick={clearInput}
-          py={0}
+          paddingY={0}
         >
           <Center
             justifyContent="space-between"
@@ -176,10 +176,9 @@ export const AddressAutocomplete = <T extends FieldValues, U extends Path<T>>({
         <InputGroup>
           <Input
             {...style}
-            id={inputId}
             aria-label={inputName}
-            value={rawValue}
-            onFocus={() => setHideSuggestions(false)}
+            autoComplete="off"
+            id={inputId}
             onBlur={e => {
               e.preventDefault();
               setHideSuggestions(true);
@@ -190,8 +189,9 @@ export const AddressAutocomplete = <T extends FieldValues, U extends Path<T>>({
               handleChange(e.target.value);
             }}
             onChange={e => handleChange(e.target.value)}
-            autoComplete="off"
+            onFocus={() => setHideSuggestions(false)}
             placeholder="Enter address or contact name"
+            value={rawValue}
           />
           <InputRightElement>
             {rawValue ? (
@@ -204,10 +204,10 @@ export const AddressAutocomplete = <T extends FieldValues, U extends Path<T>>({
       )}
       <Input
         {...register<U>(inputName, { required: "Invalid address or contact name", validate })}
-        mb={0}
+        marginBottom={0}
+        data-testid={`real-address-input-${inputName}`}
         name={inputName}
         type="hidden"
-        data-testid={`real-address-input-${inputName}`}
       />
 
       {!hideSuggestions && <Suggestions contacts={suggestions} onChange={handleChange} />}

--- a/src/components/AddressAutocomplete/Suggestions.tsx
+++ b/src/components/AddressAutocomplete/Suggestions.tsx
@@ -17,30 +17,30 @@ export const Suggestions = ({
 
   return (
     <UnorderedList
-      data-testid="suggestions-list"
-      overflowY="auto"
-      mt="8px"
-      ml={0}
-      width="100%"
-      borderRadius="8px"
-      listStyleType="none"
       position="absolute"
+      zIndex={2}
+      overflowY="auto"
+      width="100%"
+      maxHeight={300}
+      marginTop="8px"
+      marginLeft={0}
+      background={colors.gray[700]}
       border="1px solid"
       borderColor={colors.gray[500]}
-      bg={colors.gray[700]}
-      zIndex={2}
-      maxHeight={300}
+      borderRadius="8px"
+      data-testid="suggestions-list"
+      listStyleType="none"
     >
       {contacts.map((contact, i) => (
         <Box key={contact.pkh}>
           <ListItem
+            marginBottom={i === contacts.length - 1 ? "5px" : 0}
+            padding="5px 15px 0 5px"
             onMouseDown={() => {
               // onMouseDown is the only way for this to fire before the onBlur callback of the Input
               // https://stackoverflow.com/a/28963938/6797267
               onChange(contact.name);
             }}
-            padding="5px 15px 0 5px"
-            mb={i === contacts.length - 1 ? "5px" : 0}
           >
             <AddressTile
               cursor="pointer"

--- a/src/components/AddressPill/AddressPill.tsx
+++ b/src/components/AddressPill/AddressPill.tsx
@@ -64,11 +64,11 @@ const AddressPill: React.FC<
   }
 
   return (
-    <Box data-testid="address-pill" maxW="max-content" {...rest}>
+    <Box maxWidth="max-content" data-testid="address-pill" {...rest}>
       <Flex
         ref={ref}
         alignItems="center"
-        bg={bgColor}
+        background={bgColor}
         borderRadius="full"
         onMouseEnter={() => {
           setMouseHover(true);
@@ -87,9 +87,9 @@ const AddressPill: React.FC<
           />
         )}
 
-        <Popover isOpen={isOpen} onOpen={onClickAddress} autoFocus={false}>
+        <Popover autoFocus={false} isOpen={isOpen} onOpen={onClickAddress}>
           <PopoverTrigger>
-            <Button variant="unstyled" h="24px" _focus={{ boxShadow: "none" }}>
+            <Button height="24px" _focus={{ boxShadow: "none" }} variant="unstyled">
               <AddressPillText
                 data-testid="address-pill-text"
                 alias={isAlias && rawAddress.alias ? rawAddress.alias : undefined}
@@ -102,10 +102,10 @@ const AddressPill: React.FC<
               />
             </Button>
           </PopoverTrigger>
-          <PopoverContent bg="white" maxW="max-content">
-            <PopoverArrow bg="white" />
+          <PopoverContent maxWidth="max-content" background="white">
+            <PopoverArrow background="white" />
             <PopoverBody>
-              <Text size="sm" color="black">
+              <Text color="black" size="sm">
                 Copied!
               </Text>
             </PopoverBody>

--- a/src/components/AddressTile/AddressTile.tsx
+++ b/src/components/AddressTile/AddressTile.tsx
@@ -19,32 +19,32 @@ const AddressTile: React.FC<{ address: Address } & FlexProps> = ({ address, ...f
   const addressKind = useAddressKind(address);
 
   return (
-    <Tooltip hasArrow placement="left" bg={colors.white} label={addressKind.label}>
+    <Tooltip background={colors.white} hasArrow label={addressKind.label} placement="left">
       <Flex
-        data-testid="address-tile"
         alignItems="center"
-        w="400px"
-        p="9px 10px"
-        borderRadius="4px"
-        bg={colors.gray[800]}
         justifyContent="space-between"
+        width="400px"
+        padding="9px 10px"
+        background={colors.gray[800]}
+        borderRadius="4px"
+        data-testid="address-tile"
         {...flexProps}
       >
         <Flex alignItems="center">
           <AddressTileIcon addressKind={addressKind} />
 
           {addressKind.type === "unknown" ? (
-            <Text color={colors.gray[300]} size="sm" ml="10px">
+            <Text marginLeft="10px" color={colors.gray[300]} size="sm">
               {address.pkh}
             </Text>
           ) : (
             <>
-              <Box ml="12px" width="102px" whiteSpace="nowrap" overflow="hidden">
-                <Heading size="sm" overflow="hidden" textOverflow="ellipsis">
+              <Box overflow="hidden" width="102px" marginLeft="12px" whiteSpace="nowrap">
+                <Heading overflow="hidden" textOverflow="ellipsis" size="sm">
                   {addressKind.label}
                 </Heading>
               </Box>
-              <Text color={colors.gray[300]} size="xs" ml="10px" width="89px">
+              <Text width="89px" marginLeft="10px" color={colors.gray[300]} size="xs">
                 {formatPkh(addressKind.pkh)}
               </Text>
             </>

--- a/src/components/AnnouncementBanner.tsx
+++ b/src/components/AnnouncementBanner.tsx
@@ -29,9 +29,9 @@ export const AnnouncementBanner: React.FC = () => {
 
   const MaintanceIcon = maintanceIcon;
   return open && message ? (
-    <Alert data-testid="announcement" color="black" bg="#FC7884">
+    <Alert color="black" background="#FC7884" data-testid="announcement">
       <MaintanceIcon />
-      <Box w="100%" pl="8px">
+      <Box width="100%" paddingLeft="8px">
         <AlertDescription>{message}</AlertDescription>
       </Box>
       <CloseButton onClick={() => setOpen(false)} />

--- a/src/components/AssetTiles/TezTile.tsx
+++ b/src/components/AssetTiles/TezTile.tsx
@@ -6,7 +6,13 @@ import { PrettyNumber } from "../PrettyNumber";
 
 export const TezTile: React.FC<{ mutezAmount: string }> = ({ mutezAmount }) => {
   return (
-    <Flex h="60px" borderRadius="4px" bg={colors.gray[800]} alignItems="center" p="15px">
+    <Flex
+      alignItems="center"
+      height="60px"
+      padding="15px"
+      background={colors.gray[800]}
+      borderRadius="4px"
+    >
       <TezIcon mr="12px" />
       <Flex alignItems="end">
         <PrettyNumber number={prettyTezAmount(mutezAmount)} />

--- a/src/components/BuyTez/BuyTezForm.tsx
+++ b/src/components/BuyTez/BuyTezForm.tsx
@@ -50,8 +50,8 @@ const BuyTezForm: React.FC<{
               <ModalBody>
                 <FormControl
                   data-testid="buy-tez-selector"
-                  paddingY={5}
                   isInvalid={!!errors.address}
+                  paddingY={5}
                 >
                   <OwnedImplicitAccountsAutocomplete
                     label="Recipient Account"
@@ -67,7 +67,7 @@ const BuyTezForm: React.FC<{
 
           <ModalFooter>
             <Box width="100%" data-testid="buy-tez-button">
-              <Button width="100%" type="submit" size="lg" isDisabled={!isValid} mb={2}>
+              <Button width="100%" marginBottom={2} isDisabled={!isValid} size="lg" type="submit">
                 {title}
               </Button>
             </Box>

--- a/src/components/CSVFileUploader/CSVFileUploadForm.tsx
+++ b/src/components/CSVFileUploader/CSVFileUploadForm.tsx
@@ -95,16 +95,16 @@ const CSVFileUploadForm = () => {
           <ModalHeader textAlign="center">Load CSV file</ModalHeader>
           <Text textAlign="center">Select an account and then upload the CSV file.</Text>
           <ModalBody>
-            <FormControl paddingY={5} isInvalid={!!errors.sender}>
+            <FormControl isInvalid={!!errors.sender} paddingY={5}>
               <OwnedAccountsAutocomplete label="From" inputName="sender" allowUnknown={false} />
               {errors.sender && <FormErrorMessage>{errors.sender.message}</FormErrorMessage>}
             </FormControl>
 
-            <FormControl pt={5} isInvalid={!!errors.file}>
+            <FormControl paddingTop={5} isInvalid={!!errors.file}>
               <FormLabel>Select CSV</FormLabel>
               <Flex>
                 <Input
-                  p={2}
+                  padding={2}
                   {...form.register("file", { required: "File is required" })}
                   accept=".csv"
                   type="file"
@@ -118,12 +118,12 @@ const CSVFileUploadForm = () => {
           <ModalFooter>
             <Box width="100%">
               <Button
+                width="100%"
+                marginBottom={2}
                 isDisabled={!isValid}
                 isLoading={isLoading}
                 size="lg"
-                width="100%"
                 type="submit"
-                mb={2}
               >
                 Upload
               </Button>

--- a/src/components/CSVFileUploader/index.tsx
+++ b/src/components/CSVFileUploader/index.tsx
@@ -7,8 +7,8 @@ import FileArrowDownIcon from "../../assets/icons/FileArrowDown";
 const CSVFileUploader = () => {
   const { openWith } = useContext(DynamicModalContext);
   return (
-    <Button variant="CTAWithIcon" onClick={() => openWith(<CSVFileUploadForm />)}>
-      <Text mr="4px" size="sm">
+    <Button onClick={() => openWith(<CSVFileUploadForm />)} variant="CTAWithIcon">
+      <Text marginRight="4px" size="sm">
         Load CSV file
       </Text>
       <FileArrowDownIcon stroke="currentcolor" />

--- a/src/components/ChangePassword/ChangePasswordForm.tsx
+++ b/src/components/ChangePassword/ChangePasswordForm.tsx
@@ -56,17 +56,17 @@ export const ChangePasswordForm: React.FC = () => {
 
   return (
     <FormProvider {...form}>
-      <ModalContent data-testid="change-password-modal" bg={colors.gray[700]}>
+      <ModalContent background={colors.gray[700]} data-testid="change-password-modal">
         <form onSubmit={handleSubmit(onSubmit)}>
           <ModalCloseButton />
 
-          <ModalHeader mt={5} textAlign="center">
+          <ModalHeader marginTop={5} textAlign="center">
             <Box>
               <Heading>Change Password</Heading>
             </Box>
           </ModalHeader>
           <ModalBody>
-            <FormControl isInvalid={!!errors.currentPassword} mt={3}>
+            <FormControl marginTop={3} isInvalid={!!errors.currentPassword}>
               <PasswordInput
                 inputName="currentPassword"
                 label="Current Password"
@@ -81,7 +81,7 @@ export const ChangePasswordForm: React.FC = () => {
               )}
             </FormControl>
 
-            <FormControl isInvalid={!!errors.newPassword} my={6}>
+            <FormControl isInvalid={!!errors.newPassword} marginY={6}>
               <PasswordInput
                 inputName="newPassword"
                 label="New Password"
@@ -99,7 +99,7 @@ export const ChangePasswordForm: React.FC = () => {
               )}
             </FormControl>
 
-            <FormControl isInvalid={!!errors.newPasswordConfirmation} mt={3}>
+            <FormControl marginTop={3} isInvalid={!!errors.newPasswordConfirmation}>
               <PasswordInput
                 inputName="newPasswordConfirmation"
                 label="Confirm New Password"
@@ -119,7 +119,13 @@ export const ChangePasswordForm: React.FC = () => {
             </FormControl>
           </ModalBody>
           <ModalFooter>
-            <Button marginY={3} isDisabled={!isValid} isLoading={isLoading} w="100%" type="submit">
+            <Button
+              width="100%"
+              isDisabled={!isValid}
+              isLoading={isLoading}
+              marginY={3}
+              type="submit"
+            >
               Update Password
             </Button>
           </ModalFooter>

--- a/src/components/CircleIcon.tsx
+++ b/src/components/CircleIcon.tsx
@@ -11,14 +11,14 @@ type Props = {
 export const CircleIcon = ({ icon, size, onClick = () => {} }: Props) => {
   return (
     <Box
-      height={size}
       width={size}
-      borderRadius="full"
-      bg={colors.gray[700]}
+      height={size}
       margin="auto"
+      background={colors.gray[700]}
+      borderRadius="full"
       onClick={onClick}
     >
-      <Center h="100%">{icon}</Center>
+      <Center height="100%">{icon}</Center>
     </Box>
   );
 };

--- a/src/components/ClickableCard.tsx
+++ b/src/components/ClickableCard.tsx
@@ -13,16 +13,16 @@ const ClickableCard: React.FC<
 > = ({ onClick, children, isSelected, ...props }) => {
   return (
     <Card
+      justifyContent="center"
       height="66px"
-      padding="24px"
       marginBottom="10px"
-      bgColor={colors.gray[900]}
-      borderRadius="lg"
+      padding="24px"
       border="1px solid"
       borderColor={isSelected ? ` ${colors.orangeL}` : "transparent"}
+      borderRadius="lg"
       _hover={{ border: `1px solid ${colors.gray[500]}`, bg: colors.gray[800] }}
-      justifyContent="center"
       cursor={onClick ? "pointer" : undefined}
+      backgroundColor={colors.gray[900]}
       onClick={onClick}
       {...props}
     >
@@ -38,8 +38,8 @@ export const SettingsCardWithDrawerIcon: React.FC<{
 }> = ({ left, isSelected, onClick }) => {
   return (
     <ClickableCard onClick={onClick} isSelected={isSelected}>
-      <Flex alignItems="center" h="100%">
-        <Flex justifyContent="space-between" alignItems="center" w="100%">
+      <Flex alignItems="center" height="100%">
+        <Flex alignItems="center" justifyContent="space-between" width="100%">
           <Heading size="sm">{left}</Heading>
           <ChevronRightIcon />
         </Flex>

--- a/src/components/ConfirmationModal.tsx
+++ b/src/components/ConfirmationModal.tsx
@@ -43,7 +43,7 @@ export const ConfirmationModal: React.FC<{
         </ModalBody>
       )}
       <ModalFooter>
-        <Button w="100%" onClick={onClick} variant="warning">
+        <Button width="100%" onClick={onClick} variant="warning">
           {buttonLabel}
         </Button>
       </ModalFooter>

--- a/src/components/ContactModal.tsx
+++ b/src/components/ContactModal.tsx
@@ -99,7 +99,7 @@ export const UpsertContactModal: FC<{
         <ModalHeader textAlign="center">{title}</ModalHeader>
         <ModalCloseButton />
         <ModalBody>
-          <FormControl marginY={5} isInvalid={!!errors.name}>
+          <FormControl isInvalid={!!errors.name} marginY={5}>
             <FormLabel>Name</FormLabel>
             <Input
               type="text"
@@ -111,7 +111,7 @@ export const UpsertContactModal: FC<{
             />
             {errors.name && <FormErrorMessage>{errors.name.message}</FormErrorMessage>}
           </FormControl>
-          <FormControl marginY={5} isInvalid={!!errors.pkh}>
+          <FormControl isInvalid={!!errors.pkh} marginY={5}>
             <FormLabel>Address</FormLabel>
             <Input
               type="text"
@@ -119,18 +119,18 @@ export const UpsertContactModal: FC<{
                 required: "Address is required",
                 validate: validatePkh,
               })}
-              value={contact?.pkh}
-              variant={isEdit ? "filled" : undefined}
               disabled={isEdit}
               placeholder="Enter contact’s tz address"
+              value={contact?.pkh}
+              variant={isEdit ? "filled" : undefined}
             />
             {errors.pkh && <FormErrorMessage>{errors.pkh.message}</FormErrorMessage>}
           </FormControl>
         </ModalBody>
 
-        <ModalFooter p="16px 0 0 0">
+        <ModalFooter padding="16px 0 0 0">
           <Box width="100%">
-            <Button width="100%" size="lg" type="submit" mb={2} isDisabled={!isValid}>
+            <Button width="100%" marginBottom={2} isDisabled={!isValid} size="lg" type="submit">
               {buttonText}
             </Button>
           </Box>
@@ -154,12 +154,12 @@ export const DeleteContactModal: FC<{
       <ModalHeader textAlign="center">Delete Contact</ModalHeader>
       <ModalCloseButton />
       <ModalBody>
-        <Flex alignItems="center" direction="column" justifyContent="space-between">
-          <Text size="sm" color={colors.gray[400]}>
+        <Flex alignItems="center" justifyContent="space-between" flexDirection="column">
+          <Text color={colors.gray[400]} size="sm">
             Are you sure you want to remove this contact?
           </Text>
-          <Box mt={5}>
-            <Heading size="md" textAlign="center" mb={3}>
+          <Box marginTop={5}>
+            <Heading marginBottom={3} textAlign="center" size="md">
               {contact.name}
             </Heading>
             <CopyableAddress pkh={contact.pkh} />
@@ -169,7 +169,7 @@ export const DeleteContactModal: FC<{
 
       <ModalFooter>
         <Box width="100%">
-          <Button width="100%" variant="warning" onClick={onDeleteContact} mb={2}>
+          <Button width="100%" marginBottom={2} onClick={onDeleteContact} variant="warning">
             Delete
           </Button>
         </Box>

--- a/src/components/CopyableText.tsx
+++ b/src/components/CopyableText.tsx
@@ -61,7 +61,7 @@ const CopyableText: React.FC<
 
   return (
     <Flex alignItems="center" {...rest}>
-      <Text size="sm" color={colors.gray[400]} mr="6px">
+      <Text marginRight="6px" color={colors.gray[400]} size="sm">
         {displayText}
       </Text>
       {copyValue && (
@@ -84,24 +84,24 @@ const ToastBody: React.FC<{
 }> = ({ message, onClose }) => {
   return (
     <Flex
-      p={2}
+      alignItems="center"
+      justifyContent="space-between"
+      padding={2}
       borderRadius="4px"
       backgroundColor="white"
-      justifyContent="space-between"
-      alignItems="center"
     >
       <Flex alignItems="center">
-        <Icon color={colors.green} as={BsCheckCircle} m={1} />
+        <Icon as={BsCheckCircle} margin={1} color={colors.green} />
         <Text color="black">{message}</Text>
       </Flex>
 
       <Icon
-        color="black"
         as={RxCross1}
-        cursor="pointer"
+        color="black"
         _hover={{
           color: colors.gray[600],
         }}
+        cursor="pointer"
         onClick={onClose}
       />
     </Flex>

--- a/src/components/DynamicModal.tsx
+++ b/src/components/DynamicModal.tsx
@@ -39,13 +39,13 @@ export const useDynamicModal = () => {
     openWith,
     content: (
       <Modal
+        autoFocus={false}
+        blockScrollOnMount={false}
+        closeOnOverlayClick={false}
+        isCentered
         isOpen={isOpen}
         onClose={onClose}
-        closeOnOverlayClick={false}
-        blockScrollOnMount={false}
-        autoFocus={false}
         size={size}
-        isCentered
       >
         <ModalOverlay />
         <RemoveScroll enabled={isOpen}>{modalContent}</RemoveScroll>

--- a/src/components/ErrorPage.tsx
+++ b/src/components/ErrorPage.tsx
@@ -26,19 +26,19 @@ export const ErrorPage: React.FC = () => {
 
   return (
     <Flex alignItems="stretch">
-      <Center w="100%" mt="200px">
+      <Center width="100%" marginTop="200px">
         <Box>
-          <Heading textAlign="center" mb={3}>
+          <Heading marginBottom={3} textAlign="center">
             Ooops, something went wrong!
           </Heading>
 
-          <Button onClick={onRefresh} mr={2}>
+          <Button marginRight={2} onClick={onRefresh}>
             Refresh the page
           </Button>
-          <Button mr={2} variant="secondary" onClick={onBackup}>
+          <Button marginRight={2} onClick={onBackup} variant="secondary">
             Download Backup
           </Button>
-          <Button mr={2} variant="warning" onClick={onOffboard}>
+          <Button marginRight={2} onClick={onOffboard} variant="warning">
             Offboard
           </Button>
           <Button variant="tertiary">

--- a/src/components/ExternalLink.tsx
+++ b/src/components/ExternalLink.tsx
@@ -7,13 +7,13 @@ export const ExternalLink: React.FC<PropsWithChildren<{ href: string } & LinkPro
   ...props
 }) => (
   <Link
-    href={href}
-    role="link"
-    display="flex"
-    target="_blank"
-    rel="noopener noreferrer"
     alignItems="center"
+    display="flex"
     _hover={{ textDecoration: "none" }}
+    href={href}
+    rel="noopener noreferrer"
+    role="link"
+    target="_blank"
     {...props}
   >
     {children}

--- a/src/components/FormErrorMessage.tsx
+++ b/src/components/FormErrorMessage.tsx
@@ -9,7 +9,7 @@ import ExclamationIcon from "../assets/icons/Exclamation";
 export const FormErrorMessage = ({ children, ...props }: FormErrorMessageProps) => {
   return (
     <OriginalFormErrorMessage color={colors.orange} fontSize="12px" {...props}>
-      <Icon as={ExclamationIcon} mr="6px" />
+      <Icon as={ExclamationIcon} marginRight="6px" />
       {children}
     </OriginalFormErrorMessage>
   );

--- a/src/components/IconAndTextBtn.tsx
+++ b/src/components/IconAndTextBtn.tsx
@@ -28,7 +28,7 @@ export const IconAndTextBtn: React.FC<Props> = ({
   textFirst,
   ...rest
 }) => {
-  const iconEL = <Icon w={iconWidth} h={iconHeight} as={icon} color={iconColor} />;
+  const iconEL = <Icon as={icon} width={iconWidth} height={iconHeight} color={iconColor} />;
   const textMargin_ = textFirst ? { mr: textMargin } : { ml: textMargin };
   const textEl = (
     <Text {...textMargin_} fontSize="sm">
@@ -37,15 +37,15 @@ export const IconAndTextBtn: React.FC<Props> = ({
   );
   return (
     <Flex
-      role="button"
-      color="text.dark"
-      justifyContent="space-between"
       alignItems="center"
-      onClick={onClick}
-      cursor="pointer"
+      justifyContent="space-between"
+      color="text.dark"
       _hover={{
         color: colors.gray[300],
       }}
+      cursor="pointer"
+      onClick={onClick}
+      role="button"
       {...rest}
     >
       {textFirst ? textEl : null}

--- a/src/components/Identicon.tsx
+++ b/src/components/Identicon.tsx
@@ -14,14 +14,14 @@ export const Identicon: React.FC<
 > = ({ address, identiconSize, ...props }) => {
   return (
     <Box
-      data-testid="identicon"
       sx={{
         canvas: {
           borderRadius: "4px",
         },
       }}
-      bg="white"
+      background="white"
       borderRadius="4px"
+      data-testid="identicon"
       {...props}
     >
       <ReactIdenticons

--- a/src/components/MakiLogo.tsx
+++ b/src/components/MakiLogo.tsx
@@ -8,5 +8,5 @@ export const MakiLogo: React.FC<{ size?: string | number } & ImageProps> = ({
   size = 100,
   ...props
 }) => {
-  return <Image boxSize={size} objectFit="cover" src={makiLogo} alt="Maki logo" {...props} />;
+  return <Image boxSize={size} objectFit="cover" alt="Maki logo" src={makiLogo} {...props} />;
 };

--- a/src/components/ModalBackButton.tsx
+++ b/src/components/ModalBackButton.tsx
@@ -5,10 +5,10 @@ import { backButtonStyle } from "../style/theme/modal";
 export const ModalBackButton = ({ onClick }: { onClick: () => void }) => (
   <IconButton
     {...backButtonStyle}
-    variant="ghost"
-    size="sm"
     aria-label="Back"
     icon={<ArrowBackIcon width="24px" height="20px" />}
     onClick={onClick}
+    size="sm"
+    variant="ghost"
   />
 );

--- a/src/components/NetworkSelector.tsx
+++ b/src/components/NetworkSelector.tsx
@@ -15,15 +15,15 @@ export const NetworkSelector = () => {
   return (
     <Box width="105px">
       <Select
-        data-testid="network-selector"
-        border="1px solid transparent"
-        p={0}
-        size="xs"
+        padding={0}
+        color={colors.green}
         fontSize="14px"
         fontWeight={600}
-        color={colors.green}
-        value={currentNetwork.name}
+        border="1px solid transparent"
+        data-testid="network-selector"
         onChange={e => selectNetwork(e.target.value)}
+        size="xs"
+        value={currentNetwork.name}
       >
         {availableNetworks.map(network => (
           <option key={network.name} value={network.name}>

--- a/src/components/NoItems/index.tsx
+++ b/src/components/NoItems/index.tsx
@@ -11,9 +11,9 @@ const NoItems: React.FC<
 > = ({ title, children, small = false }) => {
   const headingSize = small ? "md" : "3xl";
   return (
-    <Flex width="100%" height="100%" justifyContent="center" alignItems="center">
+    <Flex alignItems="center" justifyContent="center" width="100%" height="100%">
       <Box>
-        <Heading size={headingSize} p="42px">
+        <Heading padding="42px" size={headingSize}>
           {title}
         </Heading>
         <Center>{children}</Center>
@@ -41,7 +41,7 @@ export const NoDelegations: React.FC<{ small?: boolean; onDelegate: () => void }
   onDelegate,
 }) => (
   <NoItems title="Currently not delegating" small={small}>
-    <Button size={small ? "md" : "lg"} onClick={onDelegate}>
+    <Button onClick={onDelegate} size={small ? "md" : "lg"}>
       Start delegating
     </Button>
   </NoItems>

--- a/src/components/Offboarding/OffboardingForm.tsx
+++ b/src/components/Offboarding/OffboardingForm.tsx
@@ -45,33 +45,39 @@ const OffboardingForm = () => {
       <form onSubmit={handleSubmit(onSubmit)}>
         <ModalCloseButton />
 
-        <ModalHeader textAlign="center" marginBottom="12px">
+        <ModalHeader marginBottom="12px" textAlign="center">
           <Box>
             <WarningIcon w={10} h={10} mb={5} />
             <Heading>Off-board Wallet</Heading>
           </Box>
         </ModalHeader>
         <Box>
-          <Text textAlign="center" color={colors.gray[400]} fontWeight="bold" size="sm" mb={2}>
+          <Text
+            marginBottom={2}
+            color={colors.gray[400]}
+            fontWeight="bold"
+            textAlign="center"
+            size="sm"
+          >
             This will permanently remove any data from this computer.
           </Text>
-          <Text textAlign="center" color={colors.gray[400]} size="sm">
+          <Text color={colors.gray[400]} textAlign="center" size="sm">
             Please enter « {CONFIRMATION_CODE} » to confirm. The accounts are still available to be
             imported in the future; in order to regain access to your accounts, please make sure
             that you keep the recovery phrase.
           </Text>
           <ModalBody>
-            <Divider marginY={5} borderColor={colors.gray[700]} />
+            <Divider borderColor={colors.gray[700]} marginY={5} />
             <FormControl isInvalid={!!errors.check}>
               <Checkbox {...register("check", { required: true })}>
-                <Text ml={2} fontWeight="bold">
+                <Text marginLeft={2} fontWeight="bold">
                   I have read the warning and I am certain I want to remove my private keys locally.
                   I also made sure to keep my recovery phrase.
                 </Text>
               </Checkbox>
             </FormControl>
-            <Divider marginY={5} borderColor={colors.gray[700]} />
-            <FormControl paddingY={5} isInvalid={!!errors.confirmationCode}>
+            <Divider borderColor={colors.gray[700]} marginY={5} />
+            <FormControl isInvalid={!!errors.confirmationCode} paddingY={5}>
               <Input
                 type="text"
                 {...register("confirmationCode", {
@@ -91,11 +97,11 @@ const OffboardingForm = () => {
         <ModalFooter padding={0}>
           <Button
             width="100%"
+            marginBottom={2}
+            isDisabled={!isValid}
             size="lg"
             type="submit"
-            isDisabled={!isValid}
             variant="warning"
-            mb={2}
           >
             Confirm
           </Button>

--- a/src/components/Offboarding/useOffboardingModal.tsx
+++ b/src/components/Offboarding/useOffboardingModal.tsx
@@ -7,9 +7,9 @@ const useOffboardingModal = () => {
 
   return {
     modalElement: (
-      <Modal isOpen={isOpen} onClose={onClose} isCentered>
+      <Modal isCentered isOpen={isOpen} onClose={onClose}>
         <ModalOverlay />
-        <ModalContent bg={colors.gray[900]}>
+        <ModalContent background={colors.gray[900]}>
           <OffboardingForm />
         </ModalContent>
       </Modal>

--- a/src/components/Onboarding/FakeAccount.tsx
+++ b/src/components/Onboarding/FakeAccount.tsx
@@ -31,19 +31,19 @@ export const FakeAccount = ({ onClose }: { onClose: () => void }) => {
           <FormLabel>Address</FormLabel>
           <Input
             {...register("pkh", { required: true })}
-            placeholder="Please enter the account address"
             autoComplete="off"
+            placeholder="Please enter the account address"
           />
         </FormControl>
         <FormControl isInvalid={!!errors.name}>
           <FormLabel>Name</FormLabel>
           <Input
             {...register("name", { required: true })}
-            placeholder="Please enter the account name"
             autoComplete="off"
+            placeholder="Please enter the account name"
           />
         </FormControl>
-        <Button w="100%" size="lg" type="submit" mt={2}>
+        <Button width="100%" marginTop={2} size="lg" type="submit">
           Add account
         </Button>
       </form>

--- a/src/components/Onboarding/ModalContentWrapper.tsx
+++ b/src/components/Onboarding/ModalContentWrapper.tsx
@@ -12,14 +12,14 @@ type Props = {
 
 export default function ModalContentWrapper({ children, icon, title, subtitle }: Props) {
   return (
-    <VStack maxH="83vh" spacing={0}>
-      <Box mb="20px">
+    <VStack maxHeight="83vh" spacing={0}>
+      <Box marginBottom="20px">
         <CircleIcon size="48px" icon={icon} />
       </Box>
-      <Center mb="32px" flexDirection="column">
+      <Center flexDirection="column" marginBottom="32px">
         <Heading size="xl">{title}</Heading>
         {subtitle && (
-          <Text textAlign="center" size="sm" mt="10px" color={colors.gray[400]}>
+          <Text marginTop="10px" color={colors.gray[400]} textAlign="center" size="sm">
             {subtitle}
           </Text>
         )}

--- a/src/components/Onboarding/connectOptions/ConnectOptions.tsx
+++ b/src/components/Onboarding/connectOptions/ConnectOptions.tsx
@@ -6,35 +6,35 @@ import LinkIcon from "../../../assets/icons/Link";
 const ConnectOptions = ({ goToStep }: { goToStep: (step: Step) => void }) => {
   return (
     <ModalContentWrapper icon={<LinkIcon />} title="Connect or Import Account">
-      <VStack w="100%" spacing="16px">
-        <Button w="100%" size="lg" onClick={_ => goToStep({ type: StepType.restoreMnemonic })}>
+      <VStack width="100%" spacing="16px">
+        <Button width="100%" onClick={_ => goToStep({ type: StepType.restoreMnemonic })} size="lg">
           Import with Seed Phrase
         </Button>
         <Button
-          w="100%"
+          width="100%"
+          onClick={_ => goToStep({ type: StepType.restoreSecretKey })}
           size="lg"
           variant="tertiary"
-          onClick={_ => goToStep({ type: StepType.restoreSecretKey })}
         >
           Import with a Secret Key
         </Button>
         <Button
-          variant="tertiary"
-          w="100%"
-          size="lg"
+          width="100%"
           onClick={_ => {
             goToStep({ type: StepType.restoreBackup });
           }}
+          size="lg"
+          variant="tertiary"
         >
           Restore from Backup
         </Button>
         <Button
-          w="100%"
-          size="lg"
-          variant="tertiary"
+          width="100%"
           onClick={_ => {
             goToStep({ type: StepType.nameAccount, account: { type: "ledger" } });
           }}
+          size="lg"
+          variant="tertiary"
         >
           Connect ledger
         </Button>

--- a/src/components/Onboarding/connectOrCreate/ConnectOrCreate.tsx
+++ b/src/components/Onboarding/connectOrCreate/ConnectOrCreate.tsx
@@ -29,36 +29,42 @@ const ConnectOrCreate = ({
 
   return (
     <ModalContentWrapper icon={<WalletPlusIcon />} title="Connect or Create Account">
-      <VStack w="100%" spacing="16px">
-        <Button w="100%" size="lg" onClick={_ => goToStep({ type: StepType.notice })}>
+      <VStack width="100%" spacing="16px">
+        <Button width="100%" onClick={_ => goToStep({ type: StepType.notice })} size="lg">
           Create a new Account
         </Button>
         <Button
-          variant="tertiary"
-          w="100%"
-          size="lg"
+          width="100%"
           onClick={_ => goToStep({ type: StepType.connectOptions })}
+          size="lg"
+          variant="tertiary"
         >
           I already have a wallet
         </Button>
         {
           /* devblock:start */
           <Button
-            variant="tertiary"
-            w="100%"
-            size="lg"
+            width="100%"
             onClick={_ => goToStep({ type: StepType.fakeAccount })}
+            size="lg"
+            variant="tertiary"
           >
             Add a Fake Account
           </Button>
           /* devblock:end */
         }
-        <Flex w="100%" pt="14px" pb="6px">
-          <Divider mt="11px" />
-          <Text textAlign="center" minW="160px" size="sm" noOfLines={1} color={colors.gray[400]}>
+        <Flex width="100%" paddingTop="14px" paddingBottom="6px">
+          <Divider marginTop="11px" />
+          <Text
+            minWidth="160px"
+            color={colors.gray[400]}
+            textAlign="center"
+            noOfLines={1}
+            size="sm"
+          >
             Continue with Google
           </Text>
-          <Divider mt="11px" />
+          <Divider marginTop="11px" />
         </Flex>
         <GoogleAuth onSuccessfulAuth={onSuccessfulSocialAuth} />
       </VStack>

--- a/src/components/Onboarding/derivationPath/DerivationPath.tsx
+++ b/src/components/Onboarding/derivationPath/DerivationPath.tsx
@@ -69,7 +69,7 @@ export const DerivationPath = ({
             </FormErrorMessage>
           )}
         </FormControl>
-        <Button mt="12px" w="100%" size="lg" type="submit">
+        <Button width="100%" marginTop="12px" size="lg" type="submit">
           Continue
         </Button>
       </form>

--- a/src/components/Onboarding/eula/Eula.tsx
+++ b/src/components/Onboarding/eula/Eula.tsx
@@ -11,33 +11,37 @@ const Eula: React.FC<{
   return (
     <ModalContentWrapper icon={<DocumentIcon />} title="Accept to Continue">
       <>
-        <Checkbox onChange={e => setIsChecked(e.target.checked)} pb="24px" fontWeight="600">
+        <Checkbox
+          paddingBottom="24px"
+          fontWeight="600"
+          onChange={e => setIsChecked(e.target.checked)}
+        >
           I confirm that I have read and agreed with the{" "}
           <Link
             textDecoration="underline"
-            target="_blank"
-            rel="noopener noreferrer"
             href="https://umamiwallet.com/tos.html"
+            rel="noopener noreferrer"
+            target="_blank"
           >
             Terms of Service
           </Link>{" "}
           and the{" "}
           <Link
             textDecoration="underline"
-            target="_blank"
-            rel="noopener noreferrer"
             href="https://umamiwallet.com/privacypolicy.html"
+            rel="noopener noreferrer"
+            target="_blank"
           >
             Privacy Policy
           </Link>
         </Checkbox>
         <Button
-          w="100%"
-          size="lg"
+          width="100%"
           isDisabled={!isChecked}
           onClick={() => {
             goToStep({ type: StepType.connectOrCreate });
           }}
+          size="lg"
         >
           Continue
         </Button>

--- a/src/components/Onboarding/masterPassword/password/EnterAndConfirmPassword.tsx
+++ b/src/components/Onboarding/masterPassword/password/EnterAndConfirmPassword.tsx
@@ -47,7 +47,7 @@ export const EnterAndConfirmPassword: React.FC<{
             {errors.password && <FormErrorMessage>{errors.password.message}</FormErrorMessage>}
           </FormControl>
 
-          <FormControl mt="24px" isInvalid={!!errors.confirm}>
+          <FormControl marginTop="24px" isInvalid={!!errors.confirm}>
             <PasswordInput
               inputName="confirm"
               label="Confirm Password"
@@ -61,12 +61,12 @@ export const EnterAndConfirmPassword: React.FC<{
             {errors.confirm && <FormErrorMessage>{errors.confirm.message}</FormErrorMessage>}
           </FormControl>
           <Button
-            mt="32px"
+            width="100%"
+            marginTop="32px"
             isDisabled={!isValid || isLoading}
             isLoading={isLoading}
-            type="submit"
-            w="100%"
             size="lg"
+            type="submit"
           >
             Submit
           </Button>

--- a/src/components/Onboarding/masterPassword/password/EnterPassword.tsx
+++ b/src/components/Onboarding/masterPassword/password/EnterPassword.tsx
@@ -41,8 +41,8 @@ const EnterPassword = ({
           </FormControl>
 
           <Button
-            mt="32px"
             width="100%"
+            marginTop="32px"
             isDisabled={!isValid}
             isLoading={isLoading}
             size="lg"

--- a/src/components/Onboarding/nameAccount/NameAccountDisplay.tsx
+++ b/src/components/Onboarding/nameAccount/NameAccountDisplay.tsx
@@ -32,7 +32,7 @@ const NameAccountDisplay = ({
           />
         </FormControl>
 
-        <Button mt="32px" w="100%" size="lg" type="submit">
+        <Button width="100%" marginTop="32px" size="lg" type="submit">
           Continue
         </Button>
       </form>

--- a/src/components/Onboarding/notice/Notice.tsx
+++ b/src/components/Onboarding/notice/Notice.tsx
@@ -35,24 +35,24 @@ const Notice: React.FC<{
           })}
         </OrderedList>
         <Button
-          w="100%"
-          size="lg"
-          mt="28px"
+          width="100%"
+          marginTop="28px"
           onClick={() =>
             goToStep({
               type: StepType.showSeedphrase,
               account: { type: "mnemonic", mnemonic: generate24WordMnemonic() },
             })
           }
+          size="lg"
         >
           I understand
         </Button>
         <Button
-          w="100%"
-          size="lg"
-          mt="16px"
-          variant="tertiary"
+          width="100%"
+          marginTop="16px"
           onClick={() => goToStep({ type: StepType.restoreMnemonic })}
+          size="lg"
+          variant="tertiary"
         >
           I already have a Seed Phrase
         </Button>

--- a/src/components/Onboarding/restoreBackupFile/RestoreBackupFile.tsx
+++ b/src/components/Onboarding/restoreBackupFile/RestoreBackupFile.tsx
@@ -61,8 +61,8 @@ const RestoreBackupFile = () => {
               <FormLabel>Upload File</FormLabel>
               <Flex>
                 <Input
+                  padding="2px"
                   data-testid="file-input"
-                  p="2px"
                   {...register("file", { required: "File is required" })}
                   accept=".json"
                   type="file"
@@ -73,7 +73,7 @@ const RestoreBackupFile = () => {
                 <FormErrorMessage data-testid="file">{errors.file.message}</FormErrorMessage>
               )}
             </FormControl>
-            <FormControl isInvalid={!!errors.password} mt="24px">
+            <FormControl marginTop="24px" isInvalid={!!errors.password}>
               <PasswordInput
                 inputName="password"
                 label="Your password"
@@ -85,7 +85,7 @@ const RestoreBackupFile = () => {
                 </FormErrorMessage>
               )}
             </FormControl>
-            <Button type="submit" w="100%" size="lg" isDisabled={!isValid} mt="32px">
+            <Button width="100%" marginTop="32px" isDisabled={!isValid} size="lg" type="submit">
               Import Wallet
             </Button>
           </ModalBody>

--- a/src/components/Onboarding/restoreLedger/RestoreLedger.tsx
+++ b/src/components/Onboarding/restoreLedger/RestoreLedger.tsx
@@ -79,13 +79,13 @@ const RestoreLedger = ({
       title="Connect Ledger"
       subtitle="Complete the steps to connect."
     >
-      <VStack spacing="24px" overflowY="auto">
+      <VStack overflowY="auto" spacing="24px">
         <OrderedList spacing={4}>
           {noticeItems.map((item, index) => {
             return <ListItem key={index}>{item.content}</ListItem>;
           })}
         </OrderedList>
-        <Button w="100%" size="lg" isLoading={isLoading} onClick={connectLedger}>
+        <Button width="100%" isLoading={isLoading} onClick={connectLedger} size="lg">
           Export Public Key
         </Button>
       </VStack>

--- a/src/components/Onboarding/restoreMnemonic/RestoreMnemonic.tsx
+++ b/src/components/Onboarding/restoreMnemonic/RestoreMnemonic.tsx
@@ -81,12 +81,12 @@ const RestoreMnemonic = ({ goToStep }: { goToStep: (step: Step) => void }) => {
     >
       <Box overflowX="hidden">
         <form onSubmit={handleSubmit(onSubmit)} style={{ width: "100%" }}>
-          <VStack w="100%" spacing={4}>
+          <VStack width="100%" spacing={4}>
             <Select
-              data-testid="select"
-              icon={<ChevronDownIcon />}
               height="48px"
               color={colors.gray[450]}
+              data-testid="select"
+              icon={<ChevronDownIcon />}
               onChange={event => handleMnemonicSizeChange(event.target.value)}
               value={mnemonicSize}
             >
@@ -99,40 +99,40 @@ const RestoreMnemonic = ({ goToStep }: { goToStep: (step: Step) => void }) => {
               })}
             </Select>
 
-            <Grid templateColumns="repeat(3, 1fr)" gap={3} pb="20px">
+            <Grid gridGap={3} gridTemplateColumns="repeat(3, 1fr)" paddingBottom="20px">
               {range(mnemonicSize).map(index => {
                 return (
                   <GridItem
                     key={index}
+                    display="flex"
+                    height="38px"
+                    padding="4px"
                     fontSize="sm"
+                    background={colors.gray[800]}
                     border="1px solid"
                     borderColor={colors.gray[500]}
                     borderRadius="4px"
-                    bg={colors.gray[800]}
-                    p="4px"
-                    height="38px"
-                    display="flex"
                   >
                     <Heading
-                      pt="6px"
                       width="18px"
-                      textAlign="right"
+                      marginRight="6px"
+                      paddingTop="6px"
                       color={colors.gray[400]}
+                      textAlign="right"
                       size="sm"
-                      mr="6px"
                     >
                       {index + 1}
                     </Heading>
                     <Input
+                      border="none"
                       autoComplete="off"
                       onPaste={async e => {
                         e.preventDefault();
                         const mnemonic = await navigator.clipboard.readText();
                         pasteMnemonic(mnemonic);
                       }}
-                      size="xsmall"
-                      border="none"
                       placeholder="Type here..."
+                      size="xsmall"
                       {...register(`word${index}`, {
                         required: true,
                       })}
@@ -142,17 +142,17 @@ const RestoreMnemonic = ({ goToStep }: { goToStep: (step: Step) => void }) => {
                 );
               })}
             </Grid>
-            <Button type="submit" w="100%" size="lg" isDisabled={!isValid}>
+            <Button width="100%" isDisabled={!isValid} size="lg" type="submit">
               Continue
             </Button>
 
             {
               /* devblock:start */
               <Button
+                width="100%"
                 onClick={() => {
                   pasteMnemonic(mnemonic1);
                 }}
-                w="100%"
                 size="lg"
               >
                 Enter test mnemonic (Dev only)

--- a/src/components/Onboarding/restoreSecretKey/RestoreSecretKey.tsx
+++ b/src/components/Onboarding/restoreSecretKey/RestoreSecretKey.tsx
@@ -38,7 +38,13 @@ export const RestoreSecretKey = ({ goToStep }: { goToStep: (step: Step) => void 
           {errors.secretKey && <FormErrorMessage>{errors.secretKey.message}</FormErrorMessage>}
         </FormControl>
 
-        <Button isDisabled={!!errors.secretKey} mt="32px" w="100%" size="lg" type="submit">
+        <Button
+          width="100%"
+          marginTop="32px"
+          isDisabled={!!errors.secretKey}
+          size="lg"
+          type="submit"
+        >
           Continue
         </Button>
       </form>

--- a/src/components/Onboarding/showSeedphrase/ShowSeedphrase.tsx
+++ b/src/components/Onboarding/showSeedphrase/ShowSeedphrase.tsx
@@ -24,18 +24,18 @@ export const ShowSeedphrase = ({
               <Flex
                 key={index}
                 width="126px"
+                padding="6px"
                 border="1px dashed"
                 borderColor={colors.gray[500]}
                 borderRadius="4px"
-                p="6px"
               >
                 <Heading
                   width="18px"
-                  textAlign="right"
-                  mr="10px"
-                  pt="2px"
-                  size="sm"
+                  marginRight="10px"
+                  paddingTop="2px"
                   color={colors.gray[450]}
+                  textAlign="right"
+                  size="sm"
                 >
                   {index + 1}
                 </Heading>
@@ -45,12 +45,12 @@ export const ShowSeedphrase = ({
           })}
         </SimpleGrid>
         <Button
-          w="100%"
-          size="lg"
-          mt="20px"
+          width="100%"
+          marginTop="20px"
           onClick={_ => {
             goToStep({ type: StepType.verifySeedphrase, account });
           }}
+          size="lg"
         >
           OK, I've recorded it
         </Button>

--- a/src/components/Onboarding/useOnboardingModal.tsx
+++ b/src/components/Onboarding/useOnboardingModal.tsx
@@ -150,11 +150,11 @@ export const useOnboardingModal = (onModalClose?: () => void) => {
   return {
     modalElement: (
       <Modal
-        isOpen={isOpen}
-        onClose={closeModal}
+        autoFocus={false}
         closeOnOverlayClick={false}
         isCentered
-        autoFocus={false}
+        isOpen={isOpen}
+        onClose={closeModal}
       >
         {hasAccounts && <ModalOverlay />}
         <ModalContent>

--- a/src/components/Onboarding/verifySeedphrase/VerifySeedphrase.tsx
+++ b/src/components/Onboarding/verifySeedphrase/VerifySeedphrase.tsx
@@ -32,11 +32,15 @@ const VerifySeedphrase = ({
       title="Verify Seed Phrase"
       subtitle="To verify, please type in the word that corresponds to each sequence number."
     >
-      <Box overflowX="hidden" overflowY="auto" w="100%">
+      <Box overflowX="hidden" overflowY="auto" width="100%">
         <form onSubmit={handleSubmit(onSubmit)}>
           {randomElements.map((item, index) => {
             return (
-              <FormControl key={index} mb="12px" isInvalid={!!errors[`${item.index}`] && isDirty}>
+              <FormControl
+                key={index}
+                marginBottom="12px"
+                isInvalid={!!errors[`${item.index}`] && isDirty}
+              >
                 <InputGroup size="md">
                   <InputLeftElement>{item.index + 1}</InputLeftElement>
                   <Input
@@ -51,13 +55,13 @@ const VerifySeedphrase = ({
               </FormControl>
             );
           })}
-          <Button type="submit" w="100%" size="lg" mt="20px" isDisabled={!isValid}>
+          <Button width="100%" marginTop="20px" isDisabled={!isValid} size="lg" type="submit">
             Continue
           </Button>
 
           {
             /* devblock:start */
-            <Button onClick={onSubmit} mt="12px" w="100%" size="lg">
+            <Button width="100%" marginTop="12px" onClick={onSubmit} size="lg">
               Bypass (Dev only)
             </Button>
             /* devblock:end */

--- a/src/components/OperationTile/ContractCallTile.tsx
+++ b/src/components/OperationTile/ContractCallTile.tsx
@@ -19,8 +19,8 @@ export const ContractCallTile: React.FC<{
   const showAnyAddress = !showToAddress && !showFromAddress;
 
   return (
-    <Flex direction="column" data-testid="operation-tile-contract-call" w="100%">
-      <Flex justifyContent="space-between" mb="10px">
+    <Flex flexDirection="column" width="100%" data-testid="operation-tile-contract-call">
+      <Flex justifyContent="space-between" marginBottom="10px">
         <Center>
           <ContractIcon mr="8px" />
           <TzktLink hash={operation.hash} counter={operation.counter} data-testid="title" mr="8px">
@@ -36,8 +36,8 @@ export const ContractCallTile: React.FC<{
         <Flex justifyContent="space-between">
           <Flex>
             {showToAddress && (
-              <Flex mr="15px" data-testid="to">
-                <Text mr="6px" color={colors.gray[450]}>
+              <Flex marginRight="15px" data-testid="to">
+                <Text marginRight="6px" color={colors.gray[450]}>
                   To:
                 </Text>
                 <AddressPill address={operation.target} />
@@ -45,7 +45,7 @@ export const ContractCallTile: React.FC<{
             )}
             {(showFromAddress || showAnyAddress) && (
               <Flex data-testid="from">
-                <Text mr="6px" color={colors.gray[450]}>
+                <Text marginRight="6px" color={colors.gray[450]}>
                   From:
                 </Text>
                 <AddressPill address={operation.sender} />

--- a/src/components/OperationTile/DelegationTile.tsx
+++ b/src/components/OperationTile/DelegationTile.tsx
@@ -17,8 +17,8 @@ export const DelegationTile: React.FC<{ operation: DelegationOperation }> = ({ o
   const showFromAddress = useShowAddress(operation.sender.address);
 
   return (
-    <Flex direction="column" data-testid="operation-tile-delegation" w="100%">
-      <Flex justifyContent="space-between" mb="10px">
+    <Flex flexDirection="column" width="100%" data-testid="operation-tile-delegation">
+      <Flex justifyContent="space-between" marginBottom="10px">
         <Center>
           <BakerIcon stroke={colors.gray[450]} mr="8px" />
           <TzktLink data-testid="title" hash={operation.hash} counter={operation.counter} mr="8px">
@@ -34,8 +34,8 @@ export const DelegationTile: React.FC<{ operation: DelegationOperation }> = ({ o
         <Flex justifyContent="space-between">
           <Flex>
             {isDelegating && (
-              <Flex mr="15px" data-testid="to">
-                <Text mr="6px" color={colors.gray[450]}>
+              <Flex marginRight="15px" data-testid="to">
+                <Text marginRight="6px" color={colors.gray[450]}>
                   To:
                 </Text>
                 <AddressPill address={operation.newDelegate as TzktAlias} />
@@ -43,7 +43,7 @@ export const DelegationTile: React.FC<{ operation: DelegationOperation }> = ({ o
             )}
             {showFromAddress && (
               <Flex data-testid="from">
-                <Text mr="6px" color={colors.gray[450]}>
+                <Text marginRight="6px" color={colors.gray[450]}>
                   From:
                 </Text>
                 <AddressPill address={operation.sender} />

--- a/src/components/OperationTile/Fee.tsx
+++ b/src/components/OperationTile/Fee.tsx
@@ -39,7 +39,7 @@ export const Fee: React.FC<{
 
   return (
     <Center>
-      <Heading size="md" color={colors.gray[450]} mr="4px">
+      <Heading marginRight="4px" color={colors.gray[450]} size="md">
         Fee:
       </Heading>
       <Text color={colors.gray[400]} data-testid="fee">

--- a/src/components/OperationTile/OperationTypeWrapper.tsx
+++ b/src/components/OperationTile/OperationTypeWrapper.tsx
@@ -12,7 +12,7 @@ export const OperationTypeWrapper: React.FC<PropsWithChildren> = ({ children }) 
   }
 
   return (
-    <Text data-testid="operation-type" color={colors.gray[300]} size="sm" mr="4px">
+    <Text marginRight="4px" color={colors.gray[300]} data-testid="operation-type" size="sm">
       {children}
     </Text>
   );

--- a/src/components/OperationTile/OriginationTile.tsx
+++ b/src/components/OperationTile/OriginationTile.tsx
@@ -21,8 +21,8 @@ export const OriginationTile: React.FC<{ operation: OriginationOperation }> = ({
   const showFromAddress = useShowAddress(operation.sender.address);
 
   return (
-    <Flex direction="column" data-testid="operation-tile-origination" w="100%">
-      <Flex justifyContent="space-between" mb="10px">
+    <Flex flexDirection="column" width="100%" data-testid="operation-tile-origination">
+      <Flex justifyContent="space-between" marginBottom="10px">
         <Center>
           <ContractIcon mr="8px" />
           <TzktLink data-testid="title" hash={operation.hash} counter={operation.counter} mr="8px">
@@ -40,8 +40,8 @@ export const OriginationTile: React.FC<{ operation: OriginationOperation }> = ({
             {!showFromAddress ? (
               <Text color={colors.gray[450]}>N/A</Text>
             ) : (
-              <Flex mr="15px">
-                <Text mr="6px" color={colors.gray[450]}>
+              <Flex marginRight="15px">
+                <Text marginRight="6px" color={colors.gray[450]}>
                   From:
                 </Text>
                 <AddressPill address={operation.sender} />

--- a/src/components/OperationTile/Timestamp.tsx
+++ b/src/components/OperationTile/Timestamp.tsx
@@ -8,7 +8,7 @@ export const Timestamp: React.FC<{ timestamp: string | undefined }> = ({ timesta
   }
 
   return (
-    <Text data-testid="timestamp" size="sm" color={colors.gray[400]}>
+    <Text color={colors.gray[400]} data-testid="timestamp" size="sm">
       {getDisplayTimestamp(timestamp)}
     </Text>
   );

--- a/src/components/OperationTile/TokenTransferTile.tsx
+++ b/src/components/OperationTile/TokenTransferTile.tsx
@@ -41,14 +41,14 @@ export const TokenTransferTile: React.FC<{
 
   const titleElement = isNFT ? (
     <Tooltip
-      bg={colors.gray[700]}
+      padding="8px"
+      background={colors.gray[700]}
       border="1px solid"
       borderColor={colors.gray[500]}
       borderRadius="8px"
       data-testid="nft-tooltip"
-      p="8px"
       label={
-        <AspectRatio w="170px" h="170px" ratio={1}>
+        <AspectRatio width="170px" height="170px" ratio={1}>
           <Image src={getIPFSurl(thumbnailUri(token))} />
         </AspectRatio>
       }
@@ -62,7 +62,7 @@ export const TokenTransferTile: React.FC<{
           data-testid="title"
           color={underlineColor}
         >
-          <Text display="inline" fontWeight="600" color={titleColor}>
+          <Text display="inline" color={titleColor} fontWeight="600">
             {sign}
             {tokenAmount}
           </Text>
@@ -82,7 +82,7 @@ export const TokenTransferTile: React.FC<{
       data-testid="title"
       color={underlineColor}
     >
-      <Text display="inline" fontWeight="600" color={titleColor}>
+      <Text display="inline" color={titleColor} fontWeight="600">
         {sign}
         {tokenAmount}
       </Text>
@@ -90,8 +90,8 @@ export const TokenTransferTile: React.FC<{
   );
 
   return (
-    <Flex direction="column" data-testid="operation-tile-token-transfer" w="100%">
-      <Flex justifyContent="space-between" mb="10px">
+    <Flex flexDirection="column" width="100%" data-testid="operation-tile-token-transfer">
+      <Flex justifyContent="space-between" marginBottom="10px">
         <Center>
           <TransactionDirectionIcon isOutgoing={isOutgoing} mr="8px" />
           {titleElement}
@@ -105,8 +105,8 @@ export const TokenTransferTile: React.FC<{
         <Flex justifyContent="space-between">
           <Flex>
             {(showToAddress || showAnyAddress) && (
-              <Flex mr="15px" data-testid="to">
-                <Text mr="6px" color={colors.gray[450]}>
+              <Flex marginRight="15px" data-testid="to">
+                <Text marginRight="6px" color={colors.gray[450]}>
                   To:
                 </Text>
                 <AddressPill address={tokenTransfer.to} />
@@ -114,7 +114,7 @@ export const TokenTransferTile: React.FC<{
             )}
             {showFromAddress && (
               <Flex data-testid="from">
-                <Text mr="6px" color={colors.gray[450]}>
+                <Text marginRight="6px" color={colors.gray[450]}>
                   From:
                 </Text>
                 <AddressPill address={tokenTransfer.from as TzktAlias} />

--- a/src/components/OperationTile/TransactionTile.tsx
+++ b/src/components/OperationTile/TransactionTile.tsx
@@ -25,8 +25,8 @@ export const TransactionTile: React.FC<{ operation: TransactionOperation }> = ({
   const sign = isOutgoing ? "-" : "+";
 
   return (
-    <Flex direction="column" data-testid="operation-tile-transaction" w="100%">
-      <Flex justifyContent="space-between" mb="10px">
+    <Flex flexDirection="column" width="100%" data-testid="operation-tile-transaction">
+      <Flex justifyContent="space-between" marginBottom="10px">
         <Center>
           <TransactionDirectionIcon isOutgoing={isOutgoing} mr="8px" />
           <TzktLink
@@ -36,7 +36,7 @@ export const TransactionTile: React.FC<{ operation: TransactionOperation }> = ({
             data-testid="title"
             color={titleColor}
           >
-            <Text fontWeight="600" color={titleColor}>
+            <Text color={titleColor} fontWeight="600">
               {sign} {amount}
             </Text>
           </TzktLink>
@@ -50,8 +50,8 @@ export const TransactionTile: React.FC<{ operation: TransactionOperation }> = ({
         <Flex justifyContent="space-between">
           <Flex>
             {(showToAddress || showAnyAddress) && (
-              <Flex mr="15px" data-testid="to">
-                <Text mr="6px" color={colors.gray[450]}>
+              <Flex marginRight="15px" data-testid="to">
+                <Text marginRight="6px" color={colors.gray[450]}>
                   To:
                 </Text>
                 <AddressPill address={parsePkh(operation.target.address)} />
@@ -59,7 +59,7 @@ export const TransactionTile: React.FC<{ operation: TransactionOperation }> = ({
             )}
             {showFromAddress && (
               <Flex data-testid="from">
-                <Text mr="6px" color={colors.gray[450]}>
+                <Text marginRight="6px" color={colors.gray[450]}>
                   From:
                 </Text>
                 <AddressPill address={parsePkh(operation.sender.address)} />

--- a/src/components/PasswordInput.tsx
+++ b/src/components/PasswordInput.tsx
@@ -35,12 +35,12 @@ const PasswordInput = <T extends FieldValues, U extends Path<T>>({
   return (
     <>
       <FormLabel>{label}</FormLabel>
-      <InputGroup mt="12px">
+      <InputGroup marginTop="12px">
         <Input
-          type={showPassword ? "text" : "password"}
-          autoComplete="off"
           aria-label={label}
+          autoComplete="off"
           placeholder={placeholder}
+          type={showPassword ? "text" : "password"}
           {...register(inputName, {
             required,
             minLength: {
@@ -52,7 +52,7 @@ const PasswordInput = <T extends FieldValues, U extends Path<T>>({
           {...rest}
         />
         <InputRightElement>
-          <Button tabIndex={-1} variant="unstyled" onClick={() => setShowPassword(val => !val)}>
+          <Button onClick={() => setShowPassword(val => !val)} tabIndex={-1} variant="unstyled">
             {showPassword ? (
               <EyeSlashIcon data-testid="eye-slash-icon" />
             ) : (

--- a/src/components/PopoverMenu.tsx
+++ b/src/components/PopoverMenu.tsx
@@ -17,25 +17,25 @@ const PopoverMenu: React.FC<{
 }> = props => {
   const { onOpen, onClose, isOpen } = useDisclosure();
   return (
-    <Popover placement="bottom-start" isOpen={isOpen} onOpen={onOpen} onClose={onClose}>
+    <Popover isOpen={isOpen} onClose={onClose} onOpen={onOpen} placement="bottom-start">
       <PopoverTrigger>
         <Button
-          bg={isOpen ? colors.green : colors.gray[500]}
-          _hover={{ bg: isOpen ? colors.green : colors.gray[450] }}
-          variant="unstyled"
-          borderRadius="full"
-          border="none"
-          height="24px"
           minWidth="24px"
+          height="24px"
+          padding="0"
+          background={isOpen ? colors.green : colors.gray[500]}
+          border="none"
+          borderRadius="full"
+          _hover={{ bg: isOpen ? colors.green : colors.gray[450] }}
           data-testid="popover-cta"
-          p="0"
+          variant="unstyled"
         >
           <Center>
-            <Icon display="inline" as={BsThreeDots} color={colors.white} />
+            <Icon as={BsThreeDots} display="inline" color={colors.white} />
           </Center>
         </Button>
       </PopoverTrigger>
-      <PopoverContent w="100px" bg={colors.gray[700]}>
+      <PopoverContent width="100px" background={colors.gray[700]}>
         <PopoverBody borderRadius="lg">{props.children}</PopoverBody>
       </PopoverContent>
     </Popover>

--- a/src/components/PrettyNumber.tsx
+++ b/src/components/PrettyNumber.tsx
@@ -18,7 +18,7 @@ export const PrettyNumber: React.FC<{
     <Flex alignItems="end" data-testid="pretty-number">
       <Heading size={intSize}>{integer}</Heading>
       {decimal && (
-        <Heading size={fractionSize} whiteSpace="nowrap" overflow="hidden" textOverflow="ellipsis">
+        <Heading overflow="hidden" whiteSpace="nowrap" textOverflow="ellipsis" size={fractionSize}>
           .{decimal}
         </Heading>
       )}

--- a/src/components/ReceiveModal.tsx
+++ b/src/components/ReceiveModal.tsx
@@ -18,21 +18,21 @@ export const ReceiveModal: FC<{
         subTitle="You can receive tez or other digital assets by scanning or sharing this QR code"
       />
       <ModalBody>
-        <Flex alignItems="center" direction="column" justifyContent="space-between">
-          <Box borderRadius="8px" bg="white" p="8px">
+        <Flex alignItems="center" justifyContent="space-between" flexDirection="column">
+          <Box padding="8px" background="white" borderRadius="8px">
             <QRCode value={pkh} size={232} />
           </Box>
         </Flex>
       </ModalBody>
 
       <ModalFooter>
-        <Box w="100%">
+        <Box width="100%">
           {account && (
             <Heading textAlign="center" marginY={2}>
               {account.label}
             </Heading>
           )}
-          <Flex justifyContent="center" w="100%">
+          <Flex justifyContent="center" width="100%">
             <AddressPill address={parsePkh(pkh)} mode={{ type: "no_icons" }} />
           </Flex>
         </Box>

--- a/src/components/RenameRemoveMenu.tsx
+++ b/src/components/RenameRemoveMenu.tsx
@@ -11,19 +11,19 @@ const RenameRemoveMenu: React.FC<{ onRename: () => void; onRemove?: () => void }
   return (
     <Flex alignItems="center">
       <PopoverMenu>
-        <Box py="0">
-          <Button variant="popover" h={onRemove ? "24px" : "28px"} onClick={onRename}>
+        <Box paddingY="0">
+          <Button height={onRemove ? "24px" : "28px"} onClick={onRename} variant="popover">
             <Flex alignItems="center">
-              <Text mr="4px">Rename</Text>
+              <Text marginRight="4px">Rename</Text>
               <PenIcon />
             </Flex>
           </Button>
           {onRemove && (
             <>
-              <Divider my="4px" />
-              <Button variant="popover" onClick={onRemove}>
+              <Divider marginY="4px" />
+              <Button onClick={onRemove} variant="popover">
                 <Flex alignItems="center">
-                  <Text mr="4px">Remove</Text>
+                  <Text marginRight="4px">Remove</Text>
                   <TrashIcon />
                 </Flex>
               </Button>

--- a/src/components/Select.tsx
+++ b/src/components/Select.tsx
@@ -15,17 +15,17 @@ export const Select: React.FC<{
   return (
     <Box>
       <Flex
-        data-testid="select-input"
-        justify="space-between"
+        justifyContent="space-between"
         height="48px"
-        bg={colors.gray[800]}
-        color={colors.gray[300]}
-        border="1px solid"
-        borderRadius="4px"
         padding="15px"
+        color={colors.gray[300]}
+        background={colors.gray[800]}
+        border="1px solid"
         borderColor={colors.gray[500]}
+        borderRadius="4px"
         _hover={{ borderColor: colors.gray[450] }}
         cursor="pointer"
+        data-testid="select-input"
         onClick={() => setShowOptions(show => !show)}
       >
         <Text size="sm">{currentOption.label}</Text>
@@ -33,29 +33,29 @@ export const Select: React.FC<{
       </Flex>
       {showOptions && (
         <UnorderedList
-          data-testid="select-options"
+          position="absolute"
+          zIndex={2}
+          width="100%"
           margin={0}
           marginTop="8px"
-          borderRadius="8px"
           padding="15px"
-          bg={colors.gray[700]}
+          background={colors.gray[700]}
           border="1px solid"
-          zIndex={2}
-          listStyleType="none"
-          width="100%"
-          position="absolute"
           borderColor={colors.gray[500]}
+          borderRadius="8px"
+          data-testid="select-options"
+          listStyleType="none"
         >
           {options.map(option => (
             <ListItem
-              padding="11px"
-              borderRadius="4px"
-              color={colors.gray[300]}
-              cursor="pointer"
               key={option.value}
-              bg="transparent"
-              _hover={{ background: colors.gray[500] }}
               marginBottom="5px"
+              padding="11px"
+              color={colors.gray[300]}
+              background="transparent"
+              borderRadius="4px"
+              _hover={{ background: colors.gray[500] }}
+              cursor="pointer"
               onClick={() => {
                 setShowOptions(false);
                 setCurrentOption(option);

--- a/src/components/SendButton.tsx
+++ b/src/components/SendButton.tsx
@@ -7,9 +7,9 @@ export const SendButton: React.FC<
   } & ButtonProps
 > = ({ onClick, ...buttonProps }) => {
   return (
-    <Button variant="specialCTA" width="60px" onClick={onClick} {...buttonProps}>
+    <Button width="60px" onClick={onClick} variant="specialCTA" {...buttonProps}>
       <OutgoingArrow stroke="currentcolor" />
-      <Text ml="4px">Send</Text>
+      <Text marginLeft="4px">Send</Text>
     </Button>
   );
 };

--- a/src/components/SendFlow/BakerSmallTile.tsx
+++ b/src/components/SendFlow/BakerSmallTile.tsx
@@ -16,19 +16,19 @@ export const BakerSmallTile: React.FC<{ pkh: RawPkh }> = ({ pkh }) => {
 
   return (
     <Flex
-      bg={colors.gray[800]}
-      w="100%"
       alignItems="center"
-      px="15px"
-      py="9px"
+      width="100%"
+      background={colors.gray[800]}
       data-testid="baker-tile"
+      paddingX="15px"
+      paddingY="9px"
     >
-      <AspectRatio mr="8px" height="30px" width="30px" ratio={1}>
+      <AspectRatio width="30px" height="30px" marginRight="8px" ratio={1}>
         <Image src={logoUrl} />
       </AspectRatio>
-      <Flex ml="8px" alignItems="center">
+      <Flex alignItems="center" marginLeft="8px">
         <Heading size="sm">{baker.name}</Heading>
-        <Text mx="12px" color={colors.gray[300]} size="sm">
+        <Text color={colors.gray[300]} marginX="12px" size="sm">
           {formatPkh(baker.address)}
         </Text>
       </Flex>

--- a/src/components/SendFlow/BatchModalBody.tsx
+++ b/src/components/SendFlow/BatchModalBody.tsx
@@ -21,12 +21,12 @@ export const BatchModalBody: React.FC<{
       <ModalBody>
         <FormLabel>From</FormLabel>
         <AddressTile address={signerAddress} />
-        <Flex my="12px" px="4px" alignItems="center" justifyContent="space-between">
+        <Flex alignItems="center" justifyContent="space-between" marginY="12px" paddingX="4px">
           <Flex>
-            <Text size="sm" mr={1} color={colors.gray[450]}>
+            <Text marginRight={1} color={colors.gray[450]} size="sm">
               Transactions:
             </Text>
-            <Text size="sm" data-testid="transaction-length" color={colors.gray[400]}>
+            <Text color={colors.gray[400]} data-testid="transaction-length" size="sm">
               {transactionCount}
             </Text>
           </Flex>

--- a/src/components/SendFlow/Beacon/ContractCallSignPage.tsx
+++ b/src/components/SendFlow/Beacon/ContractCallSignPage.tsx
@@ -45,19 +45,19 @@ const ContractCallSignPage: React.FC<BeaconSignPageProps> = ({ operation, onBeac
           <ModalBody>
             <TezTile mutezAmount={mutezAmount} />
 
-            <Flex mt="12px" alignItems="center" justifyContent="end">
+            <Flex alignItems="center" justifyContent="end" marginTop="12px">
               <SignPageFee fee={fee} />
             </Flex>
 
-            <FormLabel mt="24px">From </FormLabel>
+            <FormLabel marginTop="24px">From </FormLabel>
             <AddressTile address={operation.sender.address} />
 
-            <FormLabel mt="24px">To </FormLabel>
+            <FormLabel marginTop="24px">To </FormLabel>
             <AddressTile address={contract} />
 
-            <FormLabel mt="24px">Parameter</FormLabel>
+            <FormLabel marginTop="24px">Parameter</FormLabel>
             <Accordion allowToggle={true}>
-              <AccordionItem bg={colors.gray[800]} border="none" borderRadius="8px">
+              <AccordionItem background={colors.gray[800]} border="none" borderRadius="8px">
                 <AccordionButton>
                   <Box flex="1" textAlign="left">
                     JSON

--- a/src/components/SendFlow/Beacon/DelegationSignPage.tsx
+++ b/src/components/SendFlow/Beacon/DelegationSignPage.tsx
@@ -27,7 +27,13 @@ const DelegationSignPage: React.FC<BeaconSignPageProps> = ({ operation, onBeacon
             <FormLabel>From</FormLabel>
             <AddressTile address={operation.signer.address} />
 
-            <Flex mt="12px" mb="24px" px="4px" alignItems="center" justifyContent="end">
+            <Flex
+              alignItems="center"
+              justifyContent="end"
+              marginTop="12px"
+              marginBottom="24px"
+              paddingX="4px"
+            >
               <Flex alignItems="center">
                 <SignPageFee fee={fee} />
               </Flex>

--- a/src/components/SendFlow/Beacon/TezSignPage.tsx
+++ b/src/components/SendFlow/Beacon/TezSignPage.tsx
@@ -26,14 +26,14 @@ const TezSignPage: React.FC<BeaconSignPageProps> = ({ operation, onBeaconSuccess
           <ModalBody>
             <TezTile mutezAmount={mutezAmount} />
 
-            <Flex mt="12px" alignItems="center" justifyContent="end">
+            <Flex alignItems="center" justifyContent="end" marginTop="12px">
               <SignPageFee fee={fee} />
             </Flex>
 
-            <FormLabel mt="24px">From </FormLabel>
+            <FormLabel marginTop="24px">From </FormLabel>
             <AddressTile address={operation.sender.address} />
 
-            <FormLabel mt="24px">To </FormLabel>
+            <FormLabel marginTop="24px">To </FormLabel>
             <AddressTile address={recipient} />
           </ModalBody>
           <ModalFooter>

--- a/src/components/SendFlow/Beacon/UndelegationSignPage.tsx
+++ b/src/components/SendFlow/Beacon/UndelegationSignPage.tsx
@@ -23,7 +23,7 @@ const UndelegationSignPage: React.FC<BeaconSignPageProps> = ({ operation, onBeac
             <FormLabel>From</FormLabel>
             <AddressTile address={operation.signer.address} />
 
-            <Flex mt="12px" alignItems="center" justifyContent="end" px="4px">
+            <Flex alignItems="center" justifyContent="end" marginTop="12px" paddingX="4px">
               <SignPageFee fee={fee} />
             </Flex>
           </ModalBody>

--- a/src/components/SendFlow/Delegation/FormPage.tsx
+++ b/src/components/SendFlow/Delegation/FormPage.tsx
@@ -65,7 +65,7 @@ const FormPage: React.FC<FormPageProps<FormValues>> = props => {
       <ModalContent>
         <form>
           <HeaderWrapper>
-            <Text size="2xl" fontWeight="600">
+            <Text fontWeight="600" size="2xl">
               {baker ? "Change Baker" : "Delegate"}
             </Text>
             <ModalCloseButton />
@@ -86,7 +86,7 @@ const FormPage: React.FC<FormPageProps<FormValues>> = props => {
               )}
             </FormControl>
 
-            <FormControl mt="24px" isInvalid={!!errors.baker} data-testid="baker">
+            <FormControl marginTop="24px" data-testid="baker" isInvalid={!!errors.baker}>
               <BakersAutocomplete label="Baker" inputName="baker" allowUnknown />
               {errors.baker && <FormErrorMessage>{errors.baker.message}</FormErrorMessage>}
             </FormControl>

--- a/src/components/SendFlow/Delegation/SignPage.tsx
+++ b/src/components/SendFlow/Delegation/SignPage.tsx
@@ -23,7 +23,13 @@ const SignPage: React.FC<SignPageProps> = props => {
             <FormLabel>From</FormLabel>
             <AddressTile address={signer.address} />
 
-            <Flex mt="12px" mb="24px" px="4px" alignItems="center" justifyContent="end">
+            <Flex
+              alignItems="center"
+              justifyContent="end"
+              marginTop="12px"
+              marginBottom="24px"
+              paddingX="4px"
+            >
               <Flex alignItems="center">
                 <SignPageFee fee={fee} />
               </Flex>

--- a/src/components/SendFlow/FormPageHeader.tsx
+++ b/src/components/SendFlow/FormPageHeader.tsx
@@ -15,10 +15,10 @@ const FormPageHeader: React.FC<{
 }> = ({ title = "Send", subTitle = "Send one or insert into batch" }) => {
   return (
     <HeaderWrapper>
-      <Text size="2xl" fontWeight="600">
+      <Text fontWeight="600" size="2xl">
         {title}
       </Text>
-      <Text textAlign="center" size="sm" color={colors.gray[400]}>
+      <Text color={colors.gray[400]} textAlign="center" size="sm">
         {subTitle}
       </Text>
       <ModalCloseButton />

--- a/src/components/SendFlow/MultisigAccount/FormPage.tsx
+++ b/src/components/SendFlow/MultisigAccount/FormPage.tsx
@@ -102,7 +102,7 @@ export const FormPage: React.FC<FormPageProps<FormValues>> = props => {
               )}
             </FormControl>
 
-            <FormControl my="24px" isInvalid={!!errors.sender}>
+            <FormControl isInvalid={!!errors.sender} marginY="24px">
               <OwnedImplicitAccountsAutocomplete
                 label="Select Owner"
                 inputName="sender"
@@ -121,11 +121,11 @@ export const FormPage: React.FC<FormPageProps<FormValues>> = props => {
               const inputWidth = inputSize === "short" ? "368px" : "100%";
               return (
                 <FormControl
-                  data-testid={`signer-input-${index}`}
-                  mb="8px"
                   key={field.id}
-                  width={inputWidth}
                   display="inline-block"
+                  width={inputWidth}
+                  marginBottom="8px"
+                  data-testid={`signer-input-${index}`}
                   isInvalid={!!error}
                 >
                   <OwnedImplicitAccountsAutocomplete
@@ -146,18 +146,18 @@ export const FormPage: React.FC<FormPageProps<FormValues>> = props => {
                   />
                   {signersCount > 1 && (
                     <IconButton
-                      size="xs"
-                      variant="tertiary"
-                      aria-label="Remove"
                       position="absolute"
-                      bg={colors.gray[500]}
+                      height="24px"
+                      marginTop="-36px"
+                      marginLeft="374px"
+                      background={colors.gray[500]}
+                      aria-label="Remove"
                       data-testid={`remove-signer-${index}`}
                       icon={<TrashIcon h="14px" w="12px" stroke={colors.gray[300]} />}
-                      onClick={() => signersArray.remove(index)}
-                      height="24px"
-                      ml="374px"
-                      mt="-36px"
                       isRound
+                      onClick={() => signersArray.remove(index)}
+                      size="xs"
+                      variant="tertiary"
                     />
                   )}
                   {error && (
@@ -169,23 +169,23 @@ export const FormPage: React.FC<FormPageProps<FormValues>> = props => {
               );
             })}
             <Button
-              variant="specialCTA"
               paddingLeft={0}
               onClick={() => signersArray.append({ val: "" })}
+              variant="specialCTA"
             >
               + Add Signer
             </Button>
 
-            <FormControl mt="24px" isInvalid={!!errors.threshold}>
+            <FormControl marginTop="24px" isInvalid={!!errors.threshold}>
               <FormLabel display="inline">
                 Min No. of approvals:
-                <InputGroup display="inline" ml="10px">
+                <InputGroup display="inline" marginLeft="10px">
                   <Input
-                    w="60px"
-                    type="number"
+                    width="60px"
                     color="white"
-                    step={1}
                     data-testid="threshold-input"
+                    step={1}
+                    type="number"
                     {...register("threshold", {
                       required: "No. of approvals is required",
                       max: {
@@ -199,7 +199,7 @@ export const FormPage: React.FC<FormPageProps<FormValues>> = props => {
                     })}
                   />
                 </InputGroup>
-                <Text display="inline" ml="10px" data-testid="max-signers">
+                <Text display="inline" marginLeft="10px" data-testid="max-signers">
                   out of {signersCount}
                 </Text>
               </FormLabel>
@@ -212,11 +212,11 @@ export const FormPage: React.FC<FormPageProps<FormValues>> = props => {
           </ModalBody>
           <ModalFooter>
             <Button
+              width="100%"
               isDisabled={!isValid}
               isLoading={isLoading}
               size="lg"
               type="submit"
-              width="100%"
             >
               Review
             </Button>

--- a/src/components/SendFlow/MultisigAccount/SignPage.tsx
+++ b/src/components/SendFlow/MultisigAccount/SignPage.tsx
@@ -41,17 +41,17 @@ const SignPage: React.FC<SignPageProps<FormValues>> = props => {
           <ModalBody>
             <FormLabel>Contract Name</FormLabel>
             <Text
-              bg={colors.gray[800]}
-              p="14px"
+              marginBottom="24px"
+              padding="14px"
               color={colors.gray[50]}
+              background={colors.gray[800]}
               borderRadius="6px"
-              mb="24px"
               data-testid="contract-name"
             >
               {name}
             </Text>
 
-            <Box mb="24px">
+            <Box marginBottom="24px">
               <FormLabel>Owner</FormLabel>
               <AddressTile mb="12px" address={parsePkh(sender)} />
               <Flex justifyContent="flex-end">
@@ -71,11 +71,11 @@ const SignPage: React.FC<SignPageProps<FormValues>> = props => {
               );
             })}
 
-            <Flex mt="24px" mb="24px" alignItems="center">
-              <Heading size="md" mr="12px">
+            <Flex alignItems="center" marginTop="24px" marginBottom="24px">
+              <Heading marginRight="12px" size="md">
                 Min No. of approvals:
               </Heading>
-              <Center w="100px" h="48px" bg={colors.gray[800]} borderRadius="4px">
+              <Center width="100px" height="48px" background={colors.gray[800]} borderRadius="4px">
                 <Text textAlign="center" data-testid="threshold">
                   {threshold} out of {signers.length}
                 </Text>

--- a/src/components/SendFlow/NFT/FormPage.tsx
+++ b/src/components/SendFlow/NFT/FormPage.tsx
@@ -79,32 +79,32 @@ const FormPage: React.FC<FormPagePropsWithSender<FormValues> & { nft: NFTBalance
         <form>
           <FormPageHeader />
           <ModalBody>
-            <Flex mb="12px">
+            <Flex marginBottom="12px">
               <SendNFTRecapTile nft={props.nft} />
             </Flex>
             <Flex alignItems="center">
-              <Heading size="sm" mr="4px" color={colors.gray[450]}>
+              <Heading marginRight="4px" color={colors.gray[450]} size="sm">
                 Owned:
               </Heading>
-              <Text size="sm" color={colors.gray[400]} data-testid="nft-owned">
+              <Text color={colors.gray[400]} data-testid="nft-owned" size="sm">
                 {nft.balance}
               </Text>
             </Flex>
 
-            <FormControl mt="24px" isInvalid={!!errors.quantity}>
+            <FormControl marginTop="24px" isInvalid={!!errors.quantity}>
               <FormLabel>
                 <Flex alignItems="center">
-                  <Heading size="md" mr="8px">
+                  <Heading marginRight="8px" size="md">
                     Quantity:
                   </Heading>
                   <Flex alignItems="center">
-                    <InputGroup w="75px">
+                    <InputGroup width="75px">
                       <Input
-                        w="60px"
-                        type="number"
+                        width="60px"
                         color="white"
-                        step={1}
                         data-testid="quantity-input"
+                        step={1}
+                        type="number"
                         {...register("quantity", {
                           required: "Quantity is required",
                           max: {
@@ -129,7 +129,7 @@ const FormPage: React.FC<FormPagePropsWithSender<FormValues> & { nft: NFTBalance
               )}
             </FormControl>
 
-            <FormControl mt="24px" isInvalid={!!errors.sender}>
+            <FormControl marginTop="24px" isInvalid={!!errors.sender}>
               <OwnedAccountsAutocomplete
                 label="From"
                 inputName="sender"
@@ -143,7 +143,7 @@ const FormPage: React.FC<FormPagePropsWithSender<FormValues> & { nft: NFTBalance
               )}
             </FormControl>
 
-            <FormControl mt="24px" isInvalid={!!errors.recipient}>
+            <FormControl marginTop="24px" isInvalid={!!errors.recipient}>
               <KnownAccountsAutocomplete label="To" inputName="recipient" allowUnknown />
               {errors.recipient && (
                 <FormErrorMessage data-testid="recipient-error">

--- a/src/components/SendFlow/NFT/SignPage.tsx
+++ b/src/components/SendFlow/NFT/SignPage.tsx
@@ -38,16 +38,16 @@ const SignPage: React.FC<SignPageProps<{ nft: NFTBalance }>> = props => {
         <form>
           <SignPageHeader {...props} operationsType={operations.type} />
           <ModalBody>
-            <Flex mb="12px">
+            <Flex marginBottom="12px">
               <SendNFTRecapTile nft={nft} />
             </Flex>
 
-            <Flex my="12px" px="4px" alignItems="center" justifyContent="space-between">
+            <Flex alignItems="center" justifyContent="space-between" marginY="12px" paddingX="4px">
               <Flex alignItems="center">
-                <Heading size="sm" mr="4px" color={colors.gray[450]}>
+                <Heading marginRight="4px" color={colors.gray[450]} size="sm">
                   Owned:
                 </Heading>
-                <Text size="sm" data-testid="nft-owned" color={colors.gray[400]}>
+                <Text color={colors.gray[400]} data-testid="nft-owned" size="sm">
                   {nft.balance}
                 </Text>
               </Flex>
@@ -55,11 +55,11 @@ const SignPage: React.FC<SignPageProps<{ nft: NFTBalance }>> = props => {
               <SignPageFee fee={fee} />
             </Flex>
 
-            <Flex mt="12px" mb="24px" alignItems="center">
-              <Heading size="md" mr="12px">
+            <Flex alignItems="center" marginTop="12px" marginBottom="24px">
+              <Heading marginRight="12px" size="md">
                 Quantity:
               </Heading>
-              <Center w="100px" h="48px" bg={colors.gray[800]} borderRadius="4px">
+              <Center width="100px" height="48px" background={colors.gray[800]} borderRadius="4px">
                 <Text textAlign="center">
                   {(operations.operations[0] as FA2Transfer).amount} out of {nft.balance}
                 </Text>

--- a/src/components/SendFlow/OperationSignerSelector.tsx
+++ b/src/components/SendFlow/OperationSignerSelector.tsx
@@ -18,7 +18,7 @@ export const OperationSignerSelector = ({
   switch (operationType) {
     case "proposal":
       return (
-        <FormControl mt="24px" data-testid="signer-selector">
+        <FormControl marginTop="24px" data-testid="signer-selector">
           <AvailableSignersAutocomplete
             account={sender}
             inputName="signer"

--- a/src/components/SendFlow/SendNFTRecapTile.tsx
+++ b/src/components/SendFlow/SendNFTRecapTile.tsx
@@ -9,20 +9,20 @@ export const SendNFTRecapTile = ({ nft }: { nft: NFT }) => {
   const url = getIPFSurl(thumbnailUri(nft));
   const fallbackUrl = getIPFSurl(nft.displayUri);
   return (
-    <Box aria-label="nft" w="100%">
+    <Box width="100%" aria-label="nft">
       <Flex
         alignItems="center"
-        bg={colors.gray[800]}
-        p={3}
-        h="60px"
-        data-testid="nft-name"
+        height="60px"
+        padding={3}
+        background={colors.gray[800]}
         borderRadius="4px"
+        data-testid="nft-name"
       >
-        <AspectRatio w="30px" h="30px" ratio={1}>
-          <Image src={url} fallbackSrc={fallbackUrl} />
+        <AspectRatio width="30px" height="30px" ratio={1}>
+          <Image fallbackSrc={fallbackUrl} src={url} />
         </AspectRatio>
         {nft.metadata.name && (
-          <Heading ml={4} size="sm">
+          <Heading marginLeft={4} size="sm">
             {truncate(nft.metadata.name, 45)}
           </Heading>
         )}

--- a/src/components/SendFlow/SignButton.tsx
+++ b/src/components/SendFlow/SignButton.tsx
@@ -26,11 +26,11 @@ export const SignWithGoogleButton: React.FC<
 
   return (
     <Button
-      onClick={() => getCredentials(onSuccessfulAuth)}
       width="100%"
-      size="lg"
       isDisabled={isDisabled}
       isLoading={isLoading}
+      onClick={() => getCredentials(onSuccessfulAuth)}
+      size="lg"
     >
       {children}
     </Button>
@@ -97,17 +97,17 @@ const SignButton: React.FC<{
       return (
         <Box width="100%">
           <FormProvider {...form}>
-            <FormControl isInvalid={!!errors.password} my="16px">
+            <FormControl isInvalid={!!errors.password} marginY="16px">
               <PasswordInput inputName="password" data-testid="password" />
               {errors.password && <FormErrorMessage>{errors.password.message}</FormErrorMessage>}
             </FormControl>
             <Button
-              onClick={handleSubmit(signer.type === "mnemonic" ? onMnemonicSign : onSecretKeySign)}
               width="100%"
-              size="lg"
-              mt="8px"
-              isLoading={isLoading}
+              marginTop="8px"
               isDisabled={buttonIsDisabled}
+              isLoading={isLoading}
+              onClick={handleSubmit(signer.type === "mnemonic" ? onMnemonicSign : onSecretKeySign)}
+              size="lg"
               type="submit"
             >
               {text || "Submit Transaction"}
@@ -124,11 +124,11 @@ const SignButton: React.FC<{
     case "ledger":
       return (
         <Button
-          onClick={onLedgerSign}
           width="100%"
-          size="lg"
-          isLoading={isLoading}
           isDisabled={buttonIsDisabled}
+          isLoading={isLoading}
+          onClick={onLedgerSign}
+          size="lg"
         >
           {text || "Sign with Ledger"}
         </Button>

--- a/src/components/SendFlow/SignPageFee.tsx
+++ b/src/components/SendFlow/SignPageFee.tsx
@@ -5,10 +5,10 @@ import BigNumber from "bignumber.js";
 const SignPageFee: React.FC<{ fee: string | BigNumber }> = ({ fee }) => {
   return (
     <Flex alignItems="center">
-      <Heading size="sm" mr="4px" color={colors.gray[450]}>
+      <Heading marginRight="4px" color={colors.gray[450]} size="sm">
         Fee:
       </Heading>
-      <Text size="sm" data-testid="fee" color={colors.gray[400]}>
+      <Text color={colors.gray[400]} data-testid="fee" size="sm">
         {prettyTezAmount(fee)}
       </Text>
     </Flex>

--- a/src/components/SendFlow/SignPageHeader.tsx
+++ b/src/components/SendFlow/SignPageHeader.tsx
@@ -33,10 +33,10 @@ export const SignPageHeader: React.FC<{
   return (
     <HeaderWrapper>
       {goBack && <ModalBackButton onClick={goBack} />}
-      <Text size="2xl" fontWeight="600">
+      <Text fontWeight="600" size="2xl">
         {headerText(operationsType, mode)}
       </Text>
-      <Text textAlign="center" size="sm" color={colors.gray[400]}>
+      <Text color={colors.gray[400]} textAlign="center" size="sm">
         Enter your password to confirm this transaction.
       </Text>
       <ModalCloseButton />

--- a/src/components/SendFlow/SuccessStep.tsx
+++ b/src/components/SendFlow/SuccessStep.tsx
@@ -27,21 +27,21 @@ export const SuccessStep: React.FC<{ hash: string }> = ({ hash }) => {
       <ModalHeader textAlign="center">
         Operation Submitted
         <Flex justifyContent="center">
-          <Text color="text.dark" size="sm" textAlign="center" width="340px">
+          <Text width="340px" color="text.dark" textAlign="center" size="sm">
             You can follow this operation's progress in the Operations section.
             <br />
             It may take up to 30 seconds to appear.
           </Text>
         </Flex>
       </ModalHeader>
-      <ModalBody p="0"></ModalBody>
+      <ModalBody padding="0"></ModalBody>
       <ModalFooter justifyContent="center" flexDirection="column">
         <Link to="/operations">
           <Button width="100%" onClick={onClose}>
             Go to operation
           </Button>
         </Link>
-        <Flex mt={4} alignItems="center" justifyContent="space-between">
+        <Flex alignItems="center" justifyContent="space-between" marginTop={4}>
           <Text color="text.dark">View in Tzkt</Text>
           <TzktLink ml={4} url={tzktUrl} />
         </Flex>

--- a/src/components/SendFlow/Tez/FormPage.tsx
+++ b/src/components/SendFlow/Tez/FormPage.tsx
@@ -84,8 +84,8 @@ const FormPage: React.FC<FormPageProps<FormValues> & { showPreview?: boolean }> 
               <InputGroup>
                 <Input
                   isDisabled={isLoading}
-                  type="number"
                   step={getSmallestUnit(TEZ_DECIMALS)}
+                  type="number"
                   {...register("prettyAmount", {
                     required: "Amount is required",
                     validate: makeValidateDecimals(TEZ_DECIMALS),
@@ -101,7 +101,7 @@ const FormPage: React.FC<FormPageProps<FormValues> & { showPreview?: boolean }> 
               )}
             </FormControl>
 
-            <FormControl mt="24px" isInvalid={!!errors.sender}>
+            <FormControl marginTop="24px" isInvalid={!!errors.sender}>
               <OwnedAccountsAutocomplete
                 label="From"
                 isDisabled={!!props.sender}
@@ -114,7 +114,7 @@ const FormPage: React.FC<FormPageProps<FormValues> & { showPreview?: boolean }> 
                 </FormErrorMessage>
               )}
             </FormControl>
-            <FormControl mt="24px" isInvalid={!!errors.recipient}>
+            <FormControl marginTop="24px" isInvalid={!!errors.recipient}>
               <KnownAccountsAutocomplete label="To" inputName="recipient" allowUnknown />
               {errors.recipient && (
                 <FormErrorMessage data-testid="recipient-error">

--- a/src/components/SendFlow/Tez/SignPage.tsx
+++ b/src/components/SendFlow/Tez/SignPage.tsx
@@ -24,14 +24,14 @@ const SignPage: React.FC<SignPageProps> = props => {
           <ModalBody>
             <TezTile mutezAmount={mutezAmount} />
 
-            <Flex mt="12px" alignItems="center" justifyContent="end">
+            <Flex alignItems="center" justifyContent="end" marginTop="12px">
               <SignPageFee fee={fee} />
             </Flex>
 
-            <FormLabel mt="24px">From </FormLabel>
+            <FormLabel marginTop="24px">From </FormLabel>
             <AddressTile address={operations.sender.address} />
 
-            <FormLabel mt="24px">To </FormLabel>
+            <FormLabel marginTop="24px">To </FormLabel>
             <AddressTile address={recipient} />
 
             <OperationSignerSelector

--- a/src/components/SendFlow/Token/FormPage.tsx
+++ b/src/components/SendFlow/Token/FormPage.tsx
@@ -109,8 +109,8 @@ const FormPage: React.FC<
               <InputGroup>
                 <Input
                   isDisabled={isLoading}
-                  type="number"
                   step={smallestUnit}
+                  type="number"
                   {...register("prettyAmount", {
                     required: "Amount is required",
                     max: {
@@ -121,7 +121,7 @@ const FormPage: React.FC<
                   })}
                   placeholder={smallestUnit}
                 />
-                <InputRightElement pr="12px" data-testid="token-symbol">
+                <InputRightElement paddingRight="12px" data-testid="token-symbol">
                   {tokenSymbolSafe(token)}
                 </InputRightElement>
               </InputGroup>
@@ -132,7 +132,7 @@ const FormPage: React.FC<
               )}
             </FormControl>
 
-            <FormControl mt="24px" isInvalid={!!errors.sender}>
+            <FormControl marginTop="24px" isInvalid={!!errors.sender}>
               <OwnedAccountsAutocomplete
                 label="From"
                 isDisabled={true}
@@ -146,7 +146,7 @@ const FormPage: React.FC<
               )}
             </FormControl>
 
-            <FormControl mt="24px" isInvalid={!!errors.recipient}>
+            <FormControl marginTop="24px" isInvalid={!!errors.recipient}>
               <KnownAccountsAutocomplete label="To" inputName="recipient" allowUnknown />
               {errors.recipient && (
                 <FormErrorMessage data-testid="recipient-error">

--- a/src/components/SendFlow/Token/SignPage.tsx
+++ b/src/components/SendFlow/Token/SignPage.tsx
@@ -29,7 +29,13 @@ const SignPage: React.FC<SignPageProps<{ token: FATokenBalance }>> = props => {
           <ModalBody>
             <TokenTile token={token} amount={amount} />
 
-            <Flex mt="12px" mb="24px" alignItems="center" justifyContent="end" px="4px">
+            <Flex
+              alignItems="center"
+              justifyContent="end"
+              marginTop="12px"
+              marginBottom="24px"
+              paddingX="4px"
+            >
               <Flex>
                 <SignPageFee fee={fee} />
               </Flex>

--- a/src/components/SendFlow/Undelegation/FormPage.tsx
+++ b/src/components/SendFlow/Undelegation/FormPage.tsx
@@ -69,7 +69,7 @@ const FormPage: React.FC<FormPagePropsWithSender<FormValues>> = props => {
                 isDisabled
               />
             </FormControl>
-            <FormLabel mt="24px">Baker</FormLabel>
+            <FormLabel marginTop="24px">Baker</FormLabel>
             <BakerSmallTile pkh={baker} />
           </ModalBody>
           <ModalFooter>

--- a/src/components/SendFlow/Undelegation/SignPage.tsx
+++ b/src/components/SendFlow/Undelegation/SignPage.tsx
@@ -20,7 +20,7 @@ const SignPage: React.FC<SignPageProps> = props => {
             <FormLabel>From</FormLabel>
             <AddressTile address={signer.address} />
 
-            <Flex mt="12px" alignItems="center" justifyContent="end" px="4px">
+            <Flex alignItems="center" justifyContent="end" marginTop="12px" paddingX="4px">
               <SignPageFee fee={fee} />
             </Flex>
 

--- a/src/components/SendFlow/utils.tsx
+++ b/src/components/SendFlow/utils.tsx
@@ -64,24 +64,24 @@ export const FormSubmitButtons = ({
       <Box width="100%">
         {showPreview && (
           <Button
-            onClick={onSingleSubmit}
             width="100%"
-            size="lg"
-            isLoading={isLoading}
-            type="submit"
+            marginBottom="16px"
             isDisabled={!isValid}
-            mb="16px"
+            isLoading={isLoading}
+            onClick={onSingleSubmit}
+            size="lg"
+            type="submit"
           >
             Preview
           </Button>
         )}
         <Button
-          onClick={onAddToBatch}
           width="100%"
-          size="lg"
-          isLoading={isLoading}
-          type="submit"
           isDisabled={!isValid}
+          isLoading={isLoading}
+          onClick={onAddToBatch}
+          size="lg"
+          type="submit"
           variant="tertiary"
         >
           Insert Into Batch

--- a/src/components/SideNavbar.tsx
+++ b/src/components/SideNavbar.tsx
@@ -31,21 +31,21 @@ const MenuItem: React.FC<
   return (
     <Link to={to}>
       <Flex
-        bg={isSelected ? colors.gray[600] : "transparent"}
+        alignItems="center"
+        justifyContent="flex-start"
+        width="176px"
+        marginBottom="8px"
+        padding="10px"
+        background={isSelected ? colors.gray[600] : "transparent"}
+        borderRadius="4px"
         _hover={{
           background: isSelected ? colors.gray[600] : colors.gray[800],
         }}
-        p="10px"
-        mb="8px"
-        justifyContent="flex-start"
-        alignItems="center"
-        borderRadius="4px"
         cursor="pointer"
-        width="176px"
         {...flexProps}
       >
         {icon}
-        <Text size="sm" ml="10px">
+        <Text marginLeft="10px" size="sm">
           {label}
         </Text>
       </Flex>
@@ -57,8 +57,8 @@ const TotalBalance = () => {
   const balance = useTotalBalance();
 
   return (
-    <Box mt="24px" mb="100px">
-      <Text size="sm" mb="4px">
+    <Box marginTop="24px" marginBottom="100px">
+      <Text marginBottom="4px" size="sm">
         Balance
       </Text>
       {balance !== null && <TezRecapDisplay balance={balance.mutez} dollarBalance={balance.usd} />}
@@ -68,15 +68,20 @@ const TotalBalance = () => {
 
 export const SideNavbar = () => {
   return (
-    <Flex flexDirection="column" bg={colors.gray[900]} w="236px" p="30px 30px 30px 30px">
+    <Flex
+      flexDirection="column"
+      width="236px"
+      padding="30px 30px 30px 30px"
+      background={colors.gray[900]}
+    >
       <Box>
-        <Flex height="30px" justifyContent="space-between" alignItems="center">
+        <Flex alignItems="center" justifyContent="space-between" height="30px">
           <MakiLogo size={38} />
           <NetworkSelector />
         </Flex>
-        <Divider mt="28px" />
+        <Divider marginTop="28px" />
       </Box>
-      <Flex flexDirection="column" justifyContent="space-between" flex={1}>
+      <Flex justifyContent="space-between" flexDirection="column" flex={1}>
         <Box>
           {/* TODO: add UpdateAppButton component once it's ready */}
           <TotalBalance />

--- a/src/components/SliderItem.tsx
+++ b/src/components/SliderItem.tsx
@@ -6,14 +6,14 @@ import DiamondIcon from "../assets/icons/Diamond";
 
 export default function SlideItem({ item }: { item: SlideritemRecord }) {
   return (
-    <Box data-testid={`slide-${item.id}`} paddingBottom="35px">
+    <Box paddingBottom="35px" data-testid={`slide-${item.id}`}>
       <Box
-        backgroundRepeat="no-repeat"
+        height="400px"
         backgroundPosition="top"
+        backgroundRepeat="no-repeat"
         __css={{
           backgroundImage: `linear-gradient(to bottom, rgba(245, 246, 252, 0), rgba(0, 0, 0, 1)), url(${item.image?.url})`,
         }}
-        height="400px"
       ></Box>
       <Flex flexDirection="column">
         <CircleIcon size="58px" icon={<DiamondIcon width="32px" height="32px" />} />

--- a/src/components/TezRecapDisplay.tsx
+++ b/src/components/TezRecapDisplay.tsx
@@ -13,7 +13,7 @@ export const TezRecapDisplay: React.FC<{
     <Box textAlign={props.center ? "center" : "initial"}>
       <Heading size="md">{prettyTezAmount(props.balance)}</Heading>
       {props.dollarBalance !== null && (
-        <Text size="sm" mt="6px" color={colors.gray[400]}>
+        <Text marginTop="6px" color={colors.gray[400]} size="sm">
           ${props.dollarBalance.toFixed(2)}
         </Text>
       )}

--- a/src/components/TokenTile.tsx
+++ b/src/components/TokenTile.tsx
@@ -16,22 +16,22 @@ const TokenTile: React.FC<{ token: FATokenBalance; amount: string } & FlexProps>
   const symbol = tokenSymbolSafe(token);
   return (
     <Flex
-      data-testid="token-tile"
       alignItems="center"
-      w="400px"
-      p="15px"
-      borderRadius="4px"
-      bg={colors.gray[800]}
       justifyContent="start"
+      width="400px"
+      padding="15px"
+      background={colors.gray[800]}
+      borderRadius="4px"
+      data-testid="token-tile"
       {...flexProps}
     >
       <Flex alignItems="center">
-        <AspectRatio w="30px" h="30px" ratio={1} mr="12px">
+        <AspectRatio width="30px" height="30px" marginRight="12px" ratio={1}>
           <TokenIcon contract={contract} p="6.25px" bg={colors.gray[500]} borderRadius="4px" />
         </AspectRatio>
       </Flex>
       <PrettyNumber number={prettyAmount} />
-      <Text ml="4px" size="sm">
+      <Text marginLeft="4px" size="sm">
         {symbol}
       </Text>
     </Flex>

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -53,20 +53,20 @@ const UpdateButton = () => {
   return (
     <>
       {relativeTimestamp && !isSmallSize && (
-        <Text size="sm" color={colors.gray[400]} display="inline">
+        <Text display="inline" color={colors.gray[400]} size="sm">
           Updated {relativeTimestamp} ago
         </Text>
       )}
       <IconButton
-        ml="8px"
-        mr="36px"
+        marginRight="36px"
+        marginLeft="8px"
+        _active={{ color: "white", bg: colors.green }}
         aria-label="refetch"
         data-testid="refetch-button"
         icon={<FetchingIcon />}
-        onClick={onClick}
         isLoading={isLoading}
+        onClick={onClick}
         variant="circle"
-        _active={{ color: "white", bg: colors.green }}
       />
     </>
   );
@@ -78,12 +78,12 @@ export const TopBar: React.FC<{ title: string; subtitle?: string }> = ({ title, 
 
   return (
     <Box>
-      <Flex h="88px" justifyContent="space-between" alignItems="center">
+      <Flex alignItems="center" justifyContent="space-between" height="88px">
         <Flex alignItems="end">
-          <Heading size="xl" mr="6px">
+          <Heading marginRight="6px" size="xl">
             {title}
           </Heading>
-          <Text data-testid="nft-total-amount" size="xs" color={colors.gray[450]}>
+          <Text color={colors.gray[450]} data-testid="nft-total-amount" size="xs">
             {subtitle}
           </Text>
         </Flex>
@@ -93,15 +93,15 @@ export const TopBar: React.FC<{ title: string; subtitle?: string }> = ({ title, 
             <a
               href={`mailto:umami-support@trili.tech?subject=Umami V2 feedback&body=${emailBodyTemplate}`}
             >
-              <Button variant="tertiary" mr={4}>
+              <Button marginRight={4} variant="tertiary">
                 Share Feedback
               </Button>
             </a>
           )}
-          <Button variant="tertiary" onClick={() => openWith(<BuyTezForm />)}>
+          <Button onClick={() => openWith(<BuyTezForm />)} variant="tertiary">
             Buy Tez
           </Button>
-          <Button ml={4} onClick={() => openWith(<SendTezForm />)}>
+          <Button marginLeft={4} onClick={() => openWith(<SendTezForm />)}>
             Send
           </Button>
         </Box>

--- a/src/components/UpdateAppButton.tsx
+++ b/src/components/UpdateAppButton.tsx
@@ -15,23 +15,23 @@ export const UpdateAppButton = () => {
   return (
     <Box marginTop="24px" marginBottom="6px">
       <Button
+        justifyContent="flex-start"
+        width="100%"
+        height="32px"
+        paddingTop="7px"
+        paddingRight="8px"
+        paddingBottom="7px"
+        paddingLeft="8px"
         color={colors.black}
         background={colors.green}
         _hover={{
           color: colors.black,
           background: colors.greenL,
         }}
-        width="100%"
-        height="32px"
-        paddingLeft="8px"
-        paddingRight="8px"
-        paddingTop="7px"
-        paddingBottom="7px"
-        justifyContent="flex-start"
         onClick={startUpdate}
       >
         <FlipForwardEnergy />
-        <Text size="sm" marginLeft="4px">
+        <Text marginLeft="4px" size="sm">
           Update Umami
         </Text>
       </Button>

--- a/src/components/useAccountsFilter.tsx
+++ b/src/components/useAccountsFilter.tsx
@@ -20,17 +20,17 @@ export const useAccountsFilter = () => {
         <Box alignSelf="flex-start">
           <Menu>
             <MenuButton
-              isDisabled={alreadySelectedAll}
               as={Button}
-              rightIcon={<ChevronDownIcon />}
-              variant="ghost"
+              maxHeight="26px"
+              paddingLeft={0}
+              fontWeight="normal"
               _hover={{ bg: "none" }}
               _active={{ bg: "none" }}
-              maxH="26px"
-              pl={0}
-              fontWeight="normal"
               data-testid="account-filter"
-              my="16px"
+              isDisabled={alreadySelectedAll}
+              marginY="16px"
+              rightIcon={<ChevronDownIcon />}
+              variant="ghost"
             >
               Filter by Account
             </MenuButton>

--- a/src/utils/beacon/BeaconNotification/panels/PermissionRequestPanel.tsx
+++ b/src/utils/beacon/BeaconNotification/panels/PermissionRequestPanel.tsx
@@ -65,7 +65,7 @@ const PermissionRequestPanel: React.FC<{
             />
           </FormControl>
         </FormProvider>
-        <AspectRatio mt={2} mb={2} width="100%" ratio={1}>
+        <AspectRatio width="100%" marginTop={2} marginBottom={2} ratio={1}>
           <Image width="100%" height={40} src={request.appMetadata.icon} />
         </AspectRatio>
         <Text>{request.network.type}</Text>

--- a/src/utils/beacon/BeaconPeers.tsx
+++ b/src/utils/beacon/BeaconPeers.tsx
@@ -17,28 +17,28 @@ import colors from "../../style/colors";
 
 const PeerRow = ({ peerInfo, onRemove }: { peerInfo: PeerInfo; onRemove: () => void }) => {
   return (
-    <Flex height="106px" paddingY="30px" justifyContent="space-between">
+    <Flex justifyContent="space-between" height="106px" paddingY="30px">
       <Flex>
         <AspectRatio width="48px" marginRight="16px" ratio={1}>
           <Image width="100%" src={peerInfo.icon} />
         </AspectRatio>
         <Center alignItems="flex-start" flexDirection="column">
-          <Heading size="md" ml={2}>
+          <Heading marginLeft={2} size="md">
             {peerInfo.name}
           </Heading>
 
-          <Text size="sm" color={colors.gray[400]} ml={2}>
+          <Text marginLeft={2} color={colors.gray[400]} size="sm">
             {peerInfo.relayServer}
           </Text>
         </Center>
       </Flex>
       <Center>
         <IconButton
-          onClick={onRemove}
           aria-label="Remove Peer"
+          icon={<TrashIcon />}
+          onClick={onRemove}
           size="xs"
           variant="circle"
-          icon={<TrashIcon />}
         />
       </Center>
     </Flex>

--- a/src/views/addressBook/AddressBookView.tsx
+++ b/src/views/addressBook/AddressBookView.tsx
@@ -11,18 +11,18 @@ const AddContact: React.FC = () => {
   const { openWith } = useContext(DynamicModalContext);
   return (
     <Button
-      variant="CTAWithIcon"
+      alignItems="center"
+      justifyContent="end"
+      marginTop="16px"
+      marginBottom="16px"
+      cursor="pointer"
       onClick={() =>
         openWith(<UpsertContactModal title="Add contact" buttonText="Add to Contact" />)
       }
-      alignItems="center"
-      justifyContent="end"
-      mb="16px"
-      mt="16px"
-      cursor="pointer"
+      variant="CTAWithIcon"
     >
       <AddContactIcon stroke="currentcolor" />
-      <Text size="sm" ml="4px">
+      <Text marginLeft="4px" size="sm">
         Add contact
       </Text>
     </Button>
@@ -32,7 +32,7 @@ const AddContact: React.FC = () => {
 export default function AddressBookView() {
   const contacts = useAllSortedContacts();
   return (
-    <Flex direction="column" height="100%">
+    <Flex flexDirection="column" height="100%">
       <TopBar title="Address Book" />
 
       <Flex flexDirection="row-reverse">

--- a/src/views/addressBook/ContactTable.tsx
+++ b/src/views/addressBook/ContactTable.tsx
@@ -12,7 +12,7 @@ import { DeleteContactModal, UpsertContactModal } from "../../components/Contact
 const ContactTable: React.FC<{ contacts: Contact[] }> = ({ contacts }) => {
   const { openWith } = useContext(DynamicModalContext);
   return (
-    <Box bg={colors.gray[900]} overflow="auto" borderRadius="8px" px="30px">
+    <Box overflow="auto" background={colors.gray[900]} borderRadius="8px" paddingX="30px">
       <TableContainer overflowX="unset" overflowY="unset">
         <Table>
           <Tbody>
@@ -20,13 +20,13 @@ const ContactTable: React.FC<{ contacts: Contact[] }> = ({ contacts }) => {
               const rowBorderColor = i === contacts.length - 1 ? "transparent" : colors.gray[700];
               return (
                 <Tr key={contact.pkh} data-testid="contact-row">
-                  <Td data-testid="contact-row-name" borderColor={rowBorderColor} px="0">
+                  <Td borderColor={rowBorderColor} data-testid="contact-row-name" paddingX="0">
                     <Flex alignItems="center">
-                      <Box w="150px" mr="40px">
+                      <Box width="150px" marginRight="40px">
                         <Text
+                          overflow="hidden"
                           fontWeight={600}
                           whiteSpace="nowrap"
-                          overflow="hidden"
                           textOverflow="ellipsis"
                         >
                           {contact.name}
@@ -41,7 +41,7 @@ const ContactTable: React.FC<{ contacts: Contact[] }> = ({ contacts }) => {
                       />
                     </Flex>
                   </Td>
-                  <Td borderColor={rowBorderColor} px="0">
+                  <Td borderColor={rowBorderColor} paddingX="0">
                     <Flex justifyContent="end">
                       <SendButton
                         mr="20px"

--- a/src/views/batch/BatchPage.tsx
+++ b/src/views/batch/BatchPage.tsx
@@ -13,8 +13,8 @@ import { ExternalLink } from "../../components/ExternalLink";
 
 export const FilterController = ({ batchPending }: { batchPending: number }) => {
   return (
-    <Flex alignItems="center" mb="24px" mt="24px">
-      <Heading size="sm" color={colors.orangeL} flex={1}>
+    <Flex alignItems="center" marginTop="24px" marginBottom="24px">
+      <Heading flex={1} color={colors.orangeL} size="sm">
         {batchPending} Pending
       </Heading>
       <CSVFileUploader />
@@ -22,8 +22,8 @@ export const FilterController = ({ batchPending }: { batchPending: number }) => 
         ml="8px"
         href="https://github.com/trilitech/umami-v2/blob/main/doc/Batch-File-Format-Specifications.md"
       >
-        <Button variant="CTAWithIcon" paddingRight="0">
-          <Text mr="4px" size="sm">
+        <Button paddingRight="0" variant="CTAWithIcon">
+          <Text marginRight="4px" size="sm">
             See file specs
           </Text>
           <ExternalLinkIcon stroke="currentcolor" />
@@ -37,10 +37,10 @@ const BatchPage = () => {
   const batches = useBatches();
 
   return (
-    <Flex direction="column" height="100%">
+    <Flex flexDirection="column" height="100%">
       <TopBar title="Batch" />
       <FilterController batchPending={batches.length} />
-      <Box overflowY="auto" minH="80%">
+      <Box overflowY="auto" minHeight="80%">
         {batches.length > 0 ? (
           batches.map(operations => (
             <BatchView key={operations.sender.address.pkh} operations={operations} />
@@ -60,15 +60,19 @@ const EmptyBatch = () => {
     <Center height="100%" textAlign="center">
       <Box>
         <Heading size="3xl">No 'batch' to show</Heading>
-        <Text color={colors.gray[400]} mt="10px" size="xl">
+        <Text marginTop="10px" color={colors.gray[400]} size="xl">
           There is no batch transaction to show...
         </Text>
-        <Flex justifyContent="space-around" mt="30px">
+        <Flex justifyContent="space-around" marginTop="30px">
           <Box>
             <Button onClick={() => openWith(<SendTezForm showPreview={false} />)}>
               Start a Batch
             </Button>
-            <Button ml="15px" variant="tertiary" onClick={() => openWith(<CSVFileUploadForm />)}>
+            <Button
+              marginLeft="15px"
+              onClick={() => openWith(<CSVFileUploadForm />)}
+              variant="tertiary"
+            >
               Load CSV file
             </Button>
           </Box>

--- a/src/views/batch/BatchView.tsx
+++ b/src/views/batch/BatchView.tsx
@@ -37,21 +37,21 @@ const RightHeader: React.FC<{ operations: AccountOperations }> = ({
     });
 
   return (
-    <Box justifyContent="space-between" alignItems="center" data-testid="right-header">
-      <Text color={colors.gray[400]} size="sm" display="inline-block">
+    <Box alignItems="center" justifyContent="space-between" data-testid="right-header">
+      <Text display="inline-block" color={colors.gray[400]} size="sm">
         {pluralize("transaction", operations.length, true)}
       </Text>
-      <Button variant="primary" ml="30px" onClick={openBatchSignPage} isLoading={isLoading}>
+      <Button marginLeft="30px" isLoading={isLoading} onClick={openBatchSignPage} variant="primary">
         {headerText(operationsType, "batch")}
       </Button>
       <IconButton
-        onClick={() => openWith(<ClearBatchConfirmationModal sender={sender} />, "sm")}
-        aria-label="remove-batch"
-        ml="18px"
-        variant="circle"
+        marginLeft="18px"
         borderRadius="4px"
-        icon={<TrashIcon stroke={colors.gray[300]} />}
+        aria-label="remove-batch"
         data-testid="remove-batch"
+        icon={<TrashIcon stroke={colors.gray[300]} />}
+        onClick={() => openWith(<ClearBatchConfirmationModal sender={sender} />, "sm")}
+        variant="circle"
       />
     </Box>
   );
@@ -108,12 +108,12 @@ export const BatchView: React.FC<{
   const showFooter = operations.length > 9;
 
   return (
-    <Box data-testid={`batch-table-${sender.address.pkh}`} mb="16px" w="100%">
+    <Box width="100%" marginBottom="16px" data-testid={`batch-table-${sender.address.pkh}`}>
       <Flex
-        borderTopRadius="8px"
         justifyContent="space-between"
-        p="20px 23px 20px 30px"
-        bg={colors.gray[800]}
+        padding="20px 23px 20px 30px"
+        background={colors.gray[800]}
+        borderTopRadius="8px"
         data-testid="header"
       >
         <Flex alignItems="center">
@@ -122,51 +122,51 @@ export const BatchView: React.FC<{
         <RightHeader operations={accountOperations} />
       </Flex>
       <Flex
-        bg={colors.gray[900]}
-        px="30px"
-        py="20px"
         flexDirection="column"
+        background={colors.gray[900]}
         borderBottomRadius={showFooter ? 0 : "8px"}
+        paddingX="30px"
+        paddingY="20px"
       >
         {operations.map((operation, index) => (
           <Box key={nanoid()} data-testid="operation">
-            <Flex height="50px" flexDirection="column">
+            <Flex flexDirection="column" height="50px">
               <Flex>
                 <OperationView operation={operation} />
               </Flex>
 
-              <Flex mt="8px" width="100%" alignItems="center" justifyContent="space-between">
+              <Flex alignItems="center" justifyContent="space-between" width="100%" marginTop="8px">
                 <Flex>
                   <OperationRecipient operation={operation} />
                 </Flex>
                 <Flex>
-                  <Text size="sm" color={colors.gray[450]} alignSelf="flex-end">
+                  <Text alignSelf="flex-end" color={colors.gray[450]} size="sm">
                     {prettyOperationType(operation)}
                   </Text>
                   <IconButton
-                    ml="12px"
+                    width="24px"
+                    marginLeft="12px"
+                    borderRadius="full"
                     aria-label="Remove"
                     icon={<TrashIcon stroke={colors.gray[300]} />}
-                    borderRadius="full"
-                    size="xs"
-                    width="24px"
-                    variant="circle"
                     onClick={() => removeItem(sender, index)}
+                    size="xs"
+                    variant="circle"
                   />
                 </Flex>
               </Flex>
             </Flex>
-            {index < operations.length - 1 && <Divider my="20px" />}
+            {index < operations.length - 1 && <Divider marginY="20px" />}
           </Box>
         ))}
       </Flex>
       {showFooter && (
         <Flex
           justifyContent="end"
-          borderRadius="0 0 8px 8px"
-          p="20px 23px 20px 30px"
-          bg={colors.gray[800]}
           verticalAlign="middle"
+          padding="20px 23px 20px 30px"
+          background={colors.gray[800]}
+          borderRadius="0 0 8px 8px"
           data-testid="footer"
         >
           <RightHeader operations={accountOperations} />

--- a/src/views/batch/OperationRecipient.tsx
+++ b/src/views/batch/OperationRecipient.tsx
@@ -25,14 +25,14 @@ export const OperationRecipient = ({ operation }: { operation: Operation }) => {
   }
   if (!address) {
     return (
-      <Text data-testid="recipient" color={colors.gray[500]}>
+      <Text color={colors.gray[500]} data-testid="recipient">
         N/A
       </Text>
     );
   }
   return (
     <>
-      <Text mr="6px" color={colors.gray[450]}>
+      <Text marginRight="6px" color={colors.gray[450]}>
         To:
       </Text>
       <AddressPill data-testid="recipient" address={address} />

--- a/src/views/batch/OperationView.tsx
+++ b/src/views/batch/OperationView.tsx
@@ -27,7 +27,7 @@ export const OperationView = ({ operation }: { operation: Operation }) => {
           <Flex>
             {Number(operation.amount) > 1 && (
               <>
-                <Heading size="sm" color={colors.gray[450]}>
+                <Heading color={colors.gray[450]} size="sm">
                   x{operation.amount}
                 </Heading>
                 &nbsp;
@@ -35,13 +35,13 @@ export const OperationView = ({ operation }: { operation: Operation }) => {
             )}
             <Heading size="sm">
               <Tooltip
-                bg={colors.gray[700]}
+                padding="8px"
+                background={colors.gray[700]}
                 border="1px solid"
                 borderColor={colors.gray[500]}
                 borderRadius="8px"
-                p="8px"
                 label={
-                  <AspectRatio w="170px" h="170px" ratio={1}>
+                  <AspectRatio width="170px" height="170px" ratio={1}>
                     <Image src={getIPFSurl(thumbnailUri(token))} />
                   </AspectRatio>
                 }

--- a/src/views/help/HelpView.tsx
+++ b/src/views/help/HelpView.tsx
@@ -66,7 +66,7 @@ const HelpLinkRow: React.FC<{
 
           <Flex alignItems="center">
             {linkDescription && (
-              <Text size="sm" mr="4px" color={colors.gray[400]}>
+              <Text marginRight="4px" color={colors.gray[400]} size="sm">
                 {linkDescription}
               </Text>
             )}
@@ -83,10 +83,10 @@ const HelpCard: React.FC<{
   children: React.ReactNode;
 }> = ({ title, children }) => {
   return (
-    <Box marginY="10px" data-testid="help-card">
+    <Box data-testid="help-card" marginY="10px">
       <Flex>
-        <Box w="550px">
-          <Heading size="lg" mb="16px">
+        <Box width="550px">
+          <Heading marginBottom="16px" size="lg">
             {title}
           </Heading>
           {children}

--- a/src/views/home/AccountListWithDrawer.tsx
+++ b/src/views/home/AccountListWithDrawer.tsx
@@ -48,11 +48,11 @@ const AccountListWithDrawer: React.FC = () => {
     <>
       <AccountsList onOpen={onOpen} selected={selected} onSelect={setSelected} />
       <Drawer
+        autoFocus={false}
         blockScrollOnMount={!isDynamicModalOpen}
         isOpen={isOpen}
-        placement="right"
         onClose={closeDrawer}
-        autoFocus={false}
+        placement="right"
       >
         <DrawerOverlay />
         <DrawerContent>

--- a/src/views/home/AccountsList.tsx
+++ b/src/views/home/AccountsList.tsx
@@ -31,10 +31,10 @@ import { useAllAccounts } from "../../utils/hooks/getAccountDataHooks";
 export const AccountListHeader = () => {
   const { onOpen, modalElement } = useOnboardingModal();
   return (
-    <Flex flexDirection="row-reverse" marginBottom="16px" marginTop="12px">
-      <Button variant="CTAWithIcon" onClick={onOpen} paddingRight="0">
+    <Flex flexDirection="row-reverse" marginTop="12px" marginBottom="16px">
+      <Button paddingRight="0" onClick={onOpen} variant="CTAWithIcon">
         <AddAccountIcon stroke="currentcolor" />
-        <Text ml="4px" size="sm">
+        <Text marginLeft="4px" size="sm">
           Add Account
         </Text>
       </Button>
@@ -88,7 +88,7 @@ const AccountGroup: React.FC<{
   return (
     <Box data-testid={`account-group-${groupLabel}`}>
       <Flex justifyContent="space-between">
-        <Heading size="md" mb={4}>
+        <Heading marginBottom={4} size="md">
           {groupLabel}
         </Heading>
 
@@ -99,7 +99,7 @@ const AccountGroup: React.FC<{
 
       {accounts.map(account => {
         return (
-          <Box mb="16px" key={account.address.pkh}>
+          <Box key={account.address.pkh} marginBottom="16px">
             <AccountTile
               selected={account.address.pkh === selected}
               onClick={_ => onSelect(account.address.pkh)}
@@ -156,19 +156,25 @@ export const AccountsList: React.FC<{
 
   return (
     <>
-      <Box height="100%" mr={0}>
+      <Box height="100%" marginRight={0}>
         <NestedScroll>
           {compact(accountTiles)}
           <Button
-            onClick={() => openWith(<FormPage />)}
             width="100%"
-            bg={colors.black}
-            border="1px dashed"
             height="90px"
-            variant="outline"
+            background={colors.black}
+            border="1px dashed"
             borderColor={colors.gray[500]}
+            onClick={() => openWith(<FormPage />)}
+            variant="outline"
           >
-            <Text display="block" m={5} width="100%" textAlign="center" color={colors.gray[400]}>
+            <Text
+              display="block"
+              width="100%"
+              margin={5}
+              color={colors.gray[400]}
+              textAlign="center"
+            >
               <KeyIcon stroke={colors.gray[450]} mr={1} />
               Create New Multisig
             </Text>

--- a/src/views/home/DrawerTopButtons.tsx
+++ b/src/views/home/DrawerTopButtons.tsx
@@ -6,15 +6,15 @@ export const DrawerTopButtons: React.FC<{
   onClose: () => void;
 }> = ({ onClose }) => {
   return (
-    <Flex justifyContent="flex-end" pb="30px" cursor="pointer">
+    <Flex justifyContent="flex-end" paddingBottom="30px" cursor="pointer">
       <CloseDrawerButton onClose={onClose} />
     </Flex>
   );
 };
 
 export const CloseDrawerButton = ({ onClose }: { onClose: () => void }) => (
-  <Button variant="CTAWithIcon" onClick={onClose}>
+  <Button onClick={onClose} variant="CTAWithIcon">
     <ExitArrowIcon stroke="currentcolor" />
-    <Text ml="4px">Close</Text>
+    <Text marginLeft="4px">Close</Text>
   </Button>
 );

--- a/src/views/home/HomeView.tsx
+++ b/src/views/home/HomeView.tsx
@@ -5,10 +5,10 @@ import { AccountListHeader } from "./AccountsList";
 
 export default function HomeView() {
   return (
-    <Flex direction="column" height="100%">
+    <Flex flexDirection="column" height="100%">
       <TopBar title="Accounts" />
       <Flex flex={1} minHeight={1}>
-        <Flex direction="column" flex={1} mr="12px" pb="12px">
+        <Flex flexDirection="column" flex={1} marginRight="12px" paddingBottom="12px">
           <AccountListHeader />
           <Box flex={1} overflow="hidden" borderRadius="8px">
             <AccountListWithDrawer />

--- a/src/views/home/OperationListDisplay.tsx
+++ b/src/views/home/OperationListDisplay.tsx
@@ -21,13 +21,13 @@ export const OperationListDisplay: React.FC<{ operations: TzktCombinedOperation[
       {chunk.map((operation, i) => (
         <Box key={operation.id} height="90px">
           <OperationTile operation={operation} />
-          {i < chunk.length - 1 && <Divider my="20px" />}
+          {i < chunk.length - 1 && <Divider marginY="20px" />}
         </Box>
       ))}
       <Center>
         <Link to="/operations">
           <RefreshClockIcon display="inline" />{" "}
-          <Text display="inline" size="sm" color={colors.gray[300]}>
+          <Text display="inline" color={colors.gray[300]} size="sm">
             View All
           </Text>
         </Link>

--- a/src/views/nfts/NFTCard.tsx
+++ b/src/views/nfts/NFTCard.tsx
@@ -21,56 +21,56 @@ const NFTCard: React.FC<{
 
   return (
     <Card
+      width="274px"
+      borderRadius="8px"
       cursor="pointer"
       data-testid="nft-card"
-      borderRadius="8px"
       onClick={onClick}
-      width="274px"
     >
       <CardBody
-        borderRadius="8px"
-        bg={colors.gray[900]}
+        padding="16px"
+        background={colors.gray[900]}
         border="1px solid"
         borderColor={isSelected ? colors.orangeL : "transparent"}
+        borderRadius="8px"
         _hover={{ bg: colors.gray[700], borderColor: `${colors.gray[500]}` }}
-        p="16px"
       >
         <Box>
           <Image
-            data-testid="nft-image"
-            objectFit="contain"
             width="242px"
             height="242px"
-            src={url}
+            objectFit="contain"
+            data-testid="nft-image"
             fallbackSrc={fallbackUrl}
+            src={url}
           />
         </Box>
         {/* TODO: make a separate component to be shared between this and the drawer NFT card */}
         {Number(nft.balance) > 1 && (
           <Text
-            data-testid="nft-owned-count"
-            borderRadius="full"
-            height="24px"
-            px="8px"
-            paddingTop="1px"
-            backgroundColor="rgba(33, 33, 33, 0.75)"
-            display="inline"
             position="absolute"
+            display="inline"
+            height="24px"
             marginTop="-36px"
             marginLeft="10px"
+            paddingTop="1px"
             fontSize="14px"
+            borderRadius="full"
+            backgroundColor="rgba(33, 33, 33, 0.75)"
+            data-testid="nft-owned-count"
+            paddingX="8px"
           >
             {"x" + nft.balance}
           </Text>
         )}
         <Box overflow="hidden">
           <Heading
-            mt="15px"
-            mb="8px"
-            whiteSpace="nowrap"
             overflow="hidden"
-            textOverflow="ellipsis"
+            marginTop="15px"
+            marginBottom="8px"
             fontSize="sm"
+            whiteSpace="nowrap"
+            textOverflow="ellipsis"
           >
             {name}
           </Heading>

--- a/src/views/nfts/NFTDrawerBody.tsx
+++ b/src/views/nfts/NFTDrawerBody.tsx
@@ -18,12 +18,12 @@ const NFTDrawerBody = ({
   return (
     <>
       <Flex
-        data-testid="nft-drawer-body"
+        alignItems="center"
         justifyContent="space-between"
+        paddingBottom="30px"
         color={colors.gray[400]}
         cursor="pointer"
-        alignItems="center"
-        paddingBottom="30px"
+        data-testid="nft-drawer-body"
       >
         <AddressPill address={parsePkh(ownerPkh)} />
         <CloseDrawerButton onClose={onCloseDrawer} />

--- a/src/views/nfts/NFTDrawerCard.tsx
+++ b/src/views/nfts/NFTDrawerCard.tsx
@@ -44,34 +44,34 @@ const NFTDrawerCard = ({ nft, ownerPkh }: { nft: NFTBalance; ownerPkh: RawPkh })
   };
   return (
     <Box>
-      <Card bg={colors.gray[800]} height="534px" width="534px">
-        <CardBody p="24px">
-          <Box height="486px" width="486px">
+      <Card width="534px" height="534px" background={colors.gray[800]}>
+        <CardBody padding="24px">
+          <Box width="486px" height="486px">
             {isVideo ? (
               <ReactPlayer url={url} playing loop height="100%" width="100%" />
             ) : (
               <Image
-                data-testid="nft-image"
-                objectFit="contain"
-                height="486px"
                 width="486px"
+                height="486px"
+                objectFit="contain"
                 alt={name}
-                src={url}
+                data-testid="nft-image"
                 fallbackSrc={fallbackUrl}
+                src={url}
               />
             )}
           </Box>
           {Number(nft.balance) > 1 && (
             <Text
-              data-testid="nft-owned-count"
-              borderRadius="100px"
-              height="24px"
-              px="8px"
-              backgroundColor="rgba(33, 33, 33, 0.75)"
-              display="inline"
               position="absolute"
+              display="inline"
+              height="24px"
               marginTop="-38px"
               marginLeft="16px"
+              borderRadius="100px"
+              backgroundColor="rgba(33, 33, 33, 0.75)"
+              data-testid="nft-owned-count"
+              paddingX="8px"
             >
               {"x" + nft.balance}
             </Text>
@@ -82,19 +82,19 @@ const NFTDrawerCard = ({ nft, ownerPkh }: { nft: NFTBalance; ownerPkh: RawPkh })
       <TagsSection nft={nft} />
 
       {name && (
-        <Heading data-testid="nft-name" mt="16px" mb="14px" size="lg">
+        <Heading marginTop="16px" marginBottom="14px" data-testid="nft-name" size="lg">
           {name}
         </Heading>
       )}
 
       {nft.metadata.description && (
-        <Text data-testid="nft-description" size="sm" color={colors.gray[400]}>
+        <Text color={colors.gray[400]} data-testid="nft-description" size="sm">
           {nft.metadata.description}
         </Text>
       )}
 
       <Button
-        mt="20px"
+        marginTop="20px"
         onClick={() => {
           openWith(<SendNFTForm sender={getAccount(ownerPkh)} nft={nft} />);
         }}
@@ -102,13 +102,13 @@ const NFTDrawerCard = ({ nft, ownerPkh }: { nft: NFTBalance; ownerPkh: RawPkh })
         Send
       </Button>
 
-      <Accordion allowMultiple mt="32px">
+      <Accordion marginTop="32px" allowMultiple>
         <AttributesAccordionItem nft={nft} style={accordionItemStyle} />
         <PropertiesAccordionItem nft={nft} style={accordionItemStyle} />
 
-        <AccordionItem bg={colors.gray[800]} style={accordionItemStyle}>
+        <AccordionItem background={colors.gray[800]} style={accordionItemStyle}>
           <AccordionButton paddingY="16px">
-            <Heading size="md" flex="1" textAlign="left">
+            <Heading flex="1" textAlign="left" size="md">
               JSON
             </Heading>
             <AccordionIcon />

--- a/src/views/nfts/NFTGallery.tsx
+++ b/src/views/nfts/NFTGallery.tsx
@@ -10,7 +10,7 @@ export const NFTGallery: React.FC<{
   onSelect: (owner: RawPkh, nft: NFTBalance) => void;
 }> = ({ nftsByOwner, onSelect }) => {
   return (
-    <Wrap spacing="16px" mb="16px">
+    <Wrap marginBottom="16px" spacing="16px">
       {Object.entries(nftsByOwner).flatMap(([owner, nfts]) => {
         return (nfts || []).map(nft => (
           <NFTCard

--- a/src/views/nfts/NftsView.tsx
+++ b/src/views/nfts/NftsView.tsx
@@ -43,7 +43,7 @@ const NFTsViewBase = () => {
   const drawerNFT = ownerPkh && get(nfts, [ownerPkh], []).find(nft => fullId(nft) === nftId);
 
   return (
-    <Flex direction="column" height="100%">
+    <Flex flexDirection="column" height="100%">
       <TopBar title="NFTs" subtitle={`(${totalNFTs})`} />
       {accountsFilter}
 
@@ -61,11 +61,11 @@ const NFTsViewBase = () => {
           </Box>
 
           <Drawer
-            blockScrollOnMount={!isDynamicModalOpen}
-            placement="right"
-            onClose={openNFTsPage}
-            isOpen={!!drawerNFT}
             autoFocus={false}
+            blockScrollOnMount={!isDynamicModalOpen}
+            isOpen={!!drawerNFT}
+            onClose={openNFTsPage}
+            placement="right"
           >
             <DrawerOverlay />
             <DrawerContent>

--- a/src/views/nfts/drawer/AttributesAccordionItem.tsx
+++ b/src/views/nfts/drawer/AttributesAccordionItem.tsx
@@ -20,9 +20,9 @@ const AttributesAccordionItem = ({ nft, style }: { nft: NFTBalance; style: CSSPr
     return null;
   }
   return (
-    <AccordionItem data-testid="attributes-section" bg={colors.gray[800]} style={style}>
+    <AccordionItem background={colors.gray[800]} data-testid="attributes-section" style={style}>
       <AccordionButton paddingY="16px">
-        <Heading size="md" flex="1" textAlign="left">
+        <Heading flex="1" textAlign="left" size="md">
           Attributes
         </Heading>
         <AccordionIcon />
@@ -32,7 +32,7 @@ const AttributesAccordionItem = ({ nft, style }: { nft: NFTBalance; style: CSSPr
           {attributes.map(attr => {
             return (
               <WrapItem key={attr.name} flex="1" data-testid="nft-attribute">
-                <Card marginBottom="2px" width="160px" height="128px" bg={colors.gray[700]}>
+                <Card width="160px" height="128px" marginBottom="2px" background={colors.gray[700]}>
                   <CardBody padding="16px">
                     {/* TODO: make it display long attributes https://app.asana.com/0/0/1204721073861946/f */}
                     <Text color={colors.gray[400]} size="sm">

--- a/src/views/nfts/drawer/PropertiesAccordionItem.tsx
+++ b/src/views/nfts/drawer/PropertiesAccordionItem.tsx
@@ -38,9 +38,9 @@ const PropertiesAccordionItem = ({ nft, style }: { nft: NFTBalance; style: CSSPr
   const network = useSelectedNetwork();
 
   return (
-    <AccordionItem bg={colors.gray[800]} style={style}>
+    <AccordionItem background={colors.gray[800]} style={style}>
       <AccordionButton paddingY="16px">
-        <Heading size="md" flex="1" textAlign="left">
+        <Heading flex="1" textAlign="left" size="md">
           Properties
         </Heading>
         <AccordionIcon />
@@ -51,60 +51,68 @@ const PropertiesAccordionItem = ({ nft, style }: { nft: NFTBalance; style: CSSPr
           <Table variant="stripped">
             <Tbody fontSize="14px">
               <Tr
-                bg={colors.gray[900]}
-                borderRadius="8px"
+                background={colors.gray[900]}
                 borderColor={colors.gray[700]}
                 borderBottomWidth="1px"
+                borderRadius="8px"
               >
                 <Td
-                  data-testid="nft-editions"
+                  width="20%"
                   padding="16px 0 16px 15px"
-                  w="20%"
-                  borderTopLeftRadius="8px"
-                  color={colors.gray[400]}
                   paddingRight="0"
+                  color={colors.gray[400]}
+                  borderTopLeftRadius="8px"
+                  data-testid="nft-editions"
                 >
                   Editions:
                 </Td>
                 <Td
-                  data-testid="nft-editions-value"
+                  width="30%"
                   padding="16px 0 16px 5px"
-                  w="30%"
                   borderColor={colors.gray[700]}
                   borderRightWidth="1px"
+                  data-testid="nft-editions-value"
                 >
                   {nft.totalSupply || "?"}
                 </Td>
 
-                <Td padding="16px 0 16px 15px" w="20%" color={colors.gray[400]}>
+                <Td width="20%" padding="16px 0 16px 15px" color={colors.gray[400]}>
                   Token ID:
                 </Td>
-                <Td padding="16px 0 16px 5px" w="30%" borderTopRightRadius="8px">
+                <Td width="30%" padding="16px 0 16px 5px" borderTopRightRadius="8px">
                   {nft.tokenId}
                 </Td>
               </Tr>
-              <Tr bg={colors.gray[800]} borderColor={colors.gray[700]} borderBottomWidth="1px">
-                <Td data-testid="nft-royalty" padding="16px 0 16px 15px" color={colors.gray[400]}>
+              <Tr
+                background={colors.gray[800]}
+                borderColor={colors.gray[700]}
+                borderBottomWidth="1px"
+              >
+                <Td padding="16px 0 16px 15px" color={colors.gray[400]} data-testid="nft-royalty">
                   Royalties
                   {royaltyShares.length > 1 ? " (" + royaltyShares.length + ")" : ""}:
                 </Td>
                 <Td
-                  data-testid="nft-royalty-value"
                   padding="16px 0 16px 5px"
                   borderColor={colors.gray[700]}
                   borderRightWidth="1px"
+                  data-testid="nft-royalty-value"
                 >
                   {royaltyShares.length > 0 ? totalRoyalties + "%" : "-"}
                 </Td>
-                <Td data-testid="nft-mime" padding="16px 0 16px 15px" color={colors.gray[400]}>
+                <Td padding="16px 0 16px 15px" color={colors.gray[400]} data-testid="nft-mime">
                   MIME type:
                 </Td>
-                <Td data-testid="nft-mime-value" padding="16px 0 16px 5px" w="30%">
+                <Td width="30%" padding="16px 0 16px 5px" data-testid="nft-mime-value">
                   {mimeType(nft) || "-"}
                 </Td>
               </Tr>
 
-              <Tr bg={colors.gray[900]} borderColor={colors.gray[700]} borderBottomWidth="1px">
+              <Tr
+                background={colors.gray[900]}
+                borderColor={colors.gray[700]}
+                borderBottomWidth="1px"
+              >
                 <Td padding="16px 0 16px 15px" color={colors.gray[400]}>
                   Contract:
                 </Td>
@@ -114,27 +122,31 @@ const PropertiesAccordionItem = ({ nft, style }: { nft: NFTBalance; style: CSSPr
                 <Td padding="16px 0 16px 15px" color={colors.gray[400]}>
                   Metadata:
                 </Td>
-                <Td padding="16px 0 16px 5px" w="30%">
+                <Td width="30%" padding="16px 0 16px 5px">
                   TzKT <TzktLink url={metadataUri(nft, network)}></TzktLink>
                 </Td>
               </Tr>
 
-              <Tr bg={colors.gray[800]} borderColor={colors.gray[700]} borderBottomWidth="1px">
-                <Td data-testid="nft-creator" padding="16px 0 16px 15px" color={colors.gray[400]}>
+              <Tr
+                background={colors.gray[800]}
+                borderColor={colors.gray[700]}
+                borderBottomWidth="1px"
+              >
+                <Td padding="16px 0 16px 15px" color={colors.gray[400]} data-testid="nft-creator">
                   Creator:
                 </Td>
                 <Td
-                  data-testid="nft-creator-value"
                   padding="16px 0 16px 5px"
                   borderColor={colors.gray[700]}
                   borderRightWidth="1px"
+                  data-testid="nft-creator-value"
                 >
                   <CreatorElement nft={nft} />
                 </Td>
                 <Td padding="16px 0 16px 15px" color={colors.gray[400]}>
                   License:
                 </Td>
-                <Td padding="16px 0 16px 5px" w="30%">
+                <Td width="30%" padding="16px 0 16px 5px">
                   <TruncatedTextWithTooltip text={nft.metadata.rights || "-"} maxLength={15} />
                 </Td>
               </Tr>

--- a/src/views/nfts/drawer/TagsSection.tsx
+++ b/src/views/nfts/drawer/TagsSection.tsx
@@ -11,8 +11,8 @@ const TagsSection = ({ nft }: { nft: NFTBalance }) => {
     <Wrap marginTop="20px" data-testid="tags-section">
       {tags.map(tag => {
         return (
-          <WrapItem key={tag} borderRadius="100px" padding="3px 8px" bg={colors.gray[600]}>
-            <Text data-testid="nft-tag" color={colors.gray[400]}>
+          <WrapItem key={tag} padding="3px 8px" background={colors.gray[600]} borderRadius="100px">
+            <Text color={colors.gray[400]} data-testid="nft-tag">
               {tag}
             </Text>
           </WrapItem>

--- a/src/views/operations/OperationsView.tsx
+++ b/src/views/operations/OperationsView.tsx
@@ -30,13 +30,13 @@ const OperationsView = () => {
   };
 
   const loadingElement = (
-    <Text textAlign="center" color={colors.gray[500]} py="20px">
+    <Text color={colors.gray[500]} textAlign="center" paddingY="20px">
       Loading...
     </Text>
   );
 
   return (
-    <Flex direction="column" height="100%" px="6px">
+    <Flex flexDirection="column" height="100%" paddingX="6px">
       <TopBar title="Operations" />
       {accountsFilter}
       {operations.length === 0 && isLoading && loadingElement}
@@ -44,21 +44,26 @@ const OperationsView = () => {
       {operations.length > 0 && (
         <Box
           overflowY="scroll"
-          onScroll={onScroll}
+          marginBottom="20px"
+          background={colors.gray[900]}
           borderRadius="8px"
-          px="20px"
-          mb="20px"
-          bg={colors.gray[900]}
+          onScroll={onScroll}
+          paddingX="20px"
         >
           <OperationTileContext.Provider value={{ mode: "page" }}>
             {operations.map((operation, i) => {
               const isLast = i === operations.length - 1;
               return (
-                <Box key={operation.id} height="90px" mb={isLast ? "10px" : 0} py="20px">
+                <Box
+                  key={operation.id}
+                  height="90px"
+                  marginBottom={isLast ? "10px" : 0}
+                  paddingY="20px"
+                >
                   <OperationTile operation={operation} />
                   {!isLast && (
                     <Box>
-                      <Divider mt="20px" />
+                      <Divider marginTop="20px" />
                     </Box>
                   )}
                 </Box>

--- a/src/views/settings/BeaconDrawerCard.tsx
+++ b/src/views/settings/BeaconDrawerCard.tsx
@@ -23,11 +23,11 @@ export const BeaconDrawerCard = () => {
     <>
       <SettingsCardWithDrawerIcon left="dApps" onClick={onOpen} isSelected={isOpen} />
       <Drawer
+        autoFocus={false}
         blockScrollOnMount={!isDynamicModalOpen}
         isOpen={isOpen}
-        placement="right"
         onClose={closeDrawer}
-        autoFocus={false}
+        placement="right"
       >
         <DrawerOverlay />
         <DrawerContent>
@@ -45,7 +45,7 @@ const BeaconDrawerBody = () => {
   const addPeer = useAddPeer();
   return (
     <Box>
-      <Flex h={24} justifyContent="space-between" alignItems="center">
+      <Flex alignItems="center" justifyContent="space-between" height={24}>
         <Heading size="xl">dApps</Heading>
       </Flex>
       <Button
@@ -57,7 +57,7 @@ const BeaconDrawerBody = () => {
       >
         Paste a peer request code
       </Button>
-      <Text mt="16px" mb="32px" color="text.dark">
+      <Text marginTop="16px" marginBottom="32px" color="text.dark">
         or open a deeplink from inside the dApp...
       </Text>
       <BeaconPeers />

--- a/src/views/settings/ErrorLogsDrawerCard.tsx
+++ b/src/views/settings/ErrorLogsDrawerCard.tsx
@@ -30,8 +30,8 @@ const ErrorLogsDrawerCard = () => {
       <Drawer
         blockScrollOnMount={!isDynamicModalOpen}
         isOpen={isOpen}
-        placement="right"
         onClose={closeDrawer}
+        placement="right"
       >
         <DrawerOverlay />
         <DrawerContent>
@@ -48,8 +48,8 @@ const ErrorLogsDrawerCard = () => {
 const ErrorLogsDrawerBody = () => {
   const errors = [...useAppSelector(s => s.errors)].reverse();
   return (
-    <Flex direction="column" height="100%">
-      <Flex h={24} justifyContent="space-between" alignItems="center">
+    <Flex flexDirection="column" height="100%">
+      <Flex alignItems="center" justifyContent="space-between" height={24}>
         <Heading size="xl">Error Logs</Heading>
         <a
           download="UmamiErrorLogs.json"
@@ -75,9 +75,9 @@ const ErrorLogRow: React.FC<{
       <Divider marginY={1} />
       <Flex justifyContent="space-between" paddingY={3}>
         <Flex>
-          <Icon as={AiOutlineExclamationCircle} mr={2} mt="1px" />
-          <Flex direction="column">
-            <Heading size="sm" wordBreak="break-all">
+          <Icon as={AiOutlineExclamationCircle} marginTop="1px" marginRight={2} />
+          <Flex flexDirection="column">
+            <Heading wordBreak="break-all" size="sm">
               {errorLog.description}
             </Heading>
             <Text color={colors.gray[400]} size="sm">

--- a/src/views/settings/SettingsView.tsx
+++ b/src/views/settings/SettingsView.tsx
@@ -13,7 +13,7 @@ import DownloadIcon from "../../assets/icons/Download";
 
 export default function SettingsView() {
   return (
-    <Flex direction="column" height="100%">
+    <Flex flexDirection="column" height="100%">
       <TopBar title="Settings" />
       <Box overflowY="scroll">
         <Box marginTop="16px">
@@ -100,9 +100,9 @@ const BackupSection = () => {
   return (
     <SectionContainer title="Backup">
       <ClickableCard onClick={downloadBackup} isSelected={false}>
-        <Flex justifyContent="space-between" alignItems="center">
+        <Flex alignItems="center" justifyContent="space-between">
           <Heading size="sm">Download backup file</Heading>
-          <Button variant="unstyled" onClick={downloadBackup}>
+          <Button onClick={downloadBackup} variant="unstyled">
             <DownloadIcon cursor="pointer" />
           </Button>
         </Flex>
@@ -144,8 +144,8 @@ const SectionContainer: React.FC<{
   return (
     <Box marginTop="8px">
       <Flex>
-        <Box w="550px">
-          <Heading size="lg" marginBottom="16px">
+        <Box width="550px">
+          <Heading marginBottom="16px" size="lg">
             {title}
           </Heading>
           {children}

--- a/src/views/settings/network/NetworkSettingsDrawerBody.tsx
+++ b/src/views/settings/network/NetworkSettingsDrawerBody.tsx
@@ -41,23 +41,23 @@ export const NetworkSettingsDrawerBody = () => {
       <Center justifyContent="space-between">
         <Heading>Network Settings</Heading>
         <Button
-          variant="CTAWithIcon"
-          onClick={() => openWith(<UpsertNetworkModal />)}
           paddingRight="0"
+          onClick={() => openWith(<UpsertNetworkModal />)}
+          variant="CTAWithIcon"
         >
           <Text size="sm">Add Network</Text>
           <PlusIcon ml="4px" height="18px" width="18px" stroke="currentcolor" />
         </Button>
       </Center>
-      <RadioGroup mt="60px" onChange={selectNetwork} value={network.name}>
+      <RadioGroup marginTop="60px" onChange={selectNetwork} value={network.name}>
         <Stack>
           {availableNetworks.map(network => (
             <Fragment key={network.name}>
               <Divider borderColor={colors.gray[700]} />
               <Flex justifyContent="space-between" data-testid={`network-${network.name}`}>
-                <Radio height="100px" variant="primary" value={network.name}>
-                  <Flex ml="16px" flexDirection="column">
-                    <Heading size="sm" mb="4px">
+                <Radio height="100px" value={network.name} variant="primary">
+                  <Flex flexDirection="column" marginLeft="16px">
+                    <Heading marginBottom="4px" size="sm">
                       {network.name}
                     </Heading>
                     <Text color={colors.gray[400]}>{network.rpcUrl}</Text>
@@ -67,15 +67,15 @@ export const NetworkSettingsDrawerBody = () => {
                   <Center data-testid="popover-menu">
                     <PopoverMenu>
                       <Button
-                        variant="popover"
                         onClick={() => openWith(<UpsertNetworkModal network={network} />)}
+                        variant="popover"
                       >
-                        <Text mr="4px">Edit</Text>
+                        <Text marginRight="4px">Edit</Text>
                         <PenIcon />
                       </Button>
-                      <Divider mt="4px" />
-                      <Button variant="popover" onClick={() => removeNetwork(network)}>
-                        <Text mr="4px">Remove</Text>
+                      <Divider marginTop="4px" />
+                      <Button onClick={() => removeNetwork(network)} variant="popover">
+                        <Text marginRight="4px">Remove</Text>
                         <TrashIcon />
                       </Button>
                     </PopoverMenu>

--- a/src/views/settings/network/NetworkSettingsDrawerCard.tsx
+++ b/src/views/settings/network/NetworkSettingsDrawerCard.tsx
@@ -19,8 +19,8 @@ export const NetworkSettingsDrawerCard = () => {
       <Drawer
         blockScrollOnMount={!isDynamicModalOpen}
         isOpen={isDrawerOpen}
-        placement="right"
         onClose={closeDrawer}
+        placement="right"
       >
         <DrawerOverlay />
         <DrawerContent>

--- a/src/views/settings/network/UpsertNetworkModal.tsx
+++ b/src/views/settings/network/UpsertNetworkModal.tsx
@@ -45,7 +45,7 @@ export const UpsertNetworkModal = ({ network }: { network?: Network }) => {
         </ModalHeader>
         <ModalBody>
           {mode === "create" && (
-            <FormControl mb="24px" mt="32px" isInvalid={!!errors.name}>
+            <FormControl marginTop="32px" marginBottom="24px" isInvalid={!!errors.name}>
               <FormLabel>Name</FormLabel>
               <Input
                 placeholder="mainnet"
@@ -61,7 +61,7 @@ export const UpsertNetworkModal = ({ network }: { network?: Network }) => {
               {errors.name && <FormErrorMessage>{errors.name.message}</FormErrorMessage>}
             </FormControl>
           )}
-          <FormControl mb="24px" isInvalid={!!errors.rpcUrl}>
+          <FormControl marginBottom="24px" isInvalid={!!errors.rpcUrl}>
             <FormLabel>RPC URL</FormLabel>
             <Input
               placeholder="https://prod.tcinfra.net/rpc/mainnet"
@@ -69,7 +69,7 @@ export const UpsertNetworkModal = ({ network }: { network?: Network }) => {
             />
             {errors.rpcUrl && <FormErrorMessage>{errors.rpcUrl.message}</FormErrorMessage>}
           </FormControl>
-          <FormControl mb="24px" isInvalid={!!errors.tzktApiUrl}>
+          <FormControl marginBottom="24px" isInvalid={!!errors.tzktApiUrl}>
             <FormLabel>Tzkt API URL</FormLabel>
             <Input
               placeholder="https://api.ghostnet.tzkt.io"
@@ -77,7 +77,7 @@ export const UpsertNetworkModal = ({ network }: { network?: Network }) => {
             />
             {errors.tzktApiUrl && <FormErrorMessage>{errors.tzktApiUrl.message}</FormErrorMessage>}
           </FormControl>
-          <FormControl mb="24px" isInvalid={!!errors.tzktExplorerUrl}>
+          <FormControl marginBottom="24px" isInvalid={!!errors.tzktExplorerUrl}>
             <FormLabel>Tzkt Explorer URL</FormLabel>
             <Input
               placeholder="https://ghostnet.tzkt.io"
@@ -93,7 +93,7 @@ export const UpsertNetworkModal = ({ network }: { network?: Network }) => {
             <Input placeholder="https://faucet.ghostnet.teztnets.xyz" {...register("buyTezUrl")} />
           </FormControl>
           <ModalFooter>
-            <Button isDisabled={!isValid} onClick={() => {}} w="100%" type="submit">
+            <Button width="100%" isDisabled={!isValid} onClick={() => {}} type="submit">
               {mode === "edit" ? "Save changes" : "Add network"}
             </Button>
           </ModalFooter>

--- a/src/views/tokens/AccountTokens.tsx
+++ b/src/views/tokens/AccountTokens.tsx
@@ -36,20 +36,20 @@ const Header: React.FC<{
 
   return (
     <Flex
+      alignItems="center"
+      height="78px"
+      background={colors.gray[800]}
+      borderTopRadius="8px"
       data-testid="header"
       paddingX="30px"
-      bg={colors.gray[800]}
-      height="78px"
-      borderTopRadius="8px"
-      alignItems="center"
     >
       <Identicon p="8px" identiconSize={32} address={pkh} />
-      <Flex flex={1} justifyContent="space-between">
-        <Box ml="16px" data-testid="account-identifier">
-          <Heading size="md" mb="4px">
+      <Flex justifyContent="space-between" flex={1}>
+        <Box marginLeft="16px" data-testid="account-identifier">
+          <Heading marginBottom="4px" size="md">
             {label}
           </Heading>
-          <Text size="sm" color={colors.gray[300]}>
+          <Text color={colors.gray[300]} size="sm">
             {formatPkh(pkh)}
           </Text>
         </Box>
@@ -68,7 +68,12 @@ const AccountTokens: React.FC<{
   const { openWith } = useContext(DynamicModalContext);
 
   return (
-    <Card mb="16px" bgColor={colors.gray[900]} borderBottomRadius="8px" overflowX="auto">
+    <Card
+      overflowX="auto"
+      marginBottom="16px"
+      borderBottomRadius="8px"
+      backgroundColor={colors.gray[900]}
+    >
       <Header account={account} />
       <TableContainer paddingX="30px">
         <Table>
@@ -77,23 +82,23 @@ const AccountTokens: React.FC<{
               const rowBorderColor = i === tokens.length - 1 ? "transparent" : colors.gray[700];
               return (
                 <Tr key={fullId(token)} data-testid="token-tile">
-                  <Td paddingX="0" minWidth="240px" width="20%" borderColor={rowBorderColor}>
+                  <Td width="20%" minWidth="240px" borderColor={rowBorderColor} paddingX="0">
                     <Flex alignItems="center">
                       <TokenIcon display="inline-block" contract={token.contract} width="38px" />
-                      <Heading display="inline-block" size="sm" marginLeft="16px">
+                      <Heading display="inline-block" marginLeft="16px" size="sm">
                         <TokenNameWithIcon token={token} />
                       </Heading>
                     </Flex>
                   </Td>
-                  <Td paddingX="0" minWidth="200px" width="20%" borderColor={rowBorderColor}>
+                  <Td width="20%" minWidth="200px" borderColor={rowBorderColor} paddingX="0">
                     <AddressPill address={parseContractPkh(token.contract)} />
                   </Td>
-                  <Td paddingX="0" minWidth="160px" width="15%" borderColor={rowBorderColor}>
+                  <Td width="15%" minWidth="160px" borderColor={rowBorderColor} paddingX="0">
                     <Heading size="sm">
                       {tokenPrettyAmount(token.balance, token, { showSymbol: false })}
                     </Heading>
                   </Td>
-                  <Td textAlign="right" paddingX="0" borderColor={rowBorderColor}>
+                  <Td textAlign="right" borderColor={rowBorderColor} paddingX="0">
                     <SendButton
                       onClick={() => {
                         openWith(<SendTokenFormPage sender={account} token={token} />);

--- a/src/views/tokens/TokenNameWithIcon.tsx
+++ b/src/views/tokens/TokenNameWithIcon.tsx
@@ -40,7 +40,7 @@ const TokenNameWithIcon = ({
   const isVerified = verifiedTokens.includes(token.contract);
   return (
     <Flex alignItems="center">
-      <Text {...textProps} mr="4px">
+      <Text {...textProps} marginRight="4px">
         {tokenNameSafe(token)}
       </Text>
       {isVerified && <VerifiedIcon />}

--- a/src/views/tokens/TokensPage.tsx
+++ b/src/views/tokens/TokensPage.tsx
@@ -15,7 +15,7 @@ const TokensPage = () => {
     .filter(([, tokens]) => tokens.length > 0);
 
   return (
-    <Flex direction="column" height="100%">
+    <Flex flexDirection="column" height="100%">
       <TopBar title="Tokens" />
       {accountsFilter}
       {accountsWithTokens.length === 0 ? (

--- a/src/views/withSideMenu.tsx
+++ b/src/views/withSideMenu.tsx
@@ -5,7 +5,7 @@ export const withSideMenu = (body: React.ReactElement) => {
   return (
     <Flex height="100vh">
       <SideNavbar />
-      <Box flex={1} height="100%" overflowX="hidden" px={6}>
+      <Box flex={1} overflowX="hidden" height="100%" paddingX={6}>
         {body}
       </Box>
     </Flex>

--- a/yarn.lock
+++ b/yarn.lock
@@ -6870,6 +6870,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/scope-manager@npm:6.13.0":
+  version: 6.13.0
+  resolution: "@typescript-eslint/scope-manager@npm:6.13.0"
+  dependencies:
+    "@typescript-eslint/types": 6.13.0
+    "@typescript-eslint/visitor-keys": 6.13.0
+  checksum: b0b4b1c26cb3a8cfd2ddd4ac1fb7c71f5755babde6905658434042ee4039c8fdbae3cb197909a50e7e692e00db85a3b30659188dcb2f02d3065588945d929f90
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/type-utils@npm:6.11.0":
   version: 6.11.0
   resolution: "@typescript-eslint/type-utils@npm:6.11.0"
@@ -6898,6 +6908,13 @@ __metadata:
   version: 6.11.0
   resolution: "@typescript-eslint/types@npm:6.11.0"
   checksum: ca8a11320286c9b0759a70ec83b9fd99937c9686fafdd41d8ea09ed7b2fa12e6b342bf65547efe5495926cd04cfc6488315920e3caffd27f12d42cb9a8cf88c8
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/types@npm:6.13.0":
+  version: 6.13.0
+  resolution: "@typescript-eslint/types@npm:6.13.0"
+  checksum: a0a7a74943ba2e5417af87f232a410f3f17aba3caf86a887371d47ef28ad629a871689ee9e2eb7b7eb3010462e8dae5f0d04bcd27945ab2a77baba764e4b67ad
   languageName: node
   linkType: hard
 
@@ -6937,6 +6954,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/typescript-estree@npm:6.13.0":
+  version: 6.13.0
+  resolution: "@typescript-eslint/typescript-estree@npm:6.13.0"
+  dependencies:
+    "@typescript-eslint/types": 6.13.0
+    "@typescript-eslint/visitor-keys": 6.13.0
+    debug: ^4.3.4
+    globby: ^11.1.0
+    is-glob: ^4.0.3
+    semver: ^7.5.4
+    ts-api-utils: ^1.0.1
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: f1fc5d2f6c1e6c063e8bad037aab32a6c635b9e474d3863207e040f7b0b2ff1a1437dd5af043a8b6e4de3305d5fadf41e1688ff1772ee97ed3e597edba2843fb
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/utils@npm:6.11.0":
   version: 6.11.0
   resolution: "@typescript-eslint/utils@npm:6.11.0"
@@ -6972,6 +7007,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/utils@npm:^6.7.3":
+  version: 6.13.0
+  resolution: "@typescript-eslint/utils@npm:6.13.0"
+  dependencies:
+    "@eslint-community/eslint-utils": ^4.4.0
+    "@types/json-schema": ^7.0.12
+    "@types/semver": ^7.5.0
+    "@typescript-eslint/scope-manager": 6.13.0
+    "@typescript-eslint/types": 6.13.0
+    "@typescript-eslint/typescript-estree": 6.13.0
+    semver: ^7.5.4
+  peerDependencies:
+    eslint: ^7.0.0 || ^8.0.0
+  checksum: 8b37f91f8ec627ee83494b96d86811c93e4efed75aa8c30663e61b658282478dc7e9451b3f7b2a813c0f610cb274b330e162b7a86dadec62735ab9f43021590d
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/visitor-keys@npm:5.62.0":
   version: 5.62.0
   resolution: "@typescript-eslint/visitor-keys@npm:5.62.0"
@@ -6989,6 +7041,16 @@ __metadata:
     "@typescript-eslint/types": 6.11.0
     eslint-visitor-keys: ^3.4.1
   checksum: 6aae9dd79963bbefbf2e310015b909627da541a13ab4d8359eea3c86c34fdbb91e583f65b5a99dee1959f7c5d67b21b45e5a05c63ddb4b82dacd60c890ce8b25
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/visitor-keys@npm:6.13.0":
+  version: 6.13.0
+  resolution: "@typescript-eslint/visitor-keys@npm:6.13.0"
+  dependencies:
+    "@typescript-eslint/types": 6.13.0
+    eslint-visitor-keys: ^3.4.1
+  checksum: 3e7eefefa9ef0c19b56df0f66e0c51d9c3d4aae64bd68906a5225aa2a735a3803ca7a7ca638ebce0b010fa22f39f11caa46dfdec31d98675562b85a7e8465841
   languageName: node
   linkType: hard
 
@@ -10864,6 +10926,17 @@ __metadata:
     escodegen: bin/escodegen.js
     esgenerate: bin/esgenerate.js
   checksum: 096696407e161305cd05aebb95134ad176708bc5cb13d0dcc89a5fcbb959b8ed757e7f2591a5f8036f8f4952d4a724de0df14cd419e29212729fa6df5ce16bf6
+  languageName: node
+  linkType: hard
+
+"eslint-plugin-chakra-ui@npm:^0.10.1":
+  version: 0.10.1
+  resolution: "eslint-plugin-chakra-ui@npm:0.10.1"
+  dependencies:
+    "@typescript-eslint/utils": ^6.7.3
+  peerDependencies:
+    eslint: ">=6"
+  checksum: 82e9b157bcf78393550bdb79d4704080e280625ccdf308b43e27fa150a8159eba8a8c5172e847c67cfa376acc16b75ea99013b3f182c458687ce487996144f5e
   languageName: node
   linkType: hard
 
@@ -20000,6 +20073,7 @@ __metadata:
     electron-updater: ^6.1.4
     electronmon: ^2.0.2
     eslint: ^8.54.0
+    eslint-plugin-chakra-ui: ^0.10.1
     eslint-plugin-jest: ^27.6.0
     eslint-plugin-react: ^7.33.2
     eslint-plugin-react-hooks: ^4.6.0


### PR DESCRIPTION
## Proposed changes

So now the props are sorted semantically and are required to be full names (no more `w={5}`)
more details [here](https://github.com/yukukotani/eslint-plugin-chakra-ui)

these rules are autofixable so `yarn lint` will do the trick. or, while in VSCode hit Cmd+Shift+P and politely ask eslint to do its job :)
<img width="758" alt="Screenshot 2023-11-28 at 09 25 46" src="https://github.com/trilitech/umami-v2/assets/129749432/d9e0f5c4-9e0b-4569-9448-1e3389c86149">

