### PR TITLE
Upload cucumber HTML report to github for e2e tests

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -45,3 +45,10 @@ jobs:
           access-token: ${{ secrets.GITHUB_TOKEN }}
           path: "test-results/cucumber-report.json"
           show-global-summary-report: true
+
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: cucumber-report
+          path: test-results/cucumber-report.html
+          retention-days: 10


### PR DESCRIPTION
this report will be listed under the summary section of the e2e job. It contains all the screenshots already
<img width="1700" alt="Screenshot 2024-01-18 at 11 16 25" src="https://github.com/trilitech/umami-v2/assets/129749432/0121c731-f52a-43dd-a770-55fad596648d">

