### PR TITLE
Fix beacon connections mapping

### DIFF
--- a/src/utils/beacon/BeaconPeers.test.tsx
+++ b/src/utils/beacon/BeaconPeers.test.tsx
@@ -1,4 +1,4 @@
-import { NetworkType, getSenderId } from "@airgap/beacon-wallet";
+import { NetworkType } from "@airgap/beacon-wallet";
 
 import * as beaconHelper from "./beacon";
 import { BeaconPeers } from "./BeaconPeers";
@@ -38,7 +38,7 @@ let senderIds: string[];
 beforeEach(async () => {
   dispatchMockAccounts([mockMnemonicAccount(1), mockMnemonicAccount(2)]);
   jest.spyOn(beaconHelper, "usePeers").mockReturnValue({ data: peersData } as any);
-  senderIds = await Promise.all(peersData.map(peer => getSenderId(peer.publicKey)));
+  senderIds = await Promise.all(peersData.map(peer => beaconHelper.getSenderId(peer.publicKey)));
 });
 
 describe("<BeaconPeers />", () => {
@@ -99,7 +99,7 @@ describe("<BeaconPeers />", () => {
 
         const peerRows = await getPeerRows();
 
-        const addressPill = within(peerRows[0]).getByTestId("address-pill-text");
+        const addressPill = within(peerRows[1]).getByTestId("address-pill-text");
         expect(addressPill).toHaveTextContent(mockMnemonicAccount(1).label);
       });
 
@@ -114,14 +114,14 @@ describe("<BeaconPeers />", () => {
 
         const peerRows = await getPeerRows();
 
-        const addressPill = within(peerRows[0]).getByTestId("address-pill-text");
+        const addressPill = within(peerRows[1]).getByTestId("address-pill-text");
         expect(addressPill).toHaveTextContent(formatPkh(mockMnemonicAccount(5).address.pkh));
       });
 
       it("displays network type from beacon connection request", async () => {
         store.dispatch(
           beaconActions.addConnection({
-            dAppId: senderIds[1],
+            dAppId: senderIds[2],
             accountPkh: mockMnemonicAccount(1).address.pkh,
             networkType: NetworkType.OXFORDNET,
           })
@@ -129,7 +129,7 @@ describe("<BeaconPeers />", () => {
 
         const peerRows = await getPeerRows();
 
-        const network = within(peerRows[0]).getByTestId("dapp-connection-network");
+        const network = within(peerRows[2]).getByTestId("dapp-connection-network");
         expect(network).toHaveTextContent("Oxfordnet");
       });
     });
@@ -169,8 +169,7 @@ describe("<BeaconPeers />", () => {
       });
     });
 
-    // TODO: enable again when the bug in Beacon is fixed
-    it.skip("removes connection from beaconSlice", async () => {
+    it("removes connection from beaconSlice", async () => {
       const user = userEvent.setup();
       [
         {

--- a/src/utils/beacon/BeaconPeers.tsx
+++ b/src/utils/beacon/BeaconPeers.tsx
@@ -1,4 +1,3 @@
-import { getSenderId } from "@airgap/beacon-wallet";
 import {
   AspectRatio,
   Box,
@@ -13,7 +12,7 @@ import {
 import { capitalize, noop } from "lodash";
 import { Fragment, useEffect, useState } from "react";
 
-import { usePeers, useRemovePeer } from "./beacon";
+import { getSenderId, usePeers, useRemovePeer } from "./beacon";
 import { PeerInfoWithId } from "./types";
 import { TrashIcon } from "../../assets/icons";
 import { AddressPill } from "../../components/AddressPill/AddressPill";

--- a/src/utils/beacon/beacon.tsx
+++ b/src/utils/beacon/beacon.tsx
@@ -1,4 +1,10 @@
-import { ExtendedP2PPairingResponse, Serializer, WalletClient } from "@airgap/beacon-wallet";
+import {
+  ExtendedP2PPairingResponse,
+  Serializer,
+  WalletClient,
+  getSenderId as beaconGetSenderId,
+  toHex,
+} from "@airgap/beacon-wallet";
 import { useToast } from "@chakra-ui/react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useContext, useEffect } from "react";
@@ -79,6 +85,10 @@ export const BeaconProvider: React.FC<{
 
   return children;
 };
+
+// it's crucial that we convert the publicKey to hex before calling getSenderId
+// otherwise it gives incorrect results with lots of collisions
+export const getSenderId = (publicKey: string) => beaconGetSenderId(toHex(publicKey));
 
 export const resetBeacon = async () => {
   // Until walletClient.destroy is fixed


### PR DESCRIPTION
## Proposed changes

The reason why we were getting the same senderIds for different publicKeys was that we must've first converted it to a hex string and only then call the getSenderId function.

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] UI fix

## Steps to reproduce
check the test

## Checklist

- [x] Tests that prove my fix is effective or that my feature works have been added
- [x] Documentation has been added (if appropriate)
