### PR TITLE
Fix batch icon

### DIFF
--- a/src/views/batch/AccountSmallTile.test.tsx
+++ b/src/views/batch/AccountSmallTile.test.tsx
@@ -12,7 +12,7 @@ describe("<AccountSmallTile />", () => {
   it("shows account label", () => {
     const account = mockImplicitAccount(1);
 
-    render(<AccountSmallTile address={account.address} />);
+    render(<AccountSmallTile account={account} />);
 
     expect(screen.getByTestId("account-small-tile-label")).toHaveTextContent("Test account label");
   });
@@ -20,7 +20,7 @@ describe("<AccountSmallTile />", () => {
   it("shows formatted account address", () => {
     const account = mockImplicitAccount(1);
 
-    render(<AccountSmallTile address={account.address} />);
+    render(<AccountSmallTile account={account} />);
 
     expect(screen.getByTestId("account-small-tile-pkh")).toHaveTextContent(
       formatPkh(account.address.pkh)
@@ -30,7 +30,7 @@ describe("<AccountSmallTile />", () => {
   it("hides empty balance", () => {
     const account = mockImplicitAccount(1);
 
-    render(<AccountSmallTile address={account.address} />);
+    render(<AccountSmallTile account={account} />);
 
     expect(screen.queryByTestId("account-small-tile-balance")).not.toBeInTheDocument();
   });
@@ -41,7 +41,7 @@ describe("<AccountSmallTile />", () => {
       assetsActions.updateTezBalance([{ address: account.address.pkh, balance: 1234567 }])
     );
 
-    render(<AccountSmallTile address={account.address} />);
+    render(<AccountSmallTile account={account} />);
 
     expect(screen.getByTestId("account-small-tile-balance")).toHaveTextContent("1.234567 ꜩ");
   });

--- a/src/views/batch/AccountSmallTile.tsx
+++ b/src/views/batch/AccountSmallTile.tsx
@@ -3,7 +3,7 @@ import { Flex, FlexProps, Heading, Text } from "@chakra-ui/react";
 import { AddressTileIcon } from "../../components/AddressTile/AddressTileIcon";
 import { useAddressKind } from "../../components/AddressTile/useAddressKind";
 import colors from "../../style/colors";
-import { Address } from "../../types/Address";
+import { Account } from "../../types/Account";
 import { formatPkh, prettyTezAmount } from "../../utils/format";
 import { useGetAccountBalance } from "../../utils/hooks/assetsHooks";
 import { useAllAccounts } from "../../utils/hooks/getAccountDataHooks";
@@ -13,10 +13,13 @@ import { useAllAccounts } from "../../utils/hooks/getAccountDataHooks";
  *
  * Tile contains icon, account name, address and balance.
  *
- * @param address - Account address.
+ * @param account - Implicit or Multisig account.
  * @param flexProps - Flex properties to define component style.
  */
-export const AccountSmallTile = ({ address, ...flexProps }: { address: Address } & FlexProps) => {
+export const AccountSmallTile = ({
+  account: { address },
+  ...flexProps
+}: { account: Account } & FlexProps) => {
   const account = useAllAccounts().find(a => a.address.pkh === address.pkh);
   const balance = useGetAccountBalance()(address.pkh);
   const addressKind = useAddressKind(address);

--- a/src/views/batch/BatchView.tsx
+++ b/src/views/batch/BatchView.tsx
@@ -118,7 +118,7 @@ export const BatchView: React.FC<{
         data-testid="header"
       >
         <Flex alignItems="center">
-          <AccountSmallTile paddingLeft={0} address={sender.address} />
+          <AccountSmallTile paddingLeft={0} account={sender} />
         </Flex>
         <RightHeader operations={accountOperations} />
       </Flex>


### PR DESCRIPTION
## Fix batch icon
Fixed the icon in batch page. The batch page only showed the identicon that was used for mnemonic account. we need to show the icons for social/ledger/multisig account accordingly.

The space between the icon and account name should be 12px too

[Task link](https://app.asana.com/0/1205770721172203/1206185853725586/f)

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] UI fix

## Steps to reproduce

## Screenshots

Add the screenshots of how the app used to look like and how it looks now

| Before | Now |
| ------ | --- |
|  <img width="1173" alt="before" src="https://github.com/trilitech/umami-v2/assets/128799322/f7c73fbe-bc10-409d-aa58-58fabfb0846d">| <img width="1184" alt="after" src="https://github.com/trilitech/umami-v2/assets/128799322/6b09ca2b-9bec-4e2e-b97e-a94009dff733">|

Now:
<img width="1172" alt="Screenshot 2023-12-29 at 11 04 33" src="https://github.com/trilitech/umami-v2/assets/128799322/d85986b4-f1cc-4a0a-8000-f0ed84819174">
## Checklist

- [ ] Tests that prove my fix is effective or that my feature works have been added
- [ ] Documentation has been added (if appropriate)
- [ ] Screenshots are added (if any UI changes have been made)
- [ ] All TODOs have a corresponding task created (and the link is attached to it)
