### PR TITLE
Add network to dApp tile

### DIFF
--- a/src/utils/beacon/BeaconNotification/BeaconRequestNotification.test.tsx
+++ b/src/utils/beacon/BeaconNotification/BeaconRequestNotification.test.tsx
@@ -90,10 +90,14 @@ describe("<BeaconRequestNotification />", () => {
     it("saves new connection to beaconSlice", async () => {
       const user = userEvent.setup();
       render(fixture(message, () => {}));
+
+      // select account
       const account = mockMnemonicAccount(1);
       const input = screen.getByLabelText("address");
       fireEvent.change(input, { target: { value: account.address.pkh } });
       fireEvent.blur(input);
+
+      // grant permission
       const grantButton = screen.getByRole("button", { name: "Grant" });
       await waitFor(() => {
         expect(grantButton).toBeEnabled();
@@ -102,7 +106,10 @@ describe("<BeaconRequestNotification />", () => {
 
       await waitFor(() => {
         expect(store.getState().beacon).toEqual({
-          [SENDER_ID]: mockMnemonicAccount(1).address.pkh,
+          [SENDER_ID]: {
+            accountPkh: mockMnemonicAccount(1).address.pkh,
+            networkType: NetworkType.MAINNET,
+          },
         });
       });
     });

--- a/src/utils/beacon/BeaconNotification/panels/PermissionRequestPanel.tsx
+++ b/src/utils/beacon/BeaconNotification/panels/PermissionRequestPanel.tsx
@@ -62,7 +62,7 @@ export const PermissionRequestPanel: React.FC<{
 
     await walletClient.respond(response);
 
-    addConnectionToBeaconSlice(request.senderId, account.address.pkh);
+    addConnectionToBeaconSlice(request.senderId, account.address.pkh, request.network.type);
 
     onSubmit();
   };

--- a/src/utils/beacon/BeaconPeers.tsx
+++ b/src/utils/beacon/BeaconPeers.tsx
@@ -10,6 +10,7 @@ import {
   Image,
   Text,
 } from "@chakra-ui/react";
+import { capitalize } from "lodash";
 import { Fragment, useEffect, useState } from "react";
 
 import { usePeers, useRemovePeer } from "./beacon";
@@ -18,7 +19,7 @@ import { TrashIcon } from "../../assets/icons";
 import { AddressPill } from "../../components/AddressPill/AddressPill";
 import colors from "../../style/colors";
 import { parsePkh } from "../../types/Address";
-import { useGetConnectedAccount } from "../hooks/beaconHooks";
+import { useGetConnectionInfo } from "../hooks/beaconHooks";
 
 /**
  * Component displaying a list of connected dApps.
@@ -89,7 +90,7 @@ const PeerRow = ({ peerInfo, onRemove }: { peerInfo: PeerInfoWithId; onRemove: (
           <Image width="100%" src={peerInfo.icon} />
         </AspectRatio>
         <Center alignItems="flex-start" flexDirection="column">
-          <Heading marginBottom="11px" marginLeft="8px" size="md">
+          <Heading marginBottom="6px" size="md">
             {peerInfo.name}
           </Heading>
           <StoredPeerInfo peerInfo={peerInfo} />
@@ -111,23 +112,27 @@ const PeerRow = ({ peerInfo, onRemove }: { peerInfo: PeerInfoWithId; onRemove: (
 /**
  * Component for displaying additional info about connection with a dApp.
  *
- * Displays {@link AddressPill} with a connected account,
+ * Displays {@link AddressPill} with a connected account and network type,
  * if information about the connection is stored in {@link beaconSlice}.
  *
  * @param peerInfo - peerInfo provided by beacon Api + computed dAppId.
  */
 const StoredPeerInfo = ({ peerInfo }: { peerInfo: PeerInfoWithId }) => {
-  const connectedAccountPkh = useGetConnectedAccount(peerInfo.senderId);
+  const connectionInfo = useGetConnectionInfo(peerInfo.senderId);
 
-  if (!connectedAccountPkh) {
+  if (!connectionInfo) {
     return null;
   }
   return (
     <Flex>
-      <Text marginRight="6px" marginLeft="8px" color={colors.gray[400]} size="sm">
-        Connected to:
+      <AddressPill marginRight="10px" address={parsePkh(connectionInfo.accountPkh)} />
+      <Divider marginRight="10px" orientation="vertical" />
+      <Text marginTop="2px" marginRight="4px" color={colors.gray[450]} fontWeight={650} size="sm">
+        Network:
       </Text>
-      <AddressPill address={parsePkh(connectedAccountPkh)} />
+      <Text marginTop="2px" color={colors.white} data-testid="dapp-connection-network" size="sm">
+        {capitalize(connectionInfo.networkType)}
+      </Text>
     </Flex>
   );
 };

--- a/src/utils/hooks/beaconHooks.test.ts
+++ b/src/utils/hooks/beaconHooks.test.ts
@@ -1,13 +1,15 @@
+import { NetworkType } from "@airgap/beacon-wallet";
 import { renderHook } from "@testing-library/react";
 
 import {
   useAddConnection,
-  useGetConnectedAccount,
+  useGetConnectionInfo,
   useRemoveConnection,
   useResetConnections,
 } from "./beaconHooks";
 import { mockMnemonicAccount, mockSocialAccount } from "../../mocks/factories";
 import { ReduxStore } from "../../providers/ReduxStore";
+import { RawPkh } from "../../types/Address";
 import { beaconActions } from "../redux/slices/beaconSlice";
 import { store } from "../redux/store";
 
@@ -17,9 +19,17 @@ const dAppId2 = "test-dAppId-1";
 const pkh1 = mockMnemonicAccount(0).address.pkh;
 const pkh2 = mockSocialAccount(1).address.pkh;
 
+const addConnection = (dAppId: string, accountPkh: RawPkh, networkType: NetworkType) =>
+  store.dispatch(beaconActions.addConnection({ dAppId, accountPkh, networkType }));
+
+const connectionInfo = (accountPkh: RawPkh, networkType: NetworkType) => ({
+  accountPkh,
+  networkType,
+});
+
 describe("useGetConnectedAccount", () => {
   it("returns undefined when no connection for dAppId is stored", () => {
-    const view = renderHook(() => useGetConnectedAccount(dAppId1), {
+    const view = renderHook(() => useGetConnectionInfo(dAppId1), {
       wrapper: ReduxStore,
     });
 
@@ -27,26 +37,28 @@ describe("useGetConnectedAccount", () => {
   });
 
   it("returns connected account pkh by given dAppId", () => {
-    store.dispatch(beaconActions.addConnection({ dAppId: dAppId1, accountPkh: pkh1 }));
-    store.dispatch(beaconActions.addConnection({ dAppId: dAppId2, accountPkh: pkh2 }));
+    addConnection(dAppId1, pkh1, NetworkType.MAINNET);
+    addConnection(dAppId2, pkh2, NetworkType.GHOSTNET);
 
-    const view = renderHook(() => useGetConnectedAccount(dAppId2), {
+    const view = renderHook(() => useGetConnectionInfo(dAppId2), {
       wrapper: ReduxStore,
     });
 
-    expect(view.result.current).toEqual(pkh2);
+    expect(view.result.current).toEqual(connectionInfo(pkh2, NetworkType.GHOSTNET));
   });
 });
 
 describe("useResetConnections", () => {
   it("removes all connections from BeaconSlice", () => {
-    store.dispatch(beaconActions.addConnection({ dAppId: dAppId1, accountPkh: pkh1 }));
-    store.dispatch(beaconActions.addConnection({ dAppId: dAppId2, accountPkh: pkh2 }));
+    addConnection(dAppId1, pkh1, NetworkType.MAINNET);
+    addConnection(dAppId2, pkh2, NetworkType.GHOSTNET);
 
-    const { result: resetBeaconSlice } = renderHook(() => useResetConnections(), {
+    const {
+      result: { current: resetBeaconSlice },
+    } = renderHook(() => useResetConnections(), {
       wrapper: ReduxStore,
     });
-    resetBeaconSlice.current();
+    resetBeaconSlice();
 
     expect(store.getState().beacon).toEqual({});
   });
@@ -54,45 +66,51 @@ describe("useResetConnections", () => {
 
 describe("useAddConnection", () => {
   it("adds connection to BeaconSlice", () => {
-    store.dispatch(beaconActions.addConnection({ dAppId: dAppId1, accountPkh: pkh1 }));
+    addConnection(dAppId1, pkh1, NetworkType.GHOSTNET);
 
-    const { result: addConnection } = renderHook(() => useAddConnection(), {
+    const {
+      result: { current: addConnectionHook },
+    } = renderHook(() => useAddConnection(), {
       wrapper: ReduxStore,
     });
-    addConnection.current(dAppId2, pkh2);
+    addConnectionHook(dAppId2, pkh2, NetworkType.MAINNET);
 
     expect(store.getState().beacon).toEqual({
-      [dAppId1]: pkh1,
-      [dAppId2]: pkh2,
+      [dAppId1]: connectionInfo(pkh1, NetworkType.GHOSTNET),
+      [dAppId2]: connectionInfo(pkh2, NetworkType.MAINNET),
     });
   });
 
   it("overrides connection with the same dAppId", () => {
-    store.dispatch(beaconActions.addConnection({ dAppId: dAppId1, accountPkh: pkh1 }));
+    addConnection(dAppId1, pkh1, NetworkType.GHOSTNET);
 
-    const { result: addConnection } = renderHook(() => useAddConnection(), {
+    const {
+      result: { current: addConnectionHook },
+    } = renderHook(() => useAddConnection(), {
       wrapper: ReduxStore,
     });
-    addConnection.current(dAppId1, pkh2);
+    addConnectionHook(dAppId1, pkh2, NetworkType.MAINNET);
 
     expect(store.getState().beacon).toEqual({
-      [dAppId1]: pkh2,
+      [dAppId1]: connectionInfo(pkh2, NetworkType.MAINNET),
     });
   });
 });
 
 describe("useRemoveConnection", () => {
   it("removes connection from BeaconSlice", () => {
-    store.dispatch(beaconActions.addConnection({ dAppId: dAppId1, accountPkh: pkh1 }));
-    store.dispatch(beaconActions.addConnection({ dAppId: dAppId2, accountPkh: pkh2 }));
+    addConnection(dAppId1, pkh1, NetworkType.MAINNET);
+    addConnection(dAppId2, pkh2, NetworkType.GHOSTNET);
 
-    const { result: removeConnection } = renderHook(() => useRemoveConnection(), {
+    const {
+      result: { current: removeConnection },
+    } = renderHook(() => useRemoveConnection(), {
       wrapper: ReduxStore,
     });
-    removeConnection.current(dAppId2);
+    removeConnection(dAppId2);
 
     expect(store.getState().beacon).toEqual({
-      [dAppId1]: pkh1,
+      [dAppId1]: connectionInfo(pkh1, NetworkType.MAINNET),
     });
   });
 });

--- a/src/utils/hooks/beaconHooks.ts
+++ b/src/utils/hooks/beaconHooks.ts
@@ -1,15 +1,16 @@
+import { NetworkType } from "@airgap/beacon-wallet";
 import { useDispatch } from "react-redux";
 
 import { RawPkh } from "../../types/Address";
 import { useAppSelector } from "../redux/hooks";
-import { beaconSlice } from "../redux/slices/beaconSlice";
+import { DAppConnectionInfo, beaconSlice } from "../redux/slices/beaconSlice";
 
 /**
- * Returns connected account pkh by given dAppId.
+ * Returns connected account pkh & network by a given dAppId.
  *
  * @param dAppId - generated from dApp public key.
  */
-export const useGetConnectedAccount = (dAppId: string): RawPkh | undefined => {
+export const useGetConnectionInfo = (dAppId: string): DAppConnectionInfo | undefined => {
   const beaconConnections = useAppSelector(s => s.beacon);
   return beaconConnections[dAppId];
 };
@@ -23,12 +24,12 @@ export const useResetConnections = () => {
 };
 
 /**
- * Returns function for adding connection to {@link beaconSlice}.
+ * Returns function for adding connection info to {@link beaconSlice}.
  */
 export const useAddConnection = () => {
   const dispatch = useDispatch();
-  return (dAppId: string, accountPkh: RawPkh) =>
-    dispatch(beaconSlice.actions.addConnection({ dAppId, accountPkh }));
+  return (dAppId: string, accountPkh: RawPkh, networkType: NetworkType) =>
+    dispatch(beaconSlice.actions.addConnection({ dAppId, accountPkh, networkType }));
 };
 
 /**

--- a/src/utils/redux/slices/beaconSlice.ts
+++ b/src/utils/redux/slices/beaconSlice.ts
@@ -1,13 +1,19 @@
+import { NetworkType } from "@airgap/beacon-wallet";
 import { createSlice } from "@reduxjs/toolkit";
 
 import { RawPkh } from "../../../types/Address";
 
-type State = Record<string, RawPkh>;
+export type DAppConnectionInfo = {
+  accountPkh: RawPkh;
+  networkType: NetworkType;
+};
+
+type State = Record<string, DAppConnectionInfo>;
 
 const initialState: State = {};
 
 /**
- * Stores connections between dApps and accounts.
+ * Stores connection info between dApps and accounts.
  *
  * dApps are identified by dAppId (a unique string id generated from dApp public key).
  */
@@ -17,8 +23,11 @@ export const beaconSlice = createSlice({
   reducers: {
     reset: () => initialState,
 
-    addConnection: (state, { payload }: { payload: { dAppId: string; accountPkh: RawPkh } }) => {
-      state[payload.dAppId] = payload.accountPkh;
+    addConnection: (
+      state,
+      { payload }: { payload: { dAppId: string; accountPkh: RawPkh; networkType: NetworkType } }
+    ) => {
+      state[payload.dAppId] = { accountPkh: payload.accountPkh, networkType: payload.networkType };
     },
 
     removeConnection: (state, { payload }: { payload: { dAppId: string } }) => {


### PR DESCRIPTION
## Proposed changes

[Task link](https://app.asana.com/0/1205770721172203/1206080038525619/f)
- Store network together with aconnected account pkh in a beaconSlice.
- Display network on dApp tile.

Key for beaconSlice records is `senderId` (which is an encrypted dApp publicKey). 
Suggested approach works on assumption that dApps have different public keys for different networks.

For storing network we use `{ NetworkType } from '@airgap/beacon-types'` .
Network will be displayed same way as it was displayed in the permission request.
Network might not match user's networks in Umami app: 
- in a case, when network was present and then deleted 
- if a network has custom name different from what we get in the permission request.

Follow-up task: [add support for connecting the same dApp to multiple accounts](https://app.asana.com/0/1205770721172203/1206080038525610/f) 

## Types of changes

- [ ] Bugfix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] UI fix

## Steps to reproduce
Connect a dApp with any available method.
dApp should be connected using the new version, otherwise we do not display Address pill & network (because of absence of data or mismatching type).

## Screenshots

| Before | Now |
| ------ | --- |
|  <img width="614" alt="Screenshot 2023-12-12 at 16 47 52" src="https://github.com/trilitech/umami-v2/assets/150050388/8dc55526-9266-4351-9db2-cc2308128117">   |  ![Screenshot 2023-12-18 at 20 21 39](https://github.com/trilitech/umami-v2/assets/150050388/163b6ecf-c812-430f-9e2d-bceeba01c049)   |

## Checklist

- [x] Tests that prove my fix is effective or that my feature works have been added
- [x] Documentation has been added (if appropriate)
- [x] Screenshots are added (if any UI changes have been made)
- [x] All TODOs have a corresponding task created (and the link is attached to it)
