### PR TITLE
Fix hover bg color for circle buttons in account drawer

### DIFF
--- a/src/components/AccountDrawer/AccountDrawerDisplay.tsx
+++ b/src/components/AccountDrawer/AccountDrawerDisplay.tsx
@@ -39,6 +39,7 @@ const RoundButton: React.FC<{
 }> = ({ icon, label, onClick = () => {} }) => {
   return (
     <Box
+      className="account-drawer-cta-button"
       color={colors.gray[300]}
       textAlign="center"
       _hover={{ color: colors.green }}
@@ -47,6 +48,7 @@ const RoundButton: React.FC<{
       onClick={onClick}
     >
       <IconButton
+        className="account-drawer-cta-button-icon"
         marginBottom="8px"
         aria-label="button"
         icon={icon}

--- a/src/index.css
+++ b/src/index.css
@@ -33,3 +33,7 @@ code {
   border-top-right-radius: 30px;
   border-bottom-right-radius: 30px;
 }
+
+.account-drawer-cta-button:hover .account-drawer-cta-button-icon {
+  background-color: #414141; /* gray[500] */
+}


### PR DESCRIPTION
## Proposed changes

previously the bg color would change only when you hover over the circle button, but it should change also if you hover the text

## Types of changes

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] UI fix

## Steps to reproduce

## Screenshots

Add the screenshots of how the app used to look like and how it looks now

| Before | Now |
| ------ | --- |
|    https://github.com/trilitech/umami-v2/assets/129749432/6121f83d-c8f9-4368-9047-a1cf9cf1fc82  |   https://github.com/trilitech/umami-v2/assets/129749432/b4516942-2eb0-4cbd-9c61-e33e9ccb1ed1  |

## Checklist

- [ ] Tests that prove my fix is effective or that my feature works have been added
- [ ] Documentation has been added (if appropriate)
- [x] Screenshots are added (if any UI changes have been made)
- [ ] All TODOs have a corresponding task created (and the link is attached to it)
