### PR TITLE
Remove subTitle from sign page for certain account types

### DIFF
--- a/src/components/SendFlow/Batch/SignPage.tsx
+++ b/src/components/SendFlow/Batch/SignPage.tsx
@@ -23,7 +23,7 @@ export const SignPage: React.FC<{
         <form>
           <BatchModalBody
             fee={fee}
-            signerAddress={signer.address}
+            signer={signer}
             title={title}
             transactionCount={operations.operations.length}
           />

--- a/src/components/SendFlow/BatchModalBody.tsx
+++ b/src/components/SendFlow/BatchModalBody.tsx
@@ -4,34 +4,33 @@ import React from "react";
 
 import { FormPageHeader } from "./FormPageHeader";
 import { SignPageFee } from "./SignPageFee";
+import { subTitle } from "./SignPageHeader";
 import colors from "../../style/colors";
-import { ImplicitAddress } from "../../types/Address";
+import { ImplicitAccount } from "../../types/Account";
 import { AddressTile } from "../AddressTile/AddressTile";
 
 export const BatchModalBody: React.FC<{
   fee: BigNumber;
   title: string;
-  signerAddress: ImplicitAddress;
+  signer: ImplicitAccount;
   transactionCount: number;
-}> = ({ title, fee, transactionCount, signerAddress }) => {
-  return (
-    <>
-      <FormPageHeader subTitle="Enter your password to confirm this transaction." title={title} />
-      <ModalBody>
-        <FormLabel>From</FormLabel>
-        <AddressTile address={signerAddress} />
-        <Flex alignItems="center" justifyContent="space-between" marginY="12px" paddingX="4px">
-          <Flex>
-            <Text marginRight={1} color={colors.gray[450]} size="sm">
-              Transactions:
-            </Text>
-            <Text color={colors.gray[400]} data-testid="transaction-length" size="sm">
-              {transactionCount}
-            </Text>
-          </Flex>
-          <SignPageFee fee={fee} />
+}> = ({ title, fee, transactionCount, signer }) => (
+  <>
+    <FormPageHeader subTitle={subTitle(signer)} title={title} />
+    <ModalBody>
+      <FormLabel>From</FormLabel>
+      <AddressTile address={signer.address} />
+      <Flex alignItems="center" justifyContent="space-between" marginY="12px" paddingX="4px">
+        <Flex>
+          <Text marginRight={1} color={colors.gray[450]} size="sm">
+            Transactions:
+          </Text>
+          <Text color={colors.gray[400]} data-testid="transaction-length" size="sm">
+            {transactionCount}
+          </Text>
         </Flex>
-      </ModalBody>
-    </>
-  );
-};
+        <SignPageFee fee={fee} />
+      </Flex>
+    </ModalBody>
+  </>
+);

