### PR TITLE
Fix propagation on address pill click on nft page

### DIFF
--- a/src/components/AddressPill/AddressPill.tsx
+++ b/src/components/AddressPill/AddressPill.tsx
@@ -91,7 +91,12 @@ export const AddressPill: React.FC<
 
         <Popover autoFocus={false} isOpen={isOpen} onOpen={onClickAddress}>
           <PopoverTrigger>
-            <Button height="24px" _focus={{ boxShadow: "none" }} variant="unstyled">
+            <Button
+              height="24px"
+              _focus={{ boxShadow: "none" }}
+              onClick={e => e.stopPropagation()}
+              variant="unstyled"
+            >
               <AddressPillText
                 color={textColor}
                 cursor="pointer"


### PR DESCRIPTION
When you'd click an address pill on the NFT page it'd copy the address AND open the NFT drawer, but should just copy the address