### PR TITLE
Fix operations execution for unrevealed accounts

### DIFF
--- a/src/components/SendFlow/MultisigAccount/SignTransactionFormPage.tsx
+++ b/src/components/SendFlow/MultisigAccount/SignTransactionFormPage.tsx
@@ -98,7 +98,7 @@ export const SignTransactionFormPage: React.FC<SignPageProps<FormValues>> = prop
 
             <AdvancedSettingsAccordion />
 
-            <FormLabel>Approvers</FormLabel>
+            <FormLabel marginTop="24px">Approvers</FormLabel>
             <Flex flexDirection="column" gap="12px" marginBottom="12px" data-testid="approvers">
               {signers.map(signer => (
                 <AddressTile

--- a/src/mocks/helpers.ts
+++ b/src/mocks/helpers.ts
@@ -14,5 +14,5 @@ export const addAccount = (account: Account | Multisig) => {
   store.dispatch(accountsActions.addAccount(account));
 };
 
-export const fakeAddressExists = (revealedKeyPairs: { pkh: RawPkh }[]) => (pkh: RawPkh) =>
+export const fakeIsAccountRevealed = (revealedKeyPairs: { pkh: RawPkh }[]) => (pkh: RawPkh) =>
   Promise.resolve(revealedKeyPairs.map(keyPair => keyPair.pkh).includes(pkh));

--- a/src/types/AccountOperations.ts
+++ b/src/types/AccountOperations.ts
@@ -21,6 +21,9 @@ export type ImplicitOperations = {
 export type AccountOperations = ProposalOperations | ImplicitOperations;
 export type EstimatedAccountOperations = AccountOperations & {
   estimates: Estimation[];
+  // for some operations taquito automatically adds a reveal operation
+  // and returns it as the first estimate
+  revealEstimate?: Estimation;
 };
 
 export const totalFee = (estimates: Estimation[]): number =>

--- a/src/utils/hooks/setAccountDataHooks.test.ts
+++ b/src/utils/hooks/setAccountDataHooks.test.ts
@@ -12,7 +12,7 @@ import {
   mockSecretKeyAccount,
   mockSocialAccount,
 } from "../../mocks/factories";
-import { addAccount, fakeAddressExists } from "../../mocks/helpers";
+import { addAccount, fakeIsAccountRevealed } from "../../mocks/helpers";
 import { mnemonic1 } from "../../mocks/mockMnemonic";
 import { act, renderHook } from "../../mocks/testUtils";
 import { ImplicitAccount, MnemonicAccount } from "../../types/Account";
@@ -36,7 +36,7 @@ describe("setAccountDataHooks", () => {
   });
 
   describe("mnemonic accounts", () => {
-    const addressExistsMock = jest.spyOn(tezosHelpers, "addressExists");
+    const isAccountRevealedMock = jest.spyOn(tezosHelpers, "isAccountRevealed");
     const getFingerPrintMock = jest.spyOn(tezosHelpers, "getFingerPrint");
     const encryptMock = jest.spyOn(functionsToMock, "encrypt");
     const decryptMock = jest.spyOn(functionsToMock, "decrypt");
@@ -108,8 +108,8 @@ describe("setAccountDataHooks", () => {
           await mnemonicAccount(4, `${LABEL_BASE} 5`),
           await mnemonicAccount(5, `${LABEL_BASE} 6`),
         ];
-        addressExistsMock.mockImplementation(
-          fakeAddressExists(revealedAccounts.map(account => account.address))
+        isAccountRevealedMock.mockImplementation(
+          fakeIsAccountRevealed(revealedAccounts.map(account => account.address))
         );
 
         const {
@@ -148,8 +148,8 @@ describe("setAccountDataHooks", () => {
           await mnemonicAccount(2, `${LABEL_BASE} 5`),
         ];
         // Reveal mnemonic accounts
-        addressExistsMock.mockImplementation(
-          fakeAddressExists(expected.map(account => account.address))
+        isAccountRevealedMock.mockImplementation(
+          fakeIsAccountRevealed(expected.map(account => account.address))
         );
 
         const {

--- a/src/utils/mnemonic.test.ts
+++ b/src/utils/mnemonic.test.ts
@@ -8,13 +8,13 @@ import { networksActions } from "./redux/slices/networks";
 import { store } from "./redux/store";
 import * as tezosHelpers from "./tezos/helpers";
 import { mockContractContact, mockImplicitContact, mockSocialAccount } from "../mocks/factories";
-import { addAccount, fakeAddressExists } from "../mocks/helpers";
+import { addAccount, fakeIsAccountRevealed } from "../mocks/helpers";
 import { mnemonic1 } from "../mocks/mockMnemonic";
 import { renderHook } from "../mocks/testUtils";
 import { ImplicitAccount } from "../types/Account";
 import { MAINNET } from "../types/Network";
 
-const addressExistsMock = jest.spyOn(tezosHelpers, "addressExists");
+const isAccountRevealedMock = jest.spyOn(tezosHelpers, "isAccountRevealed");
 
 const testPublicKeys = [
   {
@@ -37,7 +37,7 @@ beforeEach(() => {
 
 describe("restoreRevealedPublicKeyPairs", () => {
   it("restores existing accounts", async () => {
-    addressExistsMock.mockImplementation(fakeAddressExists(testPublicKeys));
+    isAccountRevealedMock.mockImplementation(fakeIsAccountRevealed(testPublicKeys));
 
     const result = await restoreRevealedPublicKeyPairs(
       mnemonic1,
@@ -49,7 +49,7 @@ describe("restoreRevealedPublicKeyPairs", () => {
   });
 
   it("restores first account if none exists", async () => {
-    addressExistsMock.mockImplementation(fakeAddressExists([]));
+    isAccountRevealedMock.mockImplementation(fakeIsAccountRevealed([]));
 
     const result = await restoreRevealedPublicKeyPairs(
       mnemonic1,
@@ -61,7 +61,9 @@ describe("restoreRevealedPublicKeyPairs", () => {
   });
 
   it("stops at first unrevealed account", async () => {
-    addressExistsMock.mockImplementation(fakeAddressExists([testPublicKeys[0], testPublicKeys[2]]));
+    isAccountRevealedMock.mockImplementation(
+      fakeIsAccountRevealed([testPublicKeys[0], testPublicKeys[2]])
+    );
 
     const result = await restoreRevealedPublicKeyPairs(
       mnemonic1,
@@ -109,8 +111,8 @@ describe("useRestoreRevealedMnemonicAccounts", () => {
         derivationPathTemplate: "44'/1729'/?'/0'",
       },
     ];
-    addressExistsMock.mockImplementation(
-      fakeAddressExists(expected.map(account => account.address))
+    isAccountRevealedMock.mockImplementation(
+      fakeIsAccountRevealed(expected.map(account => account.address))
     );
 
     const {
@@ -127,7 +129,7 @@ describe("useRestoreRevealedMnemonicAccounts", () => {
   });
 
   it("restores one account if none were revealed", async () => {
-    addressExistsMock.mockImplementation(fakeAddressExists([]));
+    isAccountRevealedMock.mockImplementation(fakeIsAccountRevealed([]));
 
     const {
       result: { current: restoreRevealedMnemonicsHook },
@@ -148,7 +150,7 @@ describe("useRestoreRevealedMnemonicAccounts", () => {
   });
 
   it("sets unique labels for restored accounts", async () => {
-    addressExistsMock.mockImplementation(fakeAddressExists(testPublicKeys.slice(0, 3)));
+    isAccountRevealedMock.mockImplementation(fakeIsAccountRevealed(testPublicKeys.slice(0, 3)));
     store.dispatch(networksActions.setCurrent(MAINNET));
     store.dispatch(contactsActions.upsert(mockImplicitContact(1, CUSTOM_LABEL)));
     store.dispatch(contactsActions.upsert(mockContractContact(0, "ghostnet", `${CUSTOM_LABEL} 4`)));
@@ -180,7 +182,7 @@ describe("useRestoreRevealedMnemonicAccounts", () => {
   });
 
   it("restores existing accounts with a custom derivation path", async () => {
-    addressExistsMock.mockImplementation(fakeAddressExists(testPublicKeys.slice(0, 2)));
+    isAccountRevealedMock.mockImplementation(fakeIsAccountRevealed(testPublicKeys.slice(0, 2)));
 
     const {
       result: { current: restoreRevealedMnemonicsHook },

--- a/src/utils/mnemonic.ts
+++ b/src/utils/mnemonic.ts
@@ -3,7 +3,7 @@ import { generateMnemonic } from "bip39";
 import { makeDerivationPath } from "./account/derivationPathUtils";
 import { makeMnemonicAccount } from "./account/makeMnemonicAccount";
 import { useGetNextAvailableAccountLabels } from "./hooks/labelsHooks";
-import { PublicKeyPair, addressExists, derivePublicKeyPair, getFingerPrint } from "./tezos";
+import { PublicKeyPair, derivePublicKeyPair, getFingerPrint, isAccountRevealed } from "./tezos";
 import { MnemonicAccount } from "../types/Account";
 import { Network } from "../types/Network";
 
@@ -44,7 +44,7 @@ export const restoreRevealedPublicKeyPairs = async (
       mnemonic,
       makeDerivationPath(derivationPathTemplate, accountIndex)
     );
-  } while (await addressExists(pubKeyPair.pkh, network));
+  } while (await isAccountRevealed(pubKeyPair.pkh, network));
   return result;
 };
 

--- a/src/utils/tezos/estimate.test.ts
+++ b/src/utils/tezos/estimate.test.ts
@@ -1,5 +1,5 @@
 import { estimate, handleTezError } from "./estimate";
-import { addressExists, makeToolkit } from "./helpers";
+import { isAccountRevealed, makeToolkit } from "./helpers";
 import { executeParams } from "../../mocks/executeParams";
 import { mockImplicitAccount, mockTezOperation } from "../../mocks/factories";
 import { makeAccountOperations } from "../../types/AccountOperations";
@@ -7,7 +7,7 @@ import { GHOSTNET } from "../../types/Network";
 jest.mock("./helpers", () => ({
   ...jest.requireActual("./helpers"),
   makeToolkit: jest.fn(),
-  addressExists: jest.fn(),
+  isAccountRevealed: jest.fn(),
 }));
 
 const accountOperations = makeAccountOperations(mockImplicitAccount(1), mockImplicitAccount(1), [
@@ -17,7 +17,7 @@ const accountOperations = makeAccountOperations(mockImplicitAccount(1), mockImpl
 describe("estimate", () => {
   describe("Error handling", () => {
     it("Catches unrevealed account", async () => {
-      jest.mocked(addressExists).mockResolvedValue(false);
+      jest.mocked(isAccountRevealed).mockResolvedValue(false);
 
       jest.mocked(makeToolkit).mockImplementation(
         () =>
@@ -51,7 +51,7 @@ describe("estimate", () => {
     });
   });
 
-  it("returns fee, storageLimit and gasLimit estimate ", async () => {
+  it("returns estimated operations", async () => {
     const estimateResult = [
       {
         burnFeeMutez: 0,
@@ -69,6 +69,52 @@ describe("estimate", () => {
     const processedEstimateResult = {
       ...accountOperations,
       estimates: [executeParams({ fee: 289, gasLimit: 169 })],
+    };
+
+    jest.mocked(makeToolkit).mockImplementation(
+      () =>
+        ({
+          estimate: {
+            batch: jest.fn().mockResolvedValue(estimateResult),
+          },
+        }) as any
+    );
+
+    const result = await estimate(accountOperations, GHOSTNET);
+
+    expect(result).toEqual(processedEstimateResult);
+  });
+
+  it("can deal with the reveal estimation", async () => {
+    const estimateResult = [
+      {
+        burnFeeMutez: 0,
+        consumedMilligas: 1,
+        gasLimit: 2,
+        minimalFeeMutez: 3,
+        operationFeeMutez: 4,
+        storageLimit: 5,
+        suggestedFeeMutez: 6,
+        totalCost: 7,
+        usingBaseFeeMutez: 8,
+      },
+      {
+        burnFeeMutez: 0,
+        consumedMilligas: 168681,
+        gasLimit: 169,
+        minimalFeeMutez: 269,
+        operationFeeMutez: 168.9,
+        storageLimit: 0,
+        suggestedFeeMutez: 289,
+        totalCost: 269,
+        usingBaseFeeMutez: 269,
+      },
+    ];
+
+    const processedEstimateResult = {
+      ...accountOperations,
+      estimates: [executeParams({ fee: 289, gasLimit: 169 })],
+      revealEstimate: executeParams({ fee: 7, gasLimit: 2, storageLimit: 5 }),
     };
 
     jest.mocked(makeToolkit).mockImplementation(

--- a/src/utils/tezos/helpers.ts
+++ b/src/utils/tezos/helpers.ts
@@ -17,23 +17,19 @@ import {
   makeMultisigProposeOperation,
 } from "../../types/Operation";
 import { SignerConfig } from "../../types/SignerConfig";
-import { RawTzktGetAddressType } from "../tzkt/types";
+import { RawTzktAccountType } from "../tzkt/types";
 
 export type PublicKeyPair = {
   pk: string;
   pkh: string;
 };
 
-export const addressExists = async (pkh: string, network: Network): Promise<boolean> => {
-  try {
-    const url = `${network.tzktApiUrl}/v1/accounts/${pkh}`;
-    const {
-      data: { type },
-    } = await axios.get<RawTzktGetAddressType>(url);
-    return type !== "empty";
-  } catch (error: any) {
-    throw new Error(`Error fetching account from tzkt ${error.message}`);
-  }
+export const isAccountRevealed = async (pkh: string, network: Network): Promise<boolean> => {
+  const url = `${network.tzktApiUrl}/v1/accounts/${pkh}`;
+  const {
+    data: { type, revealed },
+  } = await axios.get<{ type: RawTzktAccountType; revealed: boolean }>(url);
+  return type !== "empty" && revealed;
 };
 
 // Temporary solution for generating fingerprint for seedphrase

--- a/src/utils/tzkt/types.ts
+++ b/src/utils/tzkt/types.ts
@@ -1,6 +1,11 @@
-export type RawTzktGetAddressType = {
-  type: "user" | "delegate" | "contract" | "ghost" | "rollup" | "smart_rollup" | "empty";
-};
+export type RawTzktAccountType =
+  | "user"
+  | "delegate"
+  | "contract"
+  | "ghost"
+  | "rollup"
+  | "smart_rollup"
+  | "empty";
 
 export type RawTzktGetSameMultisigsItem = {
   address: string;


### PR DESCRIPTION
## Proposed changes

New accounts, even if they are funded, until there is a reveal operation, remain unrevealed, meaning that the signer has to execute a reveal operation before making any others.
Taquito deals with that by prepending the reveal operation to the operations list on the estimation and it returns the estimation of it as the first in the estimates list.  

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] UI fix
