### PR TITLE
Fix big app size

### DIFF
--- a/package.json
+++ b/package.json
@@ -252,6 +252,9 @@
   "build": {
     "appId": "com.trilitech.umami",
     "productName": "Umami",
+    "files": [
+      "build/**"
+    ],
     "directories": {
       "buildResources": "public"
     },


### PR DESCRIPTION
[Task](https://app.asana.com/0/1205770721172203/1206403075254833/f)

By default this parameter is essentially `**/*` which would put *everything* from the root (including docs, coverage reports, etc.)
we only need some of node_modules and the build. necessary packages are included automatically

the unpacked app size changed from 800mb -> 400mb