### PR TITLE
Improve communication through beacon

### DIFF
--- a/src/components/SendFlow/Beacon/BatchSignPage.tsx
+++ b/src/components/SendFlow/Beacon/BatchSignPage.tsx
@@ -24,7 +24,7 @@ import { SignPageFee } from "../SignPageFee";
 import { headerText } from "../SignPageHeader";
 
 export const BatchSignPage: React.FC<BeaconSignPageProps> = ({ operation, fee, message }) => {
-  const { isSigning, onSign } = useSignWithBeacon(operation, message);
+  const { isSigning, onSign, network } = useSignWithBeacon(operation, message);
   const { signer } = operation;
   const transactionCount = operation.operations.length;
 
@@ -66,6 +66,7 @@ export const BatchSignPage: React.FC<BeaconSignPageProps> = ({ operation, fee, m
         <ModalFooter>
           <SignButton
             isLoading={isSigning}
+            network={network}
             onSubmit={onSign}
             signer={signer}
             text={headerText(operation.type, "batch")}

--- a/src/components/SendFlow/Beacon/ContractCallSignPage.tsx
+++ b/src/components/SendFlow/Beacon/ContractCallSignPage.tsx
@@ -36,7 +36,7 @@ export const ContractCallSignPage: React.FC<BeaconSignPageProps> = ({
     args,
   } = operation.operations[0] as ContractCall;
 
-  const { isSigning, onSign } = useSignWithBeacon(operation, message);
+  const { isSigning, onSign, network } = useSignWithBeacon(operation, message);
 
   return (
     <ModalContent>
@@ -73,6 +73,7 @@ export const ContractCallSignPage: React.FC<BeaconSignPageProps> = ({
         <ModalFooter padding="16px 0 0 0">
           <SignButton
             isLoading={isSigning}
+            network={network}
             onSubmit={onSign}
             signer={operation.signer}
             text={headerText(operation.type, "single")}

--- a/src/components/SendFlow/Beacon/DelegationSignPage.tsx
+++ b/src/components/SendFlow/Beacon/DelegationSignPage.tsx
@@ -12,7 +12,7 @@ import { headerText } from "../SignPageHeader";
 export const DelegationSignPage: React.FC<BeaconSignPageProps> = ({ operation, fee, message }) => {
   const { recipient } = operation.operations[0] as Delegation;
 
-  const { isSigning, onSign } = useSignWithBeacon(operation, message);
+  const { isSigning, onSign, network } = useSignWithBeacon(operation, message);
 
   return (
     <ModalContent>
@@ -40,6 +40,7 @@ export const DelegationSignPage: React.FC<BeaconSignPageProps> = ({ operation, f
         <ModalFooter>
           <SignButton
             isLoading={isSigning}
+            network={network}
             onSubmit={onSign}
             signer={operation.signer}
             text={headerText(operation.type, "single")}

--- a/src/components/SendFlow/Beacon/TezSignPage.test.tsx
+++ b/src/components/SendFlow/Beacon/TezSignPage.test.tsx
@@ -1,0 +1,81 @@
+import { BeaconMessageType, NetworkType, OperationRequestOutput } from "@airgap/beacon-wallet";
+import type { BatchWalletOperation } from "@taquito/taquito/dist/types/wallet/batch-operation";
+import BigNumber from "bignumber.js";
+
+import { TezSignPage } from "./TezSignPage";
+import { mockImplicitAccount, mockTezOperation } from "../../../mocks/factories";
+import {
+  act,
+  dynamicModalContextMock,
+  render,
+  screen,
+  userEvent,
+  waitFor,
+} from "../../../mocks/testUtils";
+import { GHOSTNET, MAINNET } from "../../../types/Network";
+import { WalletClient } from "../../../utils/beacon/WalletClient";
+import { useGetSecretKey } from "../../../utils/hooks/getAccountDataHooks";
+import { networksActions } from "../../../utils/redux/slices/networks";
+import { store } from "../../../utils/redux/store";
+import { executeOperations, makeToolkit } from "../../../utils/tezos";
+import { SuccessStep } from "../SuccessStep";
+
+jest.mock("../../../utils/tezos", () => ({
+  ...jest.requireActual("../../../utils/tezos"),
+  executeOperations: jest.fn(),
+  makeToolkit: jest.fn(),
+}));
+
+jest.mock("../../../utils/hooks/getAccountDataHooks", () => ({
+  ...jest.requireActual("../../../utils/hooks/getAccountDataHooks"),
+  useGetSecretKey: jest.fn(),
+}));
+
+describe("<TezSignPage />", () => {
+  it("uses correct network", async () => {
+    const user = userEvent.setup();
+    const message = {
+      id: "messageid",
+      type: BeaconMessageType.OperationRequest,
+      network: { type: NetworkType.GHOSTNET },
+      appMetadata: {},
+    } as OperationRequestOutput;
+    const operation = {
+      type: "implicit" as const,
+      sender: mockImplicitAccount(0),
+      signer: mockImplicitAccount(0),
+      operations: [mockTezOperation(0)],
+    };
+    store.dispatch(networksActions.setCurrent(MAINNET));
+    jest.mocked(useGetSecretKey).mockImplementation(() => () => Promise.resolve("secretKey"));
+
+    jest.mocked(executeOperations).mockResolvedValue({ opHash: "ophash" } as BatchWalletOperation);
+    jest.spyOn(WalletClient, "respond").mockResolvedValue();
+
+    render(<TezSignPage fee={BigNumber(123)} message={message} operation={operation} />);
+
+    expect(screen.getByText("Ghostnet")).toBeVisible();
+    expect(screen.queryByText("Mainnet")).not.toBeInTheDocument();
+
+    await act(() => user.type(screen.getByLabelText("Password"), "Password"));
+
+    const signButton = screen.getByRole("button", { name: "Confirm Transaction" });
+    await waitFor(() => expect(signButton).toBeEnabled());
+    await act(() => user.click(signButton));
+
+    expect(makeToolkit).toHaveBeenCalledWith({
+      type: "mnemonic",
+      secretKey: "secretKey",
+      network: GHOSTNET,
+    });
+
+    await waitFor(() =>
+      expect(WalletClient.respond).toHaveBeenCalledWith({
+        type: BeaconMessageType.OperationResponse,
+        id: message.id,
+        transactionHash: "ophash",
+      })
+    );
+    expect(dynamicModalContextMock.openWith).toHaveBeenCalledWith(<SuccessStep hash="ophash" />);
+  });
+});

--- a/src/components/SendFlow/Beacon/TezSignPage.tsx
+++ b/src/components/SendFlow/Beacon/TezSignPage.tsx
@@ -13,7 +13,7 @@ import { headerText } from "../SignPageHeader";
 export const TezSignPage: React.FC<BeaconSignPageProps> = ({ operation, fee, message }) => {
   const { amount: mutezAmount, recipient } = operation.operations[0] as TezTransfer;
 
-  const { isSigning, onSign } = useSignWithBeacon(operation, message);
+  const { isSigning, onSign, network } = useSignWithBeacon(operation, message);
 
   return (
     <ModalContent>
@@ -35,6 +35,7 @@ export const TezSignPage: React.FC<BeaconSignPageProps> = ({ operation, fee, mes
         <ModalFooter>
           <SignButton
             isLoading={isSigning}
+            network={network}
             onSubmit={onSign}
             signer={operation.signer}
             text={headerText(operation.type, "single")}

--- a/src/components/SendFlow/Beacon/UndelegationSignPage.tsx
+++ b/src/components/SendFlow/Beacon/UndelegationSignPage.tsx
@@ -13,7 +13,7 @@ export const UndelegationSignPage: React.FC<BeaconSignPageProps> = ({
   fee,
   message,
 }) => {
-  const { isSigning, onSign } = useSignWithBeacon(operation, message);
+  const { isSigning, onSign, network } = useSignWithBeacon(operation, message);
 
   return (
     <ModalContent>
@@ -30,6 +30,7 @@ export const UndelegationSignPage: React.FC<BeaconSignPageProps> = ({
         <ModalFooter>
           <SignButton
             isLoading={isSigning}
+            network={network}
             onSubmit={onSign}
             signer={operation.signer}
             text={headerText(operation.type, "single")}

--- a/src/components/SendFlow/Beacon/useSignWithBeacon.tsx
+++ b/src/components/SendFlow/Beacon/useSignWithBeacon.tsx
@@ -8,6 +8,7 @@ import { useContext } from "react";
 
 import { ImplicitOperations } from "../../../types/AccountOperations";
 import { WalletClient } from "../../../utils/beacon/WalletClient";
+import { useFindNetwork } from "../../../utils/hooks/networkHooks";
 import { useAsyncActionHandler } from "../../../utils/hooks/useAsyncActionHandler";
 import { executeOperations } from "../../../utils/tezos";
 import { DynamicModalContext } from "../../DynamicModal";
@@ -19,6 +20,7 @@ export const useSignWithBeacon = (
 ) => {
   const { isLoading: isSigning, handleAsyncAction } = useAsyncActionHandler();
   const { openWith } = useContext(DynamicModalContext);
+  const findNetwork = useFindNetwork();
 
   const onSign = async (tezosToolkit: TezosToolkit) =>
     handleAsyncAction(
@@ -42,5 +44,6 @@ export const useSignWithBeacon = (
   return {
     isSigning,
     onSign,
+    network: findNetwork(message.network.type),
   };
 };

--- a/src/components/SendFlow/SignButton.tsx
+++ b/src/components/SendFlow/SignButton.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, FormControl, UseToastOptions, useToast } from "@chakra-ui/react";
+import { Box, Button, FormControl, useToast } from "@chakra-ui/react";
 import { TezosToolkit } from "@taquito/taquito";
 import type { BatchWalletOperation } from "@taquito/taquito/dist/types/wallet/batch-operation";
 import React from "react";
@@ -11,6 +11,7 @@ import {
   MnemonicAccount,
   SecretKeyAccount,
 } from "../../types/Account";
+import { Network } from "../../types/Network";
 import { useGetSecretKey } from "../../utils/hooks/getAccountDataHooks";
 import { useSelectedNetwork } from "../../utils/hooks/networkHooks";
 import { useAsyncActionHandler } from "../../utils/hooks/useAsyncActionHandler";
@@ -24,13 +25,25 @@ export const SignButton: React.FC<{
   isLoading?: boolean;
   isDisabled?: boolean;
   text?: string; // TODO: after FillStep migration change to the header value from SignPage
-}> = ({ signer, onSubmit, isLoading: externalIsLoading, isDisabled, text }) => {
+  network?: Network;
+}> = ({
+  signer,
+  onSubmit,
+  isLoading: externalIsLoading,
+  isDisabled,
+  text,
+  network: preferredNetwork,
+}) => {
   const form = useForm<{ password: string }>({ mode: "onBlur", defaultValues: { password: "" } });
   const {
     handleSubmit,
     formState: { errors, isValid: isPasswordValid },
   } = form;
-  const network = useSelectedNetwork();
+  let network = useSelectedNetwork();
+  if (preferredNetwork) {
+    network = preferredNetwork;
+  }
+
   const getSecretKey = useGetSecretKey();
   const toast = useToast();
   const { isLoading: internalIsLoading, handleAsyncAction } = useAsyncActionHandler();
@@ -72,11 +85,10 @@ export const SignButton: React.FC<{
           })
         );
       },
-      (error: any) =>
-        ({
-          description: `${error.message} Please connect your ledger, open Tezos app and try submitting transaction again`,
-          status: "error",
-        }) as UseToastOptions
+      (error: any) => ({
+        description: `${error.message} Please connect your ledger, open Tezos app and try submitting transaction again`,
+        status: "error",
+      })
     ).finally(() => toast.close("ledger-sign-toast"));
 
   switch (signer.type) {

--- a/src/utils/beacon/BeaconPeers.test.tsx
+++ b/src/utils/beacon/BeaconPeers.test.tsx
@@ -39,7 +39,7 @@ const peersData: ExtendedPeerInfo[] = [
 
 beforeEach(() => {
   [mockMnemonicAccount(1), mockMnemonicAccount(2)].forEach(addAccount);
-  jest.spyOn(beaconHelper, "usePeers").mockReturnValue({ data: peersData } as any);
+  jest.spyOn(beaconHelper, "usePeers").mockReturnValue(peersData);
 });
 
 describe("<BeaconPeers />", () => {
@@ -54,7 +54,7 @@ describe("<BeaconPeers />", () => {
 
   describe("list of paired dApps", () => {
     it("shows empty state message when no paired dApps", async () => {
-      jest.spyOn(beaconHelper, "usePeers").mockReturnValue({ data: [] } as any);
+      jest.spyOn(beaconHelper, "usePeers").mockReturnValue([]);
       render(<BeaconPeers />);
 
       await waitFor(() => {
@@ -164,7 +164,7 @@ describe("<BeaconPeers />", () => {
       const deleteButton = within(peerRows[1]).getByRole("button", { name: "Remove Peer" });
       await act(() => user.click(deleteButton));
 
-      expect(WalletClient.removePeer).toHaveBeenCalledWith(peersData[1]);
+      expect(WalletClient.removePeer).toHaveBeenCalledWith(peersData[1], true);
     });
 
     it("removes connection from beaconSlice", async () => {

--- a/src/utils/beacon/PermissionRequestModal.test.tsx
+++ b/src/utils/beacon/PermissionRequestModal.test.tsx
@@ -14,7 +14,12 @@ import { addAccount } from "../../mocks/helpers";
 import { act, render, screen, userEvent } from "../../mocks/testUtils";
 import { store } from "../redux/store";
 
-jest.mock("./WalletClient");
+jest.mock("./WalletClient", () => ({
+  WalletClient: {
+    getPeers: () => Promise.resolve([]),
+    respond: jest.fn(),
+  },
+}));
 
 const TestComponent = ({ request }: { request: PermissionRequestOutput }) => (
   <Modal isOpen={true} onClose={() => {}}>

--- a/src/utils/beacon/PermissionRequestModal.tsx
+++ b/src/utils/beacon/PermissionRequestModal.tsx
@@ -1,4 +1,5 @@
 import {
+  BeaconErrorType,
   BeaconMessageType,
   BeaconResponseInputMessage,
   PermissionRequestOutput,
@@ -27,6 +28,7 @@ import { capitalize } from "lodash";
 import React, { useContext } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 
+import { useRemovePeerBySenderId } from "./beacon";
 import { WalletClient } from "./WalletClient";
 import { JsValueWrap } from "../../components/AccountDrawer/JsValueWrap";
 import { OwnedImplicitAccountsAutocomplete } from "../../components/AddressAutocomplete";
@@ -50,6 +52,16 @@ export const PermissionRequestModal: React.FC<{
     getValues,
     formState: { errors, isValid },
   } = form;
+  const removePeer = useRemovePeerBySenderId();
+
+  const onModalClose = () => {
+    void removePeer(request.senderId);
+    void WalletClient.respond({
+      id: request.id,
+      type: BeaconMessageType.Error,
+      errorType: BeaconErrorType.NOT_GRANTED_ERROR,
+    });
+  };
 
   const grant = () =>
     handleAsyncAction(async () => {
@@ -88,7 +100,7 @@ export const PermissionRequestModal: React.FC<{
           </Text>
         </Flex>
       </ModalHeader>
-      <ModalCloseButton />
+      <ModalCloseButton onClick={onModalClose} />
       <ModalBody data-testid="beacon-request-body">
         <Flex
           alignItems="center"
@@ -112,7 +124,7 @@ export const PermissionRequestModal: React.FC<{
               <AccordionIcon />
             </AccordionButton>
             <AccordionPanel>
-              <JsValueWrap value={request} />
+              <JsValueWrap overflow="auto" maxHeight="250px" value={request} />
             </AccordionPanel>
           </AccordionItem>
         </Accordion>

--- a/src/utils/beacon/SignPayloadRequestModal.test.tsx
+++ b/src/utils/beacon/SignPayloadRequestModal.test.tsx
@@ -9,7 +9,12 @@ import { act, render, screen, userEvent, waitFor } from "../../mocks/testUtils";
 import { accountsActions } from "../redux/slices/accountsSlice/accountsSlice";
 import { store } from "../redux/store";
 
-jest.mock("./WalletClient");
+jest.mock("./WalletClient", () => ({
+  WalletClient: {
+    getPeers: () => Promise.resolve([]),
+    respond: jest.fn(),
+  },
+}));
 
 const TestComponent = ({ request }: { request: SignPayloadRequestOutput }) => (
   <Modal isOpen={true} onClose={() => {}}>
@@ -63,7 +68,7 @@ describe("<SignPayloadRequestModal />", () => {
 
     await act(() => user.click(screen.getByLabelText("Password")));
     await act(() => user.type(screen.getByLabelText("Password"), "123123123"));
-    const confirmButton = screen.getByRole("button", { name: "Connect" });
+    const confirmButton = screen.getByRole("button", { name: "Sign" });
     expect(confirmButton).toBeEnabled();
 
     jest.restoreAllMocks();

--- a/src/utils/beacon/SignPayloadRequestModal.tsx
+++ b/src/utils/beacon/SignPayloadRequestModal.tsx
@@ -1,4 +1,5 @@
 import {
+  BeaconErrorType,
   BeaconMessageType,
   SignPayloadRequestOutput,
   SignPayloadResponseInput,
@@ -17,6 +18,7 @@ import {
 import { TezosToolkit } from "@taquito/taquito";
 import React, { useContext } from "react";
 
+import { useRemovePeerBySenderId } from "./beacon";
 import { decodePayload } from "./decodePayload";
 import { WalletClient } from "./WalletClient";
 import { DynamicModalContext } from "../../components/DynamicModal";
@@ -31,6 +33,16 @@ export const SignPayloadRequestModal: React.FC<{
   const getAccount = useGetImplicitAccount();
   const signerAccount = getAccount(request.sourceAddress);
   const toast = useToast();
+  const removePeer = useRemovePeerBySenderId();
+
+  const onModalClose = () => {
+    void removePeer(request.senderId);
+    void WalletClient.respond({
+      id: request.id,
+      type: BeaconMessageType.Error,
+      errorType: BeaconErrorType.ABORTED_ERROR,
+    });
+  };
 
   const sign = async (tezosToolkit: TezosToolkit) => {
     const result = await tezosToolkit.signer.sign(request.payload);
@@ -56,7 +68,7 @@ export const SignPayloadRequestModal: React.FC<{
       <ModalHeader marginBottom="32px" textAlign="center">
         Connect with pairing request
       </ModalHeader>
-      <ModalCloseButton />
+      <ModalCloseButton onClick={onModalClose} />
 
       <ModalBody>
         <Heading marginBottom="12px" size="l">
@@ -78,7 +90,7 @@ export const SignPayloadRequestModal: React.FC<{
       </ModalBody>
 
       <ModalFooter justifyContent="center" display="flex" padding="16px 0 0 0">
-        <SignButton onSubmit={sign} signer={signerAccount} text="Connect" />
+        <SignButton onSubmit={sign} signer={signerAccount} text="Sign" />
       </ModalFooter>
     </ModalContent>
   );

--- a/src/utils/hooks/beaconHooks.ts
+++ b/src/utils/hooks/beaconHooks.ts
@@ -1,4 +1,5 @@
 import { NetworkType } from "@airgap/beacon-wallet";
+import { uniq } from "lodash";
 import { useDispatch } from "react-redux";
 
 import { RawPkh } from "../../types/Address";
@@ -19,9 +20,11 @@ export const useGetPeersForAccounts = () => {
   const beaconConnections = useAppSelector(s => s.beacon);
 
   return (pkhs: RawPkh[]) =>
-    Object.entries(beaconConnections)
-      .filter(([_, connectionInfo]) => pkhs.includes(connectionInfo.accountPkh))
-      .map(([dAppId, _]) => dAppId);
+    uniq(
+      Object.entries(beaconConnections)
+        .filter(([_, connectionInfo]) => pkhs.includes(connectionInfo.accountPkh))
+        .map(([dAppId, _]) => dAppId)
+    );
 };
 
 /**

--- a/src/utils/hooks/networkHooks.test.ts
+++ b/src/utils/hooks/networkHooks.test.ts
@@ -1,4 +1,9 @@
-import { useAvailableNetworks, useSelectNetwork, useSelectedNetwork } from "./networkHooks";
+import {
+  useAvailableNetworks,
+  useFindNetwork,
+  useSelectNetwork,
+  useSelectedNetwork,
+} from "./networkHooks";
 import { renderHook } from "../../mocks/testUtils";
 import { GHOSTNET, MAINNET } from "../../types/Network";
 import { networksActions } from "../redux/slices/networks";
@@ -51,5 +56,23 @@ describe("networkHooks", () => {
       result: { current },
     } = renderHook(() => useSelectedNetwork());
     expect(current.name).toEqual("ghostnet");
+  });
+
+  describe("useFindNetwork", () => {
+    it("finds network by name", () => {
+      const {
+        result: { current: findNetwork },
+      } = renderHook(() => useFindNetwork());
+      expect(findNetwork("mainnet")).toEqual(MAINNET);
+      expect(findNetwork("maiNNet")).toEqual(MAINNET);
+    });
+
+    it("returns undefined if network not found", () => {
+      const {
+        result: { current: findNetwork },
+      } = renderHook(() => useFindNetwork());
+      expect(findNetwork("asdasd")).toEqual(undefined);
+      expect(findNetwork("mainnetX")).toEqual(undefined);
+    });
   });
 });

--- a/src/utils/hooks/networkHooks.ts
+++ b/src/utils/hooks/networkHooks.ts
@@ -7,6 +7,13 @@ export const useSelectedNetwork = () => useAppSelector(s => s.networks.current);
 
 export const useAvailableNetworks = () => useAppSelector(s => s.networks.available);
 
+export const useFindNetwork = () => {
+  const availableNetworks = useAvailableNetworks();
+
+  return (name: string) =>
+    availableNetworks.find(network => network.name.toLowerCase() === name.toLowerCase());
+};
+
 export const useSelectNetwork = () => {
   const availableNetworks = useAvailableNetworks();
   const dispatch = useDispatch();


### PR DESCRIPTION
## Proposed changes

- when we get a request from beacon on an unknown network we throw an exception
- when we get an operatino request from beacon on a non-current network, we run the estimation and the execution on the correct one
- if we close permission or payload sign modals we send a close connection message back to the dApp and remove it from the beacon connections list 

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] UI fix

## Steps to reproduce
play around with [the dApp](https://042fd6ee.taquito-test-dapp.pages.dev/)

## Checklist

- [x] Tests that prove my fix is effective or that my feature works have been added
- [ ] Documentation has been added (if appropriate)
- [ ] Screenshots are added (if any UI changes have been made)
- [ ] All TODOs have a corresponding task created (and the link is attached to it)
