### PR TITLE
Simplify dynamicModalContextMock usage

### DIFF
--- a/src/components/SendFlow/Delegation/FormPage.test.tsx
+++ b/src/components/SendFlow/Delegation/FormPage.test.tsx
@@ -3,14 +3,20 @@ import BigNumber from "bignumber.js";
 
 import { FormPage, FormValues } from "./FormPage";
 import { SignPage } from "./SignPage";
-import { dynamicModalContextMock } from "../../../mocks/dynamicModal";
 import {
   mockImplicitAccount,
   mockMnemonicAccount,
   mockMultisigAccount,
 } from "../../../mocks/factories";
 import { mockEstimatedFee } from "../../../mocks/helpers";
-import { act, render, screen, userEvent, waitFor } from "../../../mocks/testUtils";
+import {
+  act,
+  dynamicModalContextMock,
+  render,
+  screen,
+  userEvent,
+  waitFor,
+} from "../../../mocks/testUtils";
 import { mockToast } from "../../../mocks/toast";
 import { makeAccountOperations } from "../../../types/AccountOperations";
 import { accountsSlice } from "../../../utils/redux/slices/accountsSlice";
@@ -18,7 +24,6 @@ import { assetsSlice } from "../../../utils/redux/slices/assetsSlice";
 import { multisigActions } from "../../../utils/redux/slices/multisigsSlice";
 import { store } from "../../../utils/redux/store";
 import { estimate } from "../../../utils/tezos";
