### PR TITLE
Remove incorrect interations in test definitions

### DIFF
--- a/src/components/AddressPill/AddressPillIcon.test.tsx
+++ b/src/components/AddressPill/AddressPillIcon.test.tsx
@@ -5,22 +5,18 @@ import { mockContractAddress } from "../../mocks/factories";
 import { render, screen } from "../../mocks/testUtils";
 
 describe("AddressPill Icons", () => {
-  it("Left icon renders", () => {
-    const addressKindTypesWithLeftIcon: AddressKindType[] = [
-      "multisig",
-      "fa1.2",
-      "fa2",
-      "baker",
-      "contact",
-    ];
+  it.each(["multisig", "fa1.2", "fa2", "baker", "contact"])("renders %s left icon", type => {
+    render(
+      <LeftIcon
+        addressKind={{
+          type: type as AddressKindType,
+          pkh: mockContractAddress(0).pkh,
+          label: "label" as any,
+        }}
+      />
+    );
 
-    addressKindTypesWithLeftIcon.forEach(type => {
-      render(
-        <LeftIcon addressKind={{ type, pkh: mockContractAddress(0).pkh, label: "label" as any }} />
-      );
-
-      expect(screen.getByTestId(`${type}-icon`)).toBeInTheDocument();
-    });
+    expect(screen.getByTestId(`${type}-icon`)).toBeInTheDocument();
   });
 
   it("Left icon with unknown/implicit address returns null", () => {

--- a/src/components/Onboarding/derivationPath/DerivationPath.test.tsx
+++ b/src/components/Onboarding/derivationPath/DerivationPath.test.tsx
@@ -25,59 +25,57 @@ describe("<DerivationPath />", () => {
     },
   ];
 
-  testData.forEach(async ({ account, nextPage, derivationPath }) => {
-    describe(`For ${account.type}`, () => {
-      it("uses default path", async () => {
-        const user = userEvent.setup();
-        render(fixture(goToStepMock, account));
-        const confirmBtn = screen.getByRole("button", { name: /continue/i });
-        await waitFor(() => {
-          expect(confirmBtn).toBeEnabled();
-        });
-        user.click(confirmBtn);
-        await waitFor(() => {
-          expect(goToStepMock).toBeCalledTimes(1);
-        });
-        expect(goToStepMock).toBeCalledWith({
-          type: nextPage,
-          account: {
-            ...account,
-            derivationPath,
-          },
-        });
+  describe.each(testData)(`For $account.type`, ({ account, nextPage, derivationPath }) => {
+    it("uses default path", async () => {
+      const user = userEvent.setup();
+      render(fixture(goToStepMock, account));
+      const confirmBtn = screen.getByRole("button", { name: /continue/i });
+      await waitFor(() => {
+        expect(confirmBtn).toBeEnabled();
+      });
+      user.click(confirmBtn);
+      await waitFor(() => {
+        expect(goToStepMock).toBeCalledTimes(1);
+      });
+      expect(goToStepMock).toBeCalledWith({
+        type: nextPage,
+        account: {
+          ...account,
+          derivationPath,
+        },
+      });
+    });
+
+    it("allows to select a custom path", async () => {
+      const user = userEvent.setup();
+      const standard5PieceDerivationPath = "44'/1729'/?'/0'/0'";
+
+      render(fixture(goToStepMock, account));
+
+      const confirmBtn = screen.getByRole("button", { name: /continue/i });
+
+      user.click(screen.getByTestId("select-input"));
+      await waitFor(() => {
+        expect(screen.getByTestId("select-options")).toBeInTheDocument();
       });
 
-      it("allows to specify a custom path", async () => {
-        const user = userEvent.setup();
-        const standard5PieceDerivationPath = "44'/1729'/?'/0'/0'";
-        render(fixture(goToStepMock, account));
+      user.click(screen.getByText(`m/${standard5PieceDerivationPath}`));
+      await waitFor(() => {
+        expect(screen.getByTestId("select-input")).toHaveTextContent(standard5PieceDerivationPath);
+      });
+      expect(confirmBtn).toBeEnabled();
+      user.click(confirmBtn);
 
-        const confirmBtn = screen.getByRole("button", { name: /continue/i });
+      await waitFor(() => {
+        expect(goToStepMock).toBeCalledTimes(1);
+      });
 
-        user.click(screen.getByTestId("select-input"));
-        await waitFor(() => {
-          expect(screen.getByTestId("select-options")).toBeInTheDocument();
-        });
-
-        user.click(screen.getByText(`m/${standard5PieceDerivationPath}`));
-        await waitFor(() => {
-          expect(screen.getByTestId("select-input")).toHaveTextContent(
-            standard5PieceDerivationPath
-          );
-        });
-        expect(confirmBtn).toBeEnabled();
-        user.click(confirmBtn);
-
-        await waitFor(() => {
-          expect(goToStepMock).toBeCalledTimes(1);
-        });
-        expect(goToStepMock).toBeCalledWith({
-          type: nextPage,
-          account: {
-            ...account,
-            derivationPath: standard5PieceDerivationPath,
-          },
-        });
+      expect(goToStepMock).toBeCalledWith({
+        type: nextPage,
+        account: {
+          ...account,
+          derivationPath: standard5PieceDerivationPath,
+        },
       });
     });
   });

--- a/src/utils/multisig/helper.test.ts
+++ b/src/utils/multisig/helper.test.ts
@@ -14,8 +14,8 @@ jest.unmock("../tezos");
 const mockedAxios = axios as jest.Mocked<typeof axios>;
 
 describe("multisig helpers", () => {
-  DefaultNetworks.forEach(async network => {
-    describe(`getRelevantMultisigContracts (${network.name})`, () => {
+  describe.each(DefaultNetworks)("on $name", network => {
+    describe(`getRelevantMultisigContracts`, () => {
       it("fetches multisig contracts", async () => {
         const mockResponse = {
           data: tzktGetSameMultisigsResponse,
@@ -36,7 +36,8 @@ describe("multisig helpers", () => {
         ]);
       });
     });
-    describe(`getPendingOperationsForMultisigs (${network.name})`, () => {
+
+    describe(`getPendingOperationsForMultisigs`, () => {
       it("handles empty multisigs", async () => {
         const result = await getPendingOperationsForMultisigs([], network);
         expect(mockedAxios.get).toBeCalledTimes(0);


### PR DESCRIPTION
## Proposed changes

We should stick to [this](https://jestjs.io/docs/api#testeachtablename-fn-timeout) instead because it improves readability and is shorter
