### PR TITLE
Fix paddings in delete batch confirmation dialog

### DIFF
--- a/src/components/ConfirmationModal.tsx
+++ b/src/components/ConfirmationModal.tsx
@@ -29,7 +29,7 @@ export const ConfirmationModal: React.FC<{
 
   return (
     <ModalContent>
-      <ModalHeader textAlign="center">
+      <ModalHeader marginBottom="10px" textAlign="center">
         <Box>
           <WarningIcon width="40px" height="40px" marginBottom="16px" />
         </Box>


### PR DESCRIPTION
## Proposed changes

Padding added according to [FIgma](https://www.figma.com/file/65KMowhbesv92Njn8mIAAL/Umami-V2?type=design&node-id=2156%3A38603&mode=design&t=vdUEX18EIEmzp2GK-1).

Also affects confirmation modals for 
- removing account  group 
- removing account

[Task link](https://app.asana.com/0/1205770721172203/1206003018224538/f)

## Types of changes

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] UI fix

## Steps to reproduce

Add operations to the batch, delete batch to see the confirmation modal.

## Screenshots

| Before | Now |
| ------ | --- |
|    <img width="478" alt="Screenshot 2023-12-05 at 16 22 42" src="https://github.com/trilitech/umami-v2/assets/150050388/a4597725-5121-48b9-8914-b0743088b619">    |   <img width="477" alt="Screenshot 2023-12-05 at 16 21 19" src="https://github.com/trilitech/umami-v2/assets/150050388/dc1de411-003b-477e-be1b-9e9a90d4c3d9">  |
|   <img width="595" alt="Screenshot 2023-12-05 at 16 26 25" src="https://github.com/trilitech/umami-v2/assets/150050388/a92f82ae-7308-41c1-8d46-84014644303c">  |  <img width="606" alt="Screenshot 2023-12-05 at 16 30 01" src="https://github.com/trilitech/umami-v2/assets/150050388/21bd9e86-cbb0-4301-be8e-6c75bf0d267a"> |
|  <img width="595" alt="Screenshot 2023-12-05 at 16 28 06" src="https://github.com/trilitech/umami-v2/assets/150050388/94723ca6-2652-4145-a4ef-cc57af41e746">   |  <img width="601" alt="Screenshot 2023-12-05 at 16 29 30" src="https://github.com/trilitech/umami-v2/assets/150050388/99d84ad1-b02f-4593-adcf-439e626b3937"> |

## Checklist

- [ ] Tests that prove my fix is effective or that my feature works have been added
- [ ] Documentation has been added (if appropriate)
- [x] Screenshots are added (if any UI changes have been made)
- [x] All TODOs have a corresponding task created (and the link is attached to it)