-import { DynamicModalContext } from "../../DynamicModal";
 import { FormPageProps } from "../utils";
 
 const fixture = (props: FormPageProps<FormValues>) => (
@@ -157,15 +162,13 @@ describe("<Form />", () => {
       const user = userEvent.setup();
       const sender = mockImplicitAccount(0);
       render(
-        <DynamicModalContext.Provider value={dynamicModalContextMock}>
-          {fixture({
-            sender: sender,
-            form: {
-              sender: sender.address.pkh,
-              baker: mockImplicitAccount(1).address.pkh,
-            },
-          })}
-        </DynamicModalContext.Provider>
+        fixture({
+          sender: sender,
+          form: {
+            sender: sender.address.pkh,
+            baker: mockImplicitAccount(1).address.pkh,
+          },
+        })
       );
       const submitButton = screen.getByText("Preview");
       await waitFor(() => {

--- a/src/components/SendFlow/MultisigAccount/NameMultisigFormPage.test.tsx
+++ b/src/components/SendFlow/MultisigAccount/NameMultisigFormPage.test.tsx
@@ -2,11 +2,15 @@ import { Modal } from "@chakra-ui/react";
 
 import { NameMultisigFormPage } from "./NameMultisigFormPage";
 import { SelectApproversFormPage } from "./SelectApproversFormPage";
-import { dynamicModalContextMock } from "../../../mocks/dynamicModal";
 import { mockMnemonicAccount } from "../../../mocks/factories";
 import { addAccount } from "../../../mocks/helpers";
-import { fireEvent, render, screen, waitFor } from "../../../mocks/testUtils";
-import { DynamicModalContext } from "../../DynamicModal";
+import {
+  dynamicModalContextMock,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "../../../mocks/testUtils";
 
 const MULTISIG_NAME = "Test Multisig Name";
 
@@ -109,11 +113,7 @@ describe("NameMultisigFormPage", () => {
     });
 
     it("opens Select Approvers form on submit", async () => {
-      render(
-        <DynamicModalContext.Provider value={dynamicModalContextMock}>
-          {component}
-        </DynamicModalContext.Provider>
-      );
+      render(component);
 
       if (!withName) {
         const input = screen.getByLabelText("Account Name");
@@ -139,11 +139,7 @@ describe("NameMultisigFormPage", () => {
     });
 
     it("opens Select Approvers form on submit - with trimmed name", async () => {
-      render(
-        <DynamicModalContext.Provider value={dynamicModalContextMock}>
-          {component}
-        </DynamicModalContext.Provider>
-      );
+      render(component);
 
       const input = screen.getByLabelText("Account Name");
       fireEvent.change(input, { target: { value: "\tUpdated Multisig Name  " } });

--- a/src/components/SendFlow/MultisigAccount/SelectApproversFormPage.test.tsx
+++ b/src/components/SendFlow/MultisigAccount/SelectApproversFormPage.test.tsx
@@ -3,7 +3,6 @@ import BigNumber from "bignumber.js";
 
 import { FormValues, SelectApproversFormPage } from "./SelectApproversFormPage";
 import { SignTransactionFormPage } from "./SignTransactionFormPage";
-import { dynamicModalContextMock } from "../../../mocks/dynamicModal";
 import {
   mockContractAddress,
   mockContractOrigination,
@@ -12,12 +11,19 @@ import {
   mockMnemonicAccount,
 } from "../../../mocks/factories";
 import { mockEstimatedFee } from "../../../mocks/helpers";
-import { act, fireEvent, render, screen, userEvent, waitFor } from "../../../mocks/testUtils";
+import {
+  act,
+  dynamicModalContextMock,
+  fireEvent,
+  render,
+  screen,
+  userEvent,
+  waitFor,
+} from "../../../mocks/testUtils";
 import { contract, makeStorageJSON } from "../../../multisig/contract";
 import { makeAccountOperations } from "../../../types/AccountOperations";
 import { accountsSlice } from "../../../utils/redux/slices/accountsSlice";
 import { store } from "../../../utils/redux/store";
-import { DynamicModalContext } from "../../DynamicModal";
 
 const MULTISIG_NAME = "Multisig Account Name";
 const SENDER = mockMnemonicAccount(0);
@@ -256,17 +262,15 @@ describe("SelectApproversFormPage", () => {
       const user = userEvent.setup();
       const sender = mockImplicitAccount(1);
       render(
-        <DynamicModalContext.Provider value={dynamicModalContextMock}>
-          {fixture({
-            name: "Test account",
-            sender: sender.address.pkh,
-            signers: [
-              { val: mockImplicitAccount(0).address.pkh },
-              { val: mockImplicitAccount(1).address.pkh },
-            ],
-            threshold: 1,
-          })}
-        </DynamicModalContext.Provider>
+        fixture({
+          name: "Test account",
+          sender: sender.address.pkh,
+          signers: [
+            { val: mockImplicitAccount(0).address.pkh },
+            { val: mockImplicitAccount(1).address.pkh },
+          ],
+          threshold: 1,
+        })
       );
 
       const operations = makeAccountOperations(sender, sender, [
@@ -305,11 +309,7 @@ describe("SelectApproversFormPage", () => {
 
   describe("empty form", () => {
     it("builds operation that can be submitted from the next step", async () => {
-      render(
-        <DynamicModalContext.Provider value={dynamicModalContextMock}>
-          {fixture()}
-        </DynamicModalContext.Provider>
-      );
+      render(fixture());
 
       // select values
       const addSignerButton = screen.getByRole("button", { name: "+ Add Approver" });

--- a/src/components/SendFlow/NFT/FormPage.test.tsx
+++ b/src/components/SendFlow/NFT/FormPage.test.tsx
@@ -3,17 +3,23 @@ import BigNumber from "bignumber.js";
 
 import { FormPage, FormValues } from "./FormPage";
 import { SignPage } from "./SignPage";
-import { dynamicModalContextMock } from "../../../mocks/dynamicModal";
 import { mockImplicitAccount, mockMnemonicAccount, mockNFT } from "../../../mocks/factories";
 import { mockEstimatedFee } from "../../../mocks/helpers";
-import { act, fireEvent, render, screen, userEvent, waitFor } from "../../../mocks/testUtils";
+import {
+  act,
+  dynamicModalContextMock,
+  fireEvent,
+  render,
+  screen,
+  userEvent,
+  waitFor,
+} from "../../../mocks/testUtils";
 import { mockToast } from "../../../mocks/toast";
 import { makeAccountOperations } from "../../../types/AccountOperations";
 import { parseContractPkh } from "../../../types/Address";
 import { NFTBalance } from "../../../types/TokenBalance";
 import { accountsSlice } from "../../../utils/redux/slices/accountsSlice";
 import { store } from "../../../utils/redux/store";
-import { DynamicModalContext } from "../../DynamicModal";
 import { FormPagePropsWithSender } from "../utils";
 
 const fixture = (props: FormPagePropsWithSender<FormValues>, nft: NFTBalance = mockNFT(1, "1")) => (
@@ -166,16 +172,14 @@ describe("<FormPage />", () => {
         store.dispatch(accountsSlice.actions.addMockMnemonicAccounts([mockMnemonicAccount(0)]));
         const sender = mockImplicitAccount(0);
         render(
-          <DynamicModalContext.Provider value={dynamicModalContextMock}>
-            {fixture({
-              sender,
-              form: {
-                sender: sender.address.pkh,
-                recipient: mockImplicitAccount(1).address.pkh,
-                quantity: 1,
-              },
-            })}
-          </DynamicModalContext.Provider>
+          fixture({
+            sender,
+            form: {
+              sender: sender.address.pkh,
+              recipient: mockImplicitAccount(1).address.pkh,
+              quantity: 1,
+            },
+          })
         );
         const submitButton = screen.getByText("Preview");
         await waitFor(() => {

--- a/src/components/SendFlow/Tez/FormPage.test.tsx
+++ b/src/components/SendFlow/Tez/FormPage.test.tsx
@@ -3,21 +3,27 @@ import BigNumber from "bignumber.js";
 
 import { FormPage, FormValues } from "./FormPage";
 import { SignPage } from "./SignPage";
-import { dynamicModalContextMock } from "../../../mocks/dynamicModal";
 import {
   mockImplicitAccount,
   mockMnemonicAccount,
   mockMultisigAccount,
 } from "../../../mocks/factories";
 import { mockEstimatedFee } from "../../../mocks/helpers";
-import { act, fireEvent, render, screen, userEvent, waitFor } from "../../../mocks/testUtils";
+import {
+  act,
+  dynamicModalContextMock,
+  fireEvent,
+  render,
+  screen,
+  userEvent,
+  waitFor,
+} from "../../../mocks/testUtils";
 import { mockToast } from "../../../mocks/toast";
 import { makeAccountOperations } from "../../../types/AccountOperations";
 import { accountsSlice } from "../../../utils/redux/slices/accountsSlice";
 import { multisigActions } from "../../../utils/redux/slices/multisigsSlice";
 import { store } from "../../../utils/redux/store";
 import { estimate } from "../../../utils/tezos";
-import { DynamicModalContext } from "../../DynamicModal";
 import { FormPageProps } from "../utils";
 
 const fixture = (props: FormPageProps<FormValues> = {}) => (
@@ -246,15 +252,13 @@ describe("<Form />", () => {
       async sender => {
         const user = userEvent.setup();
         render(
-          <DynamicModalContext.Provider value={dynamicModalContextMock}>
-            {fixture({
-              form: {
-                sender: sender.address.pkh,
-                recipient: mockImplicitAccount(1).address.pkh,
-                prettyAmount: "1",
-              },
-            })}
-          </DynamicModalContext.Provider>
+          fixture({
+            form: {
+              sender: sender.address.pkh,
+              recipient: mockImplicitAccount(1).address.pkh,
+              prettyAmount: "1",
+            },
+          })
         );
         const submitButton = screen.getByText("Preview");
         await waitFor(() => {

--- a/src/components/SendFlow/Token/FormPage.test.tsx
+++ b/src/components/SendFlow/Token/FormPage.test.tsx
@@ -3,7 +3,6 @@ import BigNumber from "bignumber.js";
 
 import { FormPage, FormValues } from "./FormPage";
 import { SignPage } from "./SignPage";
-import { dynamicModalContextMock } from "../../../mocks/dynamicModal";
 import {
   mockFA2Token,
   mockFA2TokenRaw,
@@ -11,7 +10,15 @@ import {
   mockMnemonicAccount,
 } from "../../../mocks/factories";
 import { mockEstimatedFee } from "../../../mocks/helpers";
-import { act, fireEvent, render, screen, userEvent, waitFor } from "../../../mocks/testUtils";
+import {
+  act,
+  dynamicModalContextMock,
+  fireEvent,
+  render,
+  screen,
+  userEvent,
+  waitFor,
+} from "../../../mocks/testUtils";
 import { mockToast } from "../../../mocks/toast";
 import { makeAccountOperations } from "../../../types/AccountOperations";
 import { parseContractPkh } from "../../../types/Address";
@@ -19,7 +26,6 @@ import { FA2TokenBalance } from "../../../types/TokenBalance";
 import { accountsSlice } from "../../../utils/redux/slices/accountsSlice";
 import { assetsSlice } from "../../../utils/redux/slices/assetsSlice";
 import { store } from "../../../utils/redux/store";
-import { DynamicModalContext } from "../../DynamicModal";
 import { FormPagePropsWithSender } from "../utils";
 
 const mockAccount = mockMnemonicAccount(0);
@@ -187,19 +193,17 @@ describe("<FormPage />", () => {
         store.dispatch(assetsSlice.actions.updateTokenBalance([mockTokenRaw]));
         const sender = mockAccount;
         render(
-          <DynamicModalContext.Provider value={dynamicModalContextMock}>
-            {fixture(
-              {
-                sender,
-                form: {
-                  sender: sender.address.pkh,
-                  recipient: mockImplicitAccount(1).address.pkh,
-                  prettyAmount: "1",
-                },
+          fixture(
+            {
+              sender,
+              form: {
+                sender: sender.address.pkh,
+                recipient: mockImplicitAccount(1).address.pkh,
+                prettyAmount: "1",
               },
-              mockFA2Token(0, mockAccount, 2, 0)
-            )}
-          </DynamicModalContext.Provider>
+            },
+            mockFA2Token(0, mockAccount, 2, 0)
+          )
         );
         const submitButton = screen.getByText("Preview");
         await waitFor(() => {

--- a/src/components/SendFlow/Undelegation/FormPage.test.tsx
+++ b/src/components/SendFlow/Undelegation/FormPage.test.tsx
@@ -3,7 +3,6 @@ import BigNumber from "bignumber.js";
 
 import { FormPage, FormValues } from "./FormPage";
 import { SignPage } from "./SignPage";
-import { dynamicModalContextMock } from "../../../mocks/dynamicModal";
 import {
   mockImplicitAccount,
   mockImplicitAddress,
@@ -11,7 +10,14 @@ import {
   mockMultisigAccount,
 } from "../../../mocks/factories";
 import { mockEstimatedFee } from "../../../mocks/helpers";
-import { act, render, screen, userEvent, waitFor } from "../../../mocks/testUtils";
+import {
+  act,
+  dynamicModalContextMock,
+  render,
+  screen,
+  userEvent,
+  waitFor,
+} from "../../../mocks/testUtils";
 import { mockToast } from "../../../mocks/toast";
 import { makeAccountOperations } from "../../../types/AccountOperations";
 import { accountsSlice } from "../../../utils/redux/slices/accountsSlice";
@@ -19,7 +25,6 @@ import { assetsSlice } from "../../../utils/redux/slices/assetsSlice";
 import { multisigActions } from "../../../utils/redux/slices/multisigsSlice";
 import { store } from "../../../utils/redux/store";
 import { estimate } from "../../../utils/tezos";
-import { DynamicModalContext } from "../../DynamicModal";
 import { FormPagePropsWithSender } from "../utils";
 
 const fixture = (props: FormPagePropsWithSender<FormValues>) => (
@@ -99,15 +104,13 @@ describe("<Form />", () => {
       const user = userEvent.setup();
       const sender = mockImplicitAccount(0);
       render(
-        <DynamicModalContext.Provider value={dynamicModalContextMock}>
-          {fixture({
-            sender: sender,
-            form: {
-              sender: sender.address.pkh,
-              baker: mockImplicitAddress(2).pkh,
-            },
-          })}
-        </DynamicModalContext.Provider>
+        fixture({
+          sender: sender,
+          form: {
+            sender: sender.address.pkh,
+            baker: mockImplicitAddress(2).pkh,
+          },
+        })
       );
       const submitButton = screen.getByText("Preview");
       await waitFor(() => {

--- a/src/mocks/dynamicModal.tsx
+++ b/src/mocks/dynamicModal.tsx
@@ -1,6 +1,0 @@
-export const dynamicModalContextMock = {
-  isOpen: true,
-  onClose: jest.fn(),
-  openWith: jest.fn(),
-  content: null, // set your own content in place
-};


### PR DESCRIPTION
this way we don't need to manually wrap our components with the context. the spying functions are always there and we don't lose the original implementation, it still renders the modal on the page