### PR TITLE
Remove "View all" button from Operations empty state

### DIFF
--- a/src/components/AccountDrawer/AssetsPanel/OperationListDisplay.test.tsx
+++ b/src/components/AccountDrawer/AssetsPanel/OperationListDisplay.test.tsx
@@ -15,11 +15,6 @@ describe("<OperationListDisplay />", () => {
       expect(screen.getByTestId("empty-state-message")).toBeVisible();
       expect(screen.getByText("No operations to show")).toBeVisible();
       expect(screen.getByText("Your operations history will appear here...")).toBeVisible();
-      // check View All Operations button from empty state
-      const viewAllOperationsButton = screen.getByTestId("view-all-operations-button");
-      expect(viewAllOperationsButton).toBeVisible();
-      expect(viewAllOperationsButton).toHaveTextContent("View All Operations");
-      expect(viewAllOperationsButton).toHaveAttribute("href", "#/operations");
     });
 
     it("does not show operation tiles", () => {

--- a/src/components/AccountDrawer/AssetsPanel/OperationListDisplay.tsx
+++ b/src/components/AccountDrawer/AssetsPanel/OperationListDisplay.tsx
@@ -23,7 +23,7 @@ export const OperationListDisplay: React.FC<{
   operations: TzktCombinedOperation[];
 }> = ({ owner, operations }) => {
   if (operations.length === 0) {
-    return <NoOperations size="md" withViewAllButton={true} />;
+    return <NoOperations size="md" />;
   }
 
   const chunk = operations.slice(0, MAX_OPERATIONS_SIZE);

--- a/src/components/NoItems/index.tsx
+++ b/src/components/NoItems/index.tsx
@@ -1,7 +1,6 @@
 import "react-responsive-carousel/lib/styles/carousel.min.css";
 import { Box, Button, Center, Flex, Heading, Text } from "@chakra-ui/react";
 import { PropsWithChildren } from "react";
-import { Link } from "react-router-dom";
 
 import colors from "../../style/colors";
 import { ExternalLink } from "../ExternalLink";
@@ -47,21 +46,12 @@ export const NoItems: React.FC<
   );
 };
 
-export const NoOperations: React.FC<{ size: AvailableSizes; withViewAllButton?: boolean }> = ({
-  size,
-  withViewAllButton,
-}) => (
+export const NoOperations: React.FC<{ size: AvailableSizes }> = ({ size }) => (
   <NoItems
     description="Your operations history will appear here..."
     size={size}
     title="No operations to show"
-  >
-    {withViewAllButton && (
-      <Link data-testid="view-all-operations-button" to="/operations">
-        <Button size={SIZES[size].button}>View All Operations</Button>
-      </Link>
-    )}
-  </NoItems>
+  />
 );
 
 export const NoNFTs: React.FC<{ size: AvailableSizes }> = ({ size }) => (


### PR DESCRIPTION
## Proposed changes

[Task link]()

## Types of changes

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] UI fix

## Steps to reproduce

Open account drawer for account without operations.

## Screenshots

| Before | Now |
| ------ | --- |
|    <img width="563" alt="Screenshot 2024-02-23 at 04 57 23" src="https://github.com/trilitech/umami-v2/assets/150050388/2b5d9579-8b21-457c-98be-9c28e9fc3b98">    |   <img width="588" alt="Screenshot 2024-02-23 at 04 56 38" src="https://github.com/trilitech/umami-v2/assets/150050388/3c552a19-7b6b-4ac2-8d48-f5211e40c846">  |


