### PR TITLE
Add "view all" link to tokens tab

### DIFF
--- a/src/components/AccountDrawer/AssetsPanel/AssetsPanel.tsx
+++ b/src/components/AccountDrawer/AssetsPanel/AssetsPanel.tsx
@@ -98,7 +98,7 @@ export const AssetsPanel: React.FC<{
         </TabPanel>
 
         <TabPanel paddingTop="24px" data-testid="account-card-tokens-tab">
-          <TokenList tokens={tokens} />
+          <TokenList owner={account.address.pkh} tokens={tokens} />
         </TabPanel>
       </TabPanels>
     </Tabs>

--- a/src/components/AccountDrawer/AssetsPanel/TokenList.test.tsx
+++ b/src/components/AccountDrawer/AssetsPanel/TokenList.test.tsx
@@ -1,0 +1,75 @@
+import { TokenList } from "./TokenList";
+import { hedgehoge } from "../../../mocks/fa12Tokens";
+import { mockFA12Token, mockFA2Token, mockMnemonicAccount } from "../../../mocks/factories";
+import { render, screen } from "../../../mocks/testUtils";
+import { FA2TokenBalance, fromRaw } from "../../../types/TokenBalance";
+
+describe("<TokenList />", () => {
+  const ACCOUNT = mockMnemonicAccount(0);
+
+  describe("with no tokens", () => {
+    it('displays a "No tokens found" message', () => {
+      render(<TokenList owner={ACCOUNT.address.pkh} tokens={[]} />);
+
+      expect(screen.getByText("No tokens found")).toBeInTheDocument();
+    });
+
+    it("does not show tokens", () => {
+      render(<TokenList owner={ACCOUNT.address.pkh} tokens={[]} />);
+
+      expect(screen.queryByTestId("token-tile")).not.toBeInTheDocument();
+    });
+
+    it("doesn't show a 'View All' link", () => {
+      render(<TokenList owner={ACCOUNT.address.pkh} tokens={[]} />);
+
+      expect(screen.queryByRole("link", { name: "View All" })).not.toBeInTheDocument();
+    });
+  });
+
+  describe("with tokens", () => {
+    it("renders a list of tokens in the same order as given", () => {
+      const tokens = [
+        mockFA2Token(0, ACCOUNT, 123456, 5, "T1", "Token 1"),
+        mockFA12Token(1, ACCOUNT, 123456),
+        fromRaw(hedgehoge(ACCOUNT.address))! as FA2TokenBalance,
+      ];
+
+      render(<TokenList owner={ACCOUNT.address.pkh} tokens={tokens} />);
+
+      const tokenTiles = screen.getAllByTestId("token-tile");
+      expect(tokenTiles).toHaveLength(3);
+
+      expect(tokenTiles[0]).toHaveTextContent("Token 1");
+      expect(tokenTiles[0]).toHaveTextContent("1.23456");
+
+      expect(tokenTiles[1]).toHaveTextContent("FA1.2");
+      expect(tokenTiles[1]).toHaveTextContent("123,456");
+
+      expect(tokenTiles[2]).toHaveTextContent("Hedgehoge");
+      expect(tokenTiles[2]).toHaveTextContent("10,000.000000");
+    });
+
+    it("renders 'verified' icons for verified tokens", () => {
+      const token = {
+        ...mockFA2Token(1, ACCOUNT),
+        contract: "KT1XnTn74bUtxHfDtBmm2bGZAQfhPbvKWR8o",
+      };
+
+      render(<TokenList owner={ACCOUNT.address.pkh} tokens={[token]} />);
+
+      expect(screen.getByTestId("verified-icon")).toBeInTheDocument();
+    });
+
+    it('renders a "View All" link', () => {
+      const tokens = [mockFA2Token(0, ACCOUNT), mockFA12Token(1, ACCOUNT)];
+
+      render(<TokenList owner={ACCOUNT.address.pkh} tokens={tokens} />);
+
+      expect(screen.getByRole("link", { name: "View All" })).toHaveAttribute(
+        "href",
+        `#/tokens?accounts=${ACCOUNT.address.pkh}`
+      );
+    });
+  });
+});

--- a/src/components/AccountDrawer/AssetsPanel/TokenList.tsx
+++ b/src/components/AccountDrawer/AssetsPanel/TokenList.tsx
@@ -1,7 +1,9 @@
 import { Box, Flex, Heading } from "@chakra-ui/react";
 
+import { ViewAllLink } from "./ViewAllLink";
 import { TokenIcon } from "../../../assets/icons";
 import colors from "../../../style/colors";
+import { RawPkh } from "../../../types/Address";
 import { tokenPrettyAmount } from "../../../types/Token";
 import { FA12TokenBalance, FA2TokenBalance } from "../../../types/TokenBalance";
 import { TokenNameWithIcon } from "../../../views/tokens/TokenNameWithIcon";
@@ -35,15 +37,22 @@ const TokenTile = ({ token }: { token: FA12TokenBalance | FA2TokenBalance }) => 
   );
 };
 
-export const TokenList = ({ tokens }: { tokens: Array<FA12TokenBalance | FA2TokenBalance> }) => {
+export const TokenList = ({
+  owner,
+  tokens,
+}: {
+  owner: RawPkh;
+  tokens: Array<FA12TokenBalance | FA2TokenBalance>;
+}) => {
   if (tokens.length === 0) {
-    return <NoItems small title="No Tokens found" />;
+    return <NoItems small title="No tokens found" />;
   }
   return (
     <Box>
       {tokens.map(t => {
         return <TokenTile key={t.contract + (t.type === "fa2" ? t.tokenId : "")} token={t} />;
       })}
+      <ViewAllLink to={`/tokens?accounts=${owner}`} />
     </Box>
   );
 };


### PR DESCRIPTION
## Proposed changes

[Task link](https://app.asana.com/0/1205770721172203/1206126507486424/f)

## Types of changes

- [ ] Bugfix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] UI fix

## Steps to reproduce

Open "Tokens" assets tab for an account with tokens.
The "view all" link should open "Tokens" page filtered by the account.

## Screenshots

| Before | Now |
| ------ | --- |
|  <img width="723" alt="Screenshot 2024-01-10 at 18 34 03" src="https://github.com/trilitech/umami-v2/assets/150050388/7936c530-b702-4694-af96-9b6a2bace53c">  |  <img width="708" alt="Screenshot 2024-01-10 at 18 29 12" src="https://github.com/trilitech/umami-v2/assets/150050388/f832e1e5-8b62-49c6-aab2-48924d25b47a">  |

## Checklist
- [x] Tests that prove my fix is effective or that my feature works have been added
- [x] Documentation has been added (if appropriate)
- [x] Screenshots are added (if any UI changes have been made)
- [x] All TODOs have a corresponding task created (and the link is attached to it)
