### PR TITLE
Fix NFT drawer header bottom margin

### DIFF
--- a/src/views/nfts/NFTDrawerBody.tsx
+++ b/src/views/nfts/NFTDrawerBody.tsx
@@ -21,9 +21,8 @@ export const NFTDrawerBody = ({
       <Flex
         alignItems="center"
         justifyContent="space-between"
-        paddingBottom="30px"
+        paddingBottom="22px"
         color={colors.gray[400]}
-        cursor="pointer"
         data-testid="nft-drawer-body"
       >
         <AddressPill address={parsePkh(ownerPkh)} />


### PR DESCRIPTION
## Proposed changes

[Task link](https://docs.google.com/document/d/19YLd8_ZCdGLOogm76sIDNL15vbCC6--R3WakiyPQIu8/edit)

## Types of changes

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] UI fix

## Screenshots

the elements are centrally aligned

<img width="563" alt="Screenshot 2023-12-10 at 16 40 11" src="https://github.com/trilitech/umami-v2/assets/129749432/a1ec9fbf-5628-4a78-ba33-5c289ffd0d66">


| Before | Now |
| ------ | --- |
|  <img width="1005" alt="Screenshot 2023-12-10 at 16 43 00" src="https://github.com/trilitech/umami-v2/assets/129749432/25f50bf1-518c-40bb-b160-9e733b0bad17">  | <img width="1012" alt="Screenshot 2023-12-10 at 16 42 54" src="https://github.com/trilitech/umami-v2/assets/129749432/a6704484-7652-4549-95d0-3265557c3288">  |

## Checklist

- [ ] Tests that prove my fix is effective or that my feature works have been added
- [ ] Documentation has been added (if appropriate)
- [x] Screenshots are added (if any UI changes have been made)
- [ ] All TODOs have a corresponding task created (and the link is attached to it)
