### PR TITLE
Safer offboarding

### DIFF
--- a/src/components/Offboarding/OffboardingForm.tsx
+++ b/src/components/Offboarding/OffboardingForm.tsx
@@ -12,25 +12,27 @@ import {
   ModalHeader,
   Text,
 } from "@chakra-ui/react";
+import { noop } from "lodash";
 import { FormProvider, useForm } from "react-hook-form";
 
 import { WarningIcon } from "../../assets/icons";
 import colors from "../../style/colors";
-import { useReset } from "../../utils/hooks/setAccountDataHooks";
+import { WalletClient } from "../../utils/beacon/WalletClient";
+import { persistor } from "../../utils/redux/persistor";
 import { FormErrorMessage } from "../FormErrorMessage";
 
 const CONFIRMATION_CODE = "wasabi";
 
+const reset = () =>
+  WalletClient.destroy()
+    .catch(noop)
+    .finally(() => {
+      persistor.pause();
+      localStorage.clear();
+      window.location.reload();
+    });
+
 export const OffboardingForm = () => {
-  const reset = useReset();
-
-  const onSubmit = () => {
-    if (!getValues("check") || getValues("confirmationCode") !== CONFIRMATION_CODE) {
-      return;
-    }
-    reset();
-  };
-
   const form = useForm<{ check: boolean; confirmationCode: string }>({
     mode: "onBlur",
   });
@@ -41,6 +43,13 @@ export const OffboardingForm = () => {
     getValues,
   } = form;
 
+  const onSubmit = () => {
+    if (!getValues("check") || getValues("confirmationCode") !== CONFIRMATION_CODE) {
+      return;
+    }
+    return reset();
+  };
+
   return (
     <FormProvider {...form}>
       <form onSubmit={handleSubmit(onSubmit)}>
@@ -48,13 +57,13 @@ export const OffboardingForm = () => {
 
         <ModalHeader marginBottom="10px" textAlign="center">
           <Box>
-            <WarningIcon width={10} height={10} marginBottom={5} />
+            <WarningIcon width="40px" height="40px" marginBottom="20px" />
             <Heading>Off-board Wallet</Heading>
           </Box>
         </ModalHeader>
         <Box>
           <Text
-            marginBottom={2}
+            marginBottom="8px"
             color={colors.gray[400]}
             fontWeight="bold"
             textAlign="center"
@@ -68,16 +77,16 @@ export const OffboardingForm = () => {
             that you keep the recovery phrase.
           </Text>
           <ModalBody>
-            <Divider borderColor={colors.gray[700]} marginY={5} />
+            <Divider borderColor={colors.gray[700]} marginY="20px" />
             <FormControl isInvalid={!!errors.check}>
               <Checkbox {...register("check", { required: true })}>
-                <Text marginLeft={2} fontWeight="bold">
+                <Text marginLeft="8px" fontWeight="bold">
                   I have read the warning and I am certain I want to remove my private keys locally.
                   I also made sure to keep my recovery phrase.
                 </Text>
               </Checkbox>
             </FormControl>
-            <Divider borderColor={colors.gray[700]} marginY={5} />
+            <Divider borderColor={colors.gray[700]} marginY="20px" />
             <FormControl isInvalid={!!errors.confirmationCode} paddingY={5}>
               <Input
                 type="text"
@@ -98,7 +107,7 @@ export const OffboardingForm = () => {
         <ModalFooter padding={0}>
           <Button
             width="100%"
-            marginBottom={2}
+            marginBottom="8px"
             isDisabled={!isValid}
             size="lg"
             type="submit"

--- a/src/utils/hooks/setAccountDataHooks.ts
+++ b/src/utils/hooks/setAccountDataHooks.ts
@@ -29,12 +29,6 @@ const { removeMnemonicAndAccounts, removeNonMnemonicAccounts } = accountsSlice.a
 
 const { addAccount } = accountsSlice.actions;
 
-export const useReset = () => () => {
-  localStorage.clear();
-
-  window.location.reload();
-};
-
 /**
  * Restores accounts from a mnemonic group when it's being added by an existing seedphrase.
  *


### PR DESCRIPTION
## Proposed changes

Sometimes beacon would throw an error if we only cleaned the local storage.
also, it might be that redux persist flushes the state to the local storage right after we've just cleaned it.
also, `useReset` has never been a hook

## Types of changes

- [x] Bugfix
- [ ] New feature
- [x] Refactor
- [ ] Breaking change
- [ ] UI fix
