### PR TITLE
Close ledger toast on sign action completion

### DIFF
--- a/src/components/SendFlow/SignButton.tsx
+++ b/src/components/SendFlow/SignButton.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, FormControl, useToast } from "@chakra-ui/react";
+import { Box, Button, FormControl, UseToastOptions, useToast } from "@chakra-ui/react";
 import { TezosToolkit } from "@taquito/taquito";
 import type { BatchWalletOperation } from "@taquito/taquito/dist/types/wallet/batch-operation";
 import React from "react";
@@ -55,21 +55,29 @@ export const SignButton: React.FC<{
     });
 
   const onLedgerSign = async () =>
-    handleAsyncAction(async () => {
-      toast({
-        description: "Please open the Tezos app on your Ledger and approve the operation",
-        status: "info",
-        duration: 60000,
-        isClosable: true,
-      });
-      return onSubmit(
-        await makeToolkit({
-          type: "ledger",
-          account: signer as LedgerAccount,
-          network,
-        })
-      );
-    });
+    handleAsyncAction(
+      async () => {
+        toast({
+          id: "ledger-sign-toast",
+          description: "Please approve the operation on your Ledger",
+          status: "info",
+          duration: 60000,
+          isClosable: true,
+        });
+        return onSubmit(
+          await makeToolkit({
+            type: "ledger",
+            account: signer as LedgerAccount,
+            network,
+          })
+        );
+      },
+      (error: any) =>
+        ({
+          description: `${error.message} Please connect your ledger, open Tezos app and try submitting transaction again`,
+          status: "error",
+        }) as UseToastOptions
+    ).finally(() => toast.close("ledger-sign-toast"));
 
   switch (signer.type) {
     case "secret_key":


### PR DESCRIPTION
## Proposed changes

The toast stayed open even after error / successful sign with ledger.

[Task link](https://app.asana.com/0/1205770721172203/1206597776005797/f)

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] UI fix

## Steps to reproduce

Initiate transaction from ledger account & try signing it (successfully or not)

## Screenshots

### Before

https://github.com/trilitech/umami-v2/assets/150050388/448c3fa1-1c5f-4bee-9726-f1609b6bde48

### After

https://github.com/trilitech/umami-v2/assets/150050388/f8528d12-ebb6-4c5b-8169-5155fdc1ac51

<img width="1051" alt="Screenshot 2024-02-23 at 17 56 35" src="https://github.com/trilitech/umami-v2/assets/150050388/91c486be-b708-41bb-80d1-c0cf9e878d97">

## Checklist

- [ ] Tests that prove my fix is effective or that my feature works have been added
- [ ] Documentation has been added (if appropriate)
- [ ] Screenshots are added (if any UI changes have been made)
- [ ] All TODOs have a corresponding task created (and the link is attached to it)
