### PR TITLE
Fix Beacon errors display

### DIFF
--- a/src/components/SendFlow/Beacon/useSignWithBeacon.tsx
+++ b/src/components/SendFlow/Beacon/useSignWithBeacon.tsx
@@ -28,23 +28,20 @@ export const useSignWithBeacon = (
   });
 
   useEffect(() => {
-    const estimateFee = () => {
-      handleAsyncAction(
-        async () => {
-          const fee = await estimate(operation, network);
-          setFee(fee);
-        },
-        err => {
-          onClose();
-          return {
-            title: "Error",
-            description: `Error while processing beacon request: ${err.message}`,
-            status: "error",
-          };
-        }
-      );
-    };
-    estimateFee();
+    handleAsyncAction(
+      async () => {
+        const fee = await estimate(operation, network);
+        setFee(fee);
+      },
+      err => {
+        onClose();
+        return {
+          title: "Error",
+          description: `Error while processing beacon request: ${err.message}`,
+          status: "error",
+        };
+      }
+    );
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [network, operation]);
 

--- a/src/utils/beacon/BeaconNotification/BeaconRequestNotification.tsx
+++ b/src/utils/beacon/BeaconNotification/BeaconRequestNotification.tsx
@@ -6,7 +6,7 @@ import {
   PartialTezosOperation,
   TezosOperationType,
 } from "@airgap/beacon-wallet";
-import { Box, useToast } from "@chakra-ui/react";
+import { ModalCloseButton, ModalContent, useToast } from "@chakra-ui/react";
 import React from "react";
 
 import { PermissionRequestPanel } from "./panels/PermissionRequestPanel";
@@ -36,7 +36,13 @@ export const BeaconNotification: React.FC<{
     case BeaconMessageType.OperationRequest: {
       const signer = getAccount(message.sourceAddress);
       if (!signer) {
-        return <Box>Account not in this wallet {message.sourceAddress}</Box>;
+        return (
+          <ModalContent>
+            <ModalCloseButton />A request came through Beacon
+            <br />
+            but the requested account is not in this wallet {message.sourceAddress}
+          </ModalContent>
+        );
       }
 
       try {
@@ -64,7 +70,12 @@ export const BeaconNotification: React.FC<{
 
         return <BeaconSignPage onBeaconSuccess={handleSuccess} operation={beaconOperation} />;
       } catch (error: any) {
-        return <Box>Error handling operation request: {error.message}</Box>;
+        return (
+          <ModalContent>
+            <ModalCloseButton />
+            Error handling Beacon operation request: {error.message}
+          </ModalContent>
+        );
       }
     }
 


### PR DESCRIPTION
## Proposed changes

Without this wrapper it'd just block the whole window with a black overlay and the only way around would be to restart the app.
It's not ideal, but that's how it works at the moment because of how we react on beacon messages. we always open a modal and only then decide what should be its content. Will be fixed later on.

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] UI fix

## Steps to reproduce
throw any error on beacon operation request in the code

## Screenshots

<img width="694" alt="Screenshot 2024-02-04 at 13 49 12" src="https://github.com/trilitech/umami-v2/assets/129749432/d8af00a6-5679-4366-88d7-71c343b1d904">
<img width="534" alt="Screenshot 2024-02-04 at 13 51 49" src="https://github.com/trilitech/umami-v2/assets/129749432/39ad9368-5dd7-4553-89d8-418ef41f6ad5">

