### PR TITLE
Fix duplicating key error for peers

### DIFF
--- a/src/utils/beacon/BeaconPeers.tsx
+++ b/src/utils/beacon/BeaconPeers.tsx
@@ -72,7 +72,7 @@ const PeersDisplay = ({
 }) => (
   <Box>
     {peerInfos.map(peerInfo => (
-      <Fragment key={peerInfo.name}>
+      <Fragment key={peerInfo.senderId}>
         <Divider />
         <PeerRow onRemove={() => removePeer(peerInfo)} peerInfo={peerInfo} />
       </Fragment>


### PR DESCRIPTION
## Proposed changes

DApp might have the same name, but different beacon instances.
E. g. on mainnet & ghostnet, or when trying to connect from different browsers.

SenderId is unique for each beacon instance of a dApp, so using it as a key solves this problem.

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] UI fix

## Steps to reproduce

Connect to the same dApp from different browsers. Check console for errors.

## Screenshots

| Before | Now |
| ------ | --- |
|    <img width="1225" alt="Screenshot 2024-03-12 at 14 00 38" src="https://github.com/trilitech/umami-v2/assets/150050388/9889ff27-b8b8-4eeb-8418-f2611a10f103">    |   <img width="875" alt="Screenshot 2024-03-12 at 14 02 27" src="https://github.com/trilitech/umami-v2/assets/150050388/affb457b-4e93-4ae3-946e-5f57a42c6f9d">  |

## Checklist

- [x] Tests that prove my fix is effective or that my feature works have been added
- [ ] Documentation has been added (if appropriate)
- [x] Screenshots are added (if any UI changes have been made)
- [ ] All TODOs have a corresponding task created (and the link is attached to it)
