### PR TITLE
Fix linux builds

### DIFF
--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -30,6 +30,7 @@ win:
     - sha256
   certificateSubjectName: TRILITECH LIMITED
 linux:
+  artifactName: umami-${version}.${arch}.${ext}
   icon: icons/
   target:
     - deb
@@ -38,6 +39,7 @@ linux:
   mimeTypes:
     - x-scheme-handler/umami
 deb:
+  artifactName: umami_${version}_${arch}.${ext}
   depends:
     - libasound2
     - libnotify4


### PR DESCRIPTION
## Proposed changes

electron builder doesn't play well with monorepo setup (on linux only) so we have to rename the artifacts ourselves, otherwise, it fails with "I cannot create a dist/@umami/desktop folder blablabla"

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] UI fix