--- a/src/components/SendFlow/Beacon/ContractCallSignPage.tsx
+++ b/src/components/SendFlow/Beacon/ContractCallSignPage.tsx
@@ -45,7 +45,7 @@ export const ContractCallSignPage: React.FC<BeaconSignPageProps> = ({
     <FormProvider {...form}>
       <ModalContent>
         <form>
-          <SignPageHeader mode="single" operationsType={operation.type} />
+          <SignPageHeader mode="single" operationsType={operation.type} signer={operation.signer} />
           <ModalBody>
             <TezTile mutezAmount={mutezAmount} />
 

--- a/src/components/SendFlow/Beacon/DelegationSignPage.tsx
+++ b/src/components/SendFlow/Beacon/DelegationSignPage.tsx
@@ -25,7 +25,7 @@ export const DelegationSignPage: React.FC<BeaconSignPageProps> = ({
     <FormProvider {...form}>
       <ModalContent>
         <form>
-          <SignPageHeader mode="single" operationsType={operation.type} />
+          <SignPageHeader mode="single" operationsType={operation.type} signer={operation.signer} />
           <ModalBody>
             <FormLabel>From</FormLabel>
             <AddressTile address={operation.signer.address} />

--- a/src/components/SendFlow/Beacon/TezSignPage.tsx
+++ b/src/components/SendFlow/Beacon/TezSignPage.tsx
@@ -23,7 +23,7 @@ export const TezSignPage: React.FC<BeaconSignPageProps> = ({ operation, onBeacon
     <FormProvider {...form}>
       <ModalContent>
         <form>
-          <SignPageHeader mode="single" operationsType={operation.type} />
+          <SignPageHeader mode="single" operationsType={operation.type} signer={operation.signer} />
           <ModalBody>
             <TezTile mutezAmount={mutezAmount} />
 

--- a/src/components/SendFlow/Beacon/UndelegationSignPage.tsx
+++ b/src/components/SendFlow/Beacon/UndelegationSignPage.tsx
@@ -22,7 +22,7 @@ export const UndelegationSignPage: React.FC<BeaconSignPageProps> = ({
     <FormProvider {...form}>
       <ModalContent>
         <form>
-          <SignPageHeader mode="single" operationsType={operation.type} />
+          <SignPageHeader mode="single" operationsType={operation.type} signer={operation.signer} />
           <ModalBody>
             <FormLabel>From</FormLabel>
             <AddressTile address={operation.signer.address} />

--- a/src/components/SendFlow/Delegation/SignPage.tsx
+++ b/src/components/SendFlow/Delegation/SignPage.tsx
@@ -18,7 +18,7 @@ export const SignPage: React.FC<SignPageProps> = props => {
     <FormProvider {...form}>
       <ModalContent>
         <form>
-          <SignPageHeader {...props} operationsType={operations.type} />
+          <SignPageHeader {...props} operationsType={operations.type} signer={operations.signer} />
           <ModalBody>
             <FormLabel>From</FormLabel>
             <AddressTile address={signer.address} />

--- a/src/components/SendFlow/Multisig/SignPage.tsx
+++ b/src/components/SendFlow/Multisig/SignPage.tsx
@@ -42,7 +42,7 @@ export const SignPage: React.FC<{
       <form>
         <BatchModalBody
           fee={fee}
-          signerAddress={signer.address}
+          signer={signer}
           title={title}
           transactionCount={transactionCount}
         />

--- a/src/components/SendFlow/MultisigAccount/SignPage.tsx
+++ b/src/components/SendFlow/MultisigAccount/SignPage.tsx
@@ -76,7 +76,7 @@ export const SignPage: React.FC<SignPageProps<FormValues>> = props => {
     <FormProvider {...form}>
       <ModalContent>
         <form>
-          <SignPageHeader {...props} operationsType={operations.type} />
+          <SignPageHeader {...props} operationsType={operations.type} signer={operations.signer} />
           <ModalBody>
             <FormLabel>Contract Name</FormLabel>
             <Text

--- a/src/components/SendFlow/NFT/SignPage.tsx
+++ b/src/components/SendFlow/NFT/SignPage.tsx
@@ -37,7 +37,7 @@ export const SignPage: React.FC<SignPageProps<{ nft: NFTBalance }>> = props => {
     <FormProvider {...form}>
       <ModalContent>
         <form>
-          <SignPageHeader {...props} operationsType={operations.type} />
+          <SignPageHeader {...props} operationsType={operations.type} signer={operations.signer} />
           <ModalBody>
             <Flex marginBottom="12px">
               <SendNFTRecapTile nft={nft} />

--- a/src/components/SendFlow/SignPageHeader.test.tsx
+++ b/src/components/SendFlow/SignPageHeader.test.tsx
@@ -1,6 +1,12 @@
 import { Modal } from "@chakra-ui/react";
 
-import { SignPageHeader, headerText } from "./SignPageHeader";
+import { SignPageHeader, headerText, subTitle } from "./SignPageHeader";
+import {
+  mockLedgerAccount,
+  mockMnemonicAccount,
+  mockSecretKeyAccount,
+  mockSocialAccount,
+} from "../../mocks/factories";
 import { render, screen } from "../../mocks/testUtils";
 
 const fixture = (props: Parameters<typeof SignPageHeader>[0]) => {
@@ -13,7 +19,9 @@ const fixture = (props: Parameters<typeof SignPageHeader>[0]) => {
 describe("<SignPageHeader />", () => {
   describe("goBack", () => {
     it("is hidden if goBack is not provided", () => {
-      render(fixture({ mode: "single", operationsType: "implicit" }));
+      render(
+        fixture({ mode: "single", operationsType: "implicit", signer: mockMnemonicAccount(0) })
+      );
       expect(screen.queryByTestId("go-back-button")).not.toBeInTheDocument();
     });
   });
@@ -39,4 +47,13 @@ describe("headerText", () => {
       expect(headerText("proposal", "batch")).toBe("Propose Batch");
     });
   });
+});
+
+test.each([
+  { account: mockLedgerAccount(0), result: undefined },
+  { account: mockSocialAccount(0), result: undefined },
+  { account: mockMnemonicAccount(0), result: "Enter your password to confirm this transaction." },
+  { account: mockSecretKeyAccount(0), result: "Enter your password to confirm this transaction." },
+])("subTitle for $account.type", ({ account, result }) => {
+  expect(subTitle(account)).toEqual(result);
 });

--- a/src/components/SendFlow/SignPageHeader.tsx
+++ b/src/components/SendFlow/SignPageHeader.tsx
@@ -3,6 +3,7 @@ import { Heading, ModalCloseButton, Text } from "@chakra-ui/react";
 import { HeaderWrapper } from "./FormPageHeader";
 import { SignPageMode } from "./utils";
 import colors from "../../style/colors";
+import { ImplicitAccount } from "../../types/Account";
 import { AccountOperations } from "../../types/AccountOperations";
 import { ModalBackButton } from "../ModalBackButton";
 
@@ -26,17 +27,29 @@ export const headerText = (
   }
 };
 
+export const subTitle = (signer: ImplicitAccount): string | undefined => {
+  switch (signer.type) {
+    case "ledger":
+    case "social":
+      return;
+    case "mnemonic":
+    case "secret_key":
+      return "Enter your password to confirm this transaction.";
+  }
+};
+
 export const SignPageHeader: React.FC<{
   goBack?: () => void;
   mode: SignPageMode;
   operationsType: AccountOperations["type"];
-}> = ({ goBack, mode, operationsType }) => {
+  signer: ImplicitAccount;
+}> = ({ goBack, mode, operationsType, signer }) => {
   return (
     <HeaderWrapper>
       {goBack && <ModalBackButton onClick={goBack} />}
       <Heading size="2xl">{headerText(operationsType, mode)}</Heading>
       <Text color={colors.gray[400]} textAlign="center" size="sm">
-        Enter your password to confirm this transaction.
+        {subTitle(signer)}
       </Text>
       <ModalCloseButton />
     </HeaderWrapper>

--- a/src/components/SendFlow/Tez/SignPage.tsx
+++ b/src/components/SendFlow/Tez/SignPage.tsx
@@ -21,7 +21,7 @@ export const SignPage: React.FC<SignPageProps> = props => {
     <FormProvider {...form}>
       <ModalContent>
         <form>
-          <SignPageHeader {...props} operationsType={operations.type} />
+          <SignPageHeader {...props} operationsType={operations.type} signer={operations.signer} />
           <ModalBody>
             <TezTile mutezAmount={mutezAmount} />
 

--- a/src/components/SendFlow/Token/SignPage.tsx
+++ b/src/components/SendFlow/Token/SignPage.tsx
@@ -26,7 +26,7 @@ export const SignPage: React.FC<SignPageProps<{ token: FATokenBalance }>> = prop
     <FormProvider {...form}>
       <ModalContent>
         <form>
-          <SignPageHeader {...props} operationsType={operations.type} />
+          <SignPageHeader {...props} operationsType={operations.type} signer={operations.signer} />
           <ModalBody>
             <TokenTile amount={amount} token={token} />
 

--- a/src/components/SendFlow/Undelegation/SignPage.tsx
+++ b/src/components/SendFlow/Undelegation/SignPage.tsx
@@ -16,7 +16,7 @@ export const SignPage: React.FC<SignPageProps> = props => {
     <FormProvider {...form}>
       <ModalContent>
         <form>
-          <SignPageHeader {...props} operationsType={operations.type} />
+          <SignPageHeader {...props} operationsType={operations.type} signer={operations.signer} />
           <ModalBody>
             <FormLabel>From</FormLabel>
             <AddressTile address={signer.address} />


### PR DESCRIPTION
## Proposed changes

[Task link](https://app.asana.com/0/1205770721172203/1206234061049108/f)

Ledger & Social accounts do not have a password, hence we don't need that subtitle

## Types of changes

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] UI fix

## Steps to reproduce
- estimate any transaction

## Screenshots

Add the screenshots of how the app used to look like and how it looks now

| Before | Now |
| ------ | --- |
|   <img width="547" alt="Screenshot 2024-01-10 at 14 33 58" src="https://github.com/trilitech/umami-v2/assets/129749432/670a3f61-bdc5-4f75-b69c-7d0379eae17b"> |   <img width="520" alt="Screenshot 2024-01-10 at 13 15 08" src="https://github.com/trilitech/umami-v2/assets/129749432/8d5c8689-7079-47b8-bc3e-031d84838e48">  |

## Checklist

- [x] Tests that prove my fix is effective or that my feature works have been added
- [ ] Documentation has been added (if appropriate)
- [x] Screenshots are added (if any UI changes have been made)
- [ ] All TODOs have a corresponding task created (and the link is attached to it)
