### PR TITLE
Improve refetch cucumber step stability

### DIFF
--- a/src/e2e/steps/utils.ts
+++ b/src/e2e/steps/utils.ts
@@ -5,6 +5,7 @@ import { BASE_URL } from "./onboarding";
 import { CustomWorld } from "./world";
 import { State } from "../../utils/redux/slices/accountsSlice";
 import { makeSecretKeyAccount } from "../../utils/redux/thunks/secretKeyAccount";
+import { refetch } from "../utils";
 
 Given(/I have accounts?/, async function (this: CustomWorld, table: DataTable) {
   const accounts: State = {
@@ -66,6 +67,5 @@ When("I wait for TZKT to process the updates", async function (this: CustomWorld
 });
 
 When("I refetch the data", async function (this: CustomWorld) {
-  await this.page.getByTestId("refetch-button").click();
-  expect(this.page.getByText("Updated just now")).toBeVisible();
+  await refetch(this.page);
 });


### PR DESCRIPTION
## Proposed changes

Sometimes, due to animations and overall load on CI we might miss the "updated now" text, but localstorage shows real numbers and it's much less flaky to test the lastUpdatedAt instead

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] UI fix
