### PR TITLE
Do not update accounts slice on adding secretKeyAccount with existing pkh

### DIFF
--- a/src/utils/redux/thunks/secretKeyAccount.test.ts
+++ b/src/utils/redux/thunks/secretKeyAccount.test.ts
@@ -1,56 +1,96 @@
 import { remove, restore } from "./secretKeyAccount";
 import { mockSecretKeyAccount } from "../../../mocks/factories";
+import { mnemonic1 } from "../../../mocks/mockMnemonic";
+import { ImplicitAccount } from "../../../types/Account";
+import { AVAILABLE_DERIVATION_PATHS, makeDerivationPath } from "../../account/derivationPathUtils";
 import { decrypt } from "../../crypto/AES";
 import { EncryptedData } from "../../crypto/types";
+import { derivePublicKeyPair, deriveSecretKey } from "../../mnemonic";
 import { accountsSlice } from "../slices/accountsSlice";
 import { store } from "../store";
 
 jest.unmock("../../tezos");
 
 describe("secretKeyAccount", () => {
-  test("restore", async () => {
-    const secretKey = "edsk3QoqBuvdamxouPhin7swCvkQNgq4jP5KZPbwWNnwdZpSpJiEbq";
-    const label = "Test Account";
-    const password = "12345678";
+  describe("restore", () => {
+    it("adds account and secret key to accounts slice", async () => {
+      const secretKey = "edsk3QoqBuvdamxouPhin7swCvkQNgq4jP5KZPbwWNnwdZpSpJiEbq";
+      const label = "Test Account";
+      const password = "12345678";
 
-    await store.dispatch(
-      restore({
-        secretKey,
-        label,
-        password,
-      })
-    );
+      await store.dispatch(
+        restore({
+          secretKey,
+          label,
+          password,
+        })
+      );
 
-    const pkh = "tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb";
+      const pkh = "tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb";
 
-    expect(store.getState().accounts.items).toEqual([
-      {
-        type: "secret_key",
-        address: { pkh, type: "implicit" },
-        label: "Test Account",
-        pk: "edpkvGfYw3LyB1UcCahKQk4rF2tvbMUk8GFiTuMjL75uGXrpvKXhjn",
-      },
-    ]);
+      expect(store.getState().accounts.items).toEqual([
+        {
+          type: "secret_key",
+          address: { pkh, type: "implicit" },
+          label: "Test Account",
+          pk: "edpkvGfYw3LyB1UcCahKQk4rF2tvbMUk8GFiTuMjL75uGXrpvKXhjn",
+        },
+      ]);
 
-    const encrypted = store.getState().accounts.secretKeys[pkh] as EncryptedData;
-    const decrypted = await decrypt(encrypted, password);
+      const encrypted = store.getState().accounts.secretKeys[pkh] as EncryptedData;
+      const decrypted = await decrypt(encrypted, password);
+      expect(decrypted).toEqual(secretKey);
+    });
 
-    expect(decrypted).toEqual(secretKey);
+    it("doesn't update accounts slice on adding account with existing pkh", async () => {
+      const derivationPath = makeDerivationPath(AVAILABLE_DERIVATION_PATHS[2].value, 0);
+      const pubKeyPair = await derivePublicKeyPair(mnemonic1, derivationPath);
+      const existingMnemonic = {
+        curve: "ed25519",
+        derivationPath: derivationPath,
+        type: "mnemonic",
+        pk: pubKeyPair.pk,
+        address: { type: "implicit", pkh: pubKeyPair.pkh },
+        seedFingerPrint: "mockFingerPrint",
+        label: "Mnemonic Acc",
+        derivationPathPattern: AVAILABLE_DERIVATION_PATHS[2].value,
+      } as ImplicitAccount;
+      store.dispatch(accountsSlice.actions.addAccount(existingMnemonic));
+
+      const secretKey = await deriveSecretKey(mnemonic1, derivationPath, "ed25519");
+      const label = "Secret Key Acc";
+      const password = "12345678";
+
+      await expect(() =>
+        store.dispatch(
+          restore({
+            secretKey,
+            label,
+            password,
+          })
+        )
+      ).rejects.toThrow(`Can't add account ${pubKeyPair.pkh} in store since it already exists.`);
+
+      expect(store.getState().accounts.items).toEqual([existingMnemonic]);
+      expect(store.getState().accounts.secretKeys).toEqual({});
+    });
   });
 
-  test("remove", async () => {
-    const account = mockSecretKeyAccount(0);
-    store.dispatch(accountsSlice.actions.addAccount(account));
-    store.dispatch(
-      accountsSlice.actions.addSecretKey({
-        pkh: account.address.pkh,
-        encryptedSecretKey: "encryptedSecretKey" as any,
-      })
-    );
+  describe("remove", () => {
+    test("deletes relevant data from accounts slice", async () => {
+      const account = mockSecretKeyAccount(0);
+      store.dispatch(accountsSlice.actions.addAccount(account));
+      store.dispatch(
+        accountsSlice.actions.addSecretKey({
+          pkh: account.address.pkh,
+          encryptedSecretKey: "encryptedSecretKey" as any,
+        })
+      );
 
-    await store.dispatch(remove(account));
+      await store.dispatch(remove(account));
 
-    expect(store.getState().accounts.items).toEqual([]);
-    expect(store.getState().accounts.secretKeys).toEqual({});
+      expect(store.getState().accounts.items).toEqual([]);
+      expect(store.getState().accounts.secretKeys).toEqual({});
+    });
   });
 });

--- a/src/utils/redux/thunks/secretKeyAccount.ts
+++ b/src/utils/redux/thunks/secretKeyAccount.ts
@@ -37,8 +37,8 @@ export const restore =
       label,
       password,
     });
-    dispatch(accountsSlice.actions.addSecretKey({ pkh: account.address.pkh, encryptedSecretKey }));
     dispatch(accountsSlice.actions.addAccount(account));
+    dispatch(accountsSlice.actions.addSecretKey({ pkh: account.address.pkh, encryptedSecretKey }));
   };
 
 export const remove = (account: SecretKeyAccount) => async (dispatch: AppDispatch) => {


### PR DESCRIPTION
## Proposed changes

The order of accountSlice actions had to be changes. 
We check for pkh uniqueness in `addAccount` and throw if pkh is already used.

Should be updated later as a part of [removing concat unique from slice actions](https://app.asana.com/0/1205770721172203/1206202496403360/f)

[Task link](https://app.asana.com/0/1205770721172203/1205832227004002/f)

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] UI fix

## Steps to reproduce
Add a secret key account using secret key for one of the existing accounts.

## Checklist

- [x] Tests that prove my fix is effective or that my feature works have been added
- [ ] Documentation has been added (if appropriate)
- [ ] Screenshots are added (if any UI changes have been made)
- [ ] All TODOs have a corresponding task created (and the link is attached to it)
