### PR TITLE
Add more informative tzkt network error toasts

### DIFF
--- a/src/utils/tezos/fetch.ts
+++ b/src/utils/tezos/fetch.ts
@@ -33,7 +33,15 @@ const tzktRateLimiter = new Semaphore(10);
 export const withRateLimit = <T>(fn: () => Promise<T>) =>
   tzktRateLimiter
     .acquire()
-    .then(() => promiseRetry(fn, { retries: 3, minTimeout: 100 }))
+    .then(() => promiseRetry(retry => fn().catch(retry), { retries: 3, minTimeout: 100 }))
+    .catch((error: any) => {
+      // tzkt throws HttpError, but doesn't export it
+      // default behaviour just shows Error: 504 which isn't very helpful for the user
+      if ("status" in error && "data" in error) {
+        throw new Error(`Fetching data from tzkt failed with: ${error.status}, ${error.data}`);
+      }
+      throw error;
+    })
     .finally(() => tzktRateLimiter.release());
 
 export type DelegationOperation = tzktApi.DelegationOperation & {

--- a/src/utils/useAssetsPolling.ts
+++ b/src/utils/useAssetsPolling.ts
@@ -1,5 +1,5 @@
 import { useToast } from "@chakra-ui/react";
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { useQuery, useQueryClient } from "react-query";
 
 import { getErrorContext } from "./getErrorContext";
@@ -110,9 +110,8 @@ export const useAssetsPolling = () => {
 
   const implicitAddresses = implicitAccounts.map(account => account.address.pkh);
 
-  const accountAssetsQuery = useQuery("allAssets", {
-    queryFn: () => updateAccountAssets(dispatch, network, implicitAddresses),
-    onError: (error: any) => {
+  const onError = useCallback(
+    (error: any) => {
       dispatch(errorsSlice.actions.add(getErrorContext(error)));
       toast({
         description: `Data fetching error: ${error.message}`,
@@ -120,6 +119,12 @@ export const useAssetsPolling = () => {
         isClosable: true,
       });
     },
+    [dispatch, toast]
+  );
+
+  const accountAssetsQuery = useQuery("allAssets", {
+    queryFn: () => updateAccountAssets(dispatch, network, implicitAddresses),
+    onError,
     retry: false, // retries are handled by the underlying functions
     refetchInterval: BLOCK_TIME,
     refetchIntervalInBackground: true,
@@ -128,6 +133,7 @@ export const useAssetsPolling = () => {
 
   const conversionrateQuery = useQuery("conversionRate", {
     queryFn: () => updateConversionRate(dispatch),
+    onError,
     refetchInterval: CONVERSION_RATE_REFRESH_RATE,
     refetchIntervalInBackground: true,
     refetchOnWindowFocus: false,
@@ -135,6 +141,7 @@ export const useAssetsPolling = () => {
 
   const blockNumberQuery = useQuery("blockNumber", {
     queryFn: () => updateBlockLevel(dispatch, network),
+    onError,
     retry: false, // retries are handled by the underlying functions
     refetchInterval: BLOCK_TIME,
     refetchIntervalInBackground: true,
@@ -143,6 +150,7 @@ export const useAssetsPolling = () => {
 
   const bakersQuery = useQuery("bakers", {
     queryFn: () => updateBakers(dispatch, network),
+    onError,
     retry: false, // retries are handled by the underlying functions
     refetchInterval: BAKERS_REFRESH_RATE,
     refetchIntervalInBackground: true,


### PR DESCRIPTION
## Proposed changes

Tzkt throws HttpError with 2 fields: status, data. We were getting an instance of an Error class with the message being "Error: <status>" which would resolve into `Error 504`.
I put the data into the error message too so that at least it's clear where it's coming from and what happened instead of just 504.

Also, there was a bug in the promise retry lib usage, it wasn't retrying the operation


## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] UI fix
