### PR TITLE
Make backup import password optional

### DIFF
--- a/src/components/Onboarding/connectOptions/ConnectOptions.tsx
+++ b/src/components/Onboarding/connectOptions/ConnectOptions.tsx
@@ -1,10 +1,12 @@
 import { Button, VStack } from "@chakra-ui/react";
 
 import { LinkIcon } from "../../../assets/icons";
+import { useImplicitAccounts } from "../../../utils/hooks/getAccountDataHooks";
 import { ModalContentWrapper } from "../ModalContentWrapper";
 import { Step, StepType } from "../useOnboardingModal";
 
 export const ConnectOptions = ({ goToStep }: { goToStep: (step: Step) => void }) => {
+  const accountsExist = useImplicitAccounts().length > 0;
   return (
     <ModalContentWrapper icon={<LinkIcon />} title="Connect or Import Account">
       <VStack width="100%" spacing="16px">
@@ -17,18 +19,20 @@ export const ConnectOptions = ({ goToStep }: { goToStep: (step: Step) => void })
           size="lg"
           variant="tertiary"
         >
-          Import with a Secret Key
+          Import with Secret Key
         </Button>
-        <Button
-          width="100%"
-          onClick={_ => {
-            goToStep({ type: StepType.restoreBackup });
-          }}
-          size="lg"
-          variant="tertiary"
-        >
-          Restore from Backup
-        </Button>
+        {!accountsExist && (
+          <Button
+            width="100%"
+            onClick={_ => {
+              goToStep({ type: StepType.restoreBackup });
+            }}
+            size="lg"
+            variant="tertiary"
+          >
+            Restore from Backup
+          </Button>
+        )}
         <Button
           width="100%"
           onClick={_ => {

--- a/src/components/Onboarding/restoreBackupFile/RestoreBackupFile.test.tsx
+++ b/src/components/Onboarding/restoreBackupFile/RestoreBackupFile.test.tsx
@@ -4,22 +4,12 @@ import { RestoreBackupFile } from "./RestoreBackupFile";
 import { render, screen } from "../../../mocks/testUtils";
 
 describe("<RestoreBackupFile />", () => {
-  describe("Form", () => {
-    it("requires a password", async () => {
-      render(<RestoreBackupFile />);
+  it("requires a backup file", async () => {
+    render(<RestoreBackupFile />);
 
-      fireEvent.blur(screen.getByLabelText("Your password"));
-      await waitFor(() => {
-        expect(screen.getByTestId("password")).toHaveTextContent("Password is required");
-      });
-    });
-    it("requires a backup file", async () => {
-      render(<RestoreBackupFile />);
-
-      fireEvent.blur(screen.getByLabelText("Upload File"));
-      await waitFor(() => {
-        expect(screen.getByTestId("file")).toHaveTextContent("File is required");
-      });
+    fireEvent.blur(screen.getByLabelText("Upload File"));
+    await waitFor(() => {
+      expect(screen.getByTestId("file")).toHaveTextContent("File is required");
     });
   });
 });

--- a/src/components/Onboarding/restoreBackupFile/RestoreBackupFile.tsx
+++ b/src/components/Onboarding/restoreBackupFile/RestoreBackupFile.tsx
@@ -12,6 +12,7 @@ import { FormProvider, useForm } from "react-hook-form";
 import { restoreV2BackupFile, useRestoreV1BackupFile } from "./utils";
 import { RotateIcon } from "../../../assets/icons";
 import { useAsyncActionHandler } from "../../../utils/hooks/useAsyncActionHandler";
+import { PasswordInput } from "../../PasswordInput";
 import { ModalContentWrapper } from "../ModalContentWrapper";
 
 type FormFields = {
@@ -74,8 +75,12 @@ export const RestoreBackupFile = () => {
               )}
             </FormControl>
             <FormControl marginTop="24px">
-              <FormLabel>Your password (if you have one)</FormLabel>
-              <Input data-testid="password-input" />
+              <PasswordInput
+                data-testid="password-input"
+                inputName="password"
+                label="Your password (if you have one)"
+                required={false}
+              />
               {errors.password && (
                 <FormErrorMessage data-testid="password">
                   {errors.password.message}

--- a/src/components/PasswordInput.tsx
+++ b/src/components/PasswordInput.tsx
@@ -19,10 +19,11 @@ export type PasswordInputProps<T extends FieldValues, U extends Path<T>> = {
   inputName: U;
   label?: string;
   placeholder?: string;
-  required?: string;
+  required?: string | boolean;
   validate?: RegisterOptions<T, U>["validate"];
 } & InputProps;
 
+// TODO: add an error message and make it nested under FormControl
 export const PasswordInput = <T extends FieldValues, U extends Path<T>>({
   inputName,
   label = "Password",
@@ -45,7 +46,7 @@ export const PasswordInput = <T extends FieldValues, U extends Path<T>>({
           {...register(inputName, {
             required,
             minLength: {
-              value: MIN_LENGTH,
+              value: required ? MIN_LENGTH : 0,
               message: `Your password must be at least ${MIN_LENGTH} characters long`,
             },
             validate,

--- a/src/e2e/onboarding/importSecretKey.e2e.ts
+++ b/src/e2e/onboarding/importSecretKey.e2e.ts
@@ -14,7 +14,7 @@ test("Import secret key", async ({ page }) => {
 
   await page.getByRole("button", { name: "Continue" }).click();
   await page.getByRole("button", { name: "I already have a wallet" }).click();
-  await page.getByRole("button", { name: "Import with a Secret Key" }).click();
+  await page.getByRole("button", { name: "Import with Secret Key" }).click();
 
   await page.getByRole("textbox").fill(AliceAccount.secretKey);
   await page.getByRole("button", { name: "Continue" }).click();

--- a/src/utils/redux/slices/accountsSlice.ts
+++ b/src/utils/redux/slices/accountsSlice.ts
@@ -138,3 +138,5 @@ const concatUnique = (existingAccounts: ImplicitAccount[], newAccounts: Implicit
 
   return [...existingAccounts, ...newAccounts];
 };
+
+export const accountsActions = accountsSlice.actions;


### PR DESCRIPTION
## Proposed changes

Please read commit messages

Also, made Import with Secret Key button consistent with others

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] UI fix

## Steps to reproduce

## Screenshots

<img width="556" alt="Screenshot 2023-12-07 at 21 13 46" src="https://github.com/trilitech/umami-v2/assets/129749432/7c89704f-079f-4818-8013-044366520e35">
<img width="535" alt="Screenshot 2023-12-07 at 21 36 10" src="https://github.com/trilitech/umami-v2/assets/129749432/90d7f55f-aa2d-4332-ae3c-d4f631198e91">
<img width="845" alt="Screenshot 2023-12-07 at 21 13 19" src="https://github.com/trilitech/umami-v2/assets/129749432/d7f1fac7-6be1-4002-82c5-fec2095def47">


## Checklist

- [ ] Tests that prove my fix is effective or that my feature works have been added
- [ ] Documentation has been added (if appropriate)
- [ ] Screenshots are added (if any UI changes have been made)
- [ ] All TODOs have a corresponding task created (and the link is attached to it)
