### PR TITLE
Show last update after 2min

### DIFF
--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -23,14 +23,6 @@ import { assetsActions } from "../utils/redux/slices/assetsSlice";
 export const emailBodyTemplate =
   "What is it about? (if a bug report please consider including your account address) %0A PLEASE FILL %0A%0A What is the feedback? %0A PLEASE FILL";
 
-const formatRelativeTimestamp = (timestamp: string) => {
-  return formatDistance(new Date(timestamp), new Date());
-};
-
-const diffInMinutes = (timestamp: string) => {
-  return differenceInMinutes(new Date(), new Date(timestamp));
-};
-
 const UpdateButton = () => {
   const [isSmallSize] = useMediaQuery("(max-width: 1200px)");
 
@@ -42,13 +34,15 @@ const UpdateButton = () => {
     dispatch(assetsActions.refetch());
   };
   const showLastTimeUpdated =
-    lastTimeUpdated !== null && diffInMinutes(lastTimeUpdated) >= 2 && !isSmallSize;
+    lastTimeUpdated !== null &&
+    differenceInMinutes(new Date(), new Date(lastTimeUpdated)) >= 2 &&
+    !isSmallSize;
 
   return (
     <>
       {showLastTimeUpdated && (
         <Text display="inline" color={colors.gray[400]} size="sm">
-          Updated {formatRelativeTimestamp(lastTimeUpdated)} ago
+          Updated {formatDistance(new Date(lastTimeUpdated), new Date())} ago
         </Text>
       )}
       <IconButton


### PR DESCRIPTION
## Show last update after 2min

[Task link](https://app.asana.com/0/1205770721172203/1205771213579333)

Refactor the update button in topbar component by removing the hooks.
The message is shown only after 2minuteus of unsync (e.g. no internet connnection)
## Types of changes

- [x] Bugfix
- [ ] New feature
- [x] Refactor
- [ ] Breaking change
- [ ] UI fix



## Screenshots

 

https://github.com/trilitech/umami-v2/assets/128799322/15b737ff-908e-421f-b8d7-e08b02412797


https://github.com/trilitech/umami-v2/assets/128799322/b483718e-d907-4170-a4a9-4f3e0edb7e38



