### PR TITLE
Update current network when we edit it

### DIFF
--- a/src/utils/redux/slices/networks.test.ts
+++ b/src/utils/redux/slices/networks.test.ts
@@ -37,6 +37,22 @@ describe("networksSlice", () => {
       store.dispatch(networksActions.upsertNetwork({ ...MAINNET, buyTezUrl: undefined }));
       expect(store.getState().networks.available).toEqual([MAINNET, GHOSTNET]);
     });
+
+    it("updates current network if it's the one we're updating", () => {
+      const newNetwork = { ...MAINNET, name: "Another Network" };
+      store.dispatch(networksActions.upsertNetwork(newNetwork));
+
+      store.dispatch(networksActions.setCurrent(newNetwork));
+      expect(store.getState().networks.current).toEqual(newNetwork);
+
+      const updatedNetwork = { ...newNetwork, rpcUrl: "something else" };
+      store.dispatch(networksActions.upsertNetwork(updatedNetwork));
+
+      expect(store.getState().networks).toEqual({
+        available: [MAINNET, GHOSTNET, updatedNetwork],
+        current: updatedNetwork,
+      });
+    });
   });
 
   describe("removeNetwork", () => {

--- a/src/utils/redux/slices/networks.ts
+++ b/src/utils/redux/slices/networks.ts
@@ -26,6 +26,13 @@ export const networksSlice = createSlice({
         return;
       }
       const index = state.available.findIndex(n => n.name === network.name);
+      // If the current network is the one we're updating, update it too
+      // otherwise, it's going to be changed only
+      // when we switch to another one and back to the current one
+      if (state.current.name === network.name) {
+        state.current = network;
+      }
+
       if (index !== -1) {
         state.available[index] = network;
         return;


### PR DESCRIPTION
## Proposed changes

When we edit the current network (which is not default) we would still have the current one set to a previous version because these objects diverge
Now it's updated too

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] UI fix
