### PR TITLE
Fix beacon signing

### DIFF
--- a/apps/desktop/src/components/SendFlow/Beacon/BatchSignPage.tsx
+++ b/apps/desktop/src/components/SendFlow/Beacon/BatchSignPage.tsx
@@ -36,7 +36,7 @@ export const BatchSignPage: React.FC<BeaconSignPageProps> = ({ operation, messag
           <Header message={message} mode="batch" operation={operation} />
 
           <ModalBody>
-            <Accordion allowToggle={true}>
+            <Accordion allowToggle>
               <AccordionItem background={colors.gray[800]} border="none" borderRadius="8px">
                 <AccordionButton>
                   <Heading flex="1" textAlign="left" paddingY="6px" size="sm">

--- a/apps/desktop/src/components/SendFlow/Beacon/FinalizeUnstakeSignPage.tsx
+++ b/apps/desktop/src/components/SendFlow/Beacon/FinalizeUnstakeSignPage.tsx
@@ -1,4 +1,5 @@
 import { Flex, FormLabel, ModalBody, ModalContent, ModalFooter } from "@chakra-ui/react";
+import { FormProvider } from "react-hook-form";
 
 import { type BeaconSignPageProps } from "./BeaconSignPageProps";
 import { Header } from "./Header";
@@ -11,35 +12,37 @@ import { SignPageFee } from "../SignPageFee";
 import { headerText } from "../SignPageHeader";
 
 export const FinalizeUnstakeSignPage: React.FC<BeaconSignPageProps> = ({ operation, message }) => {
-  const { isSigning, onSign, network, fee } = useSignWithBeacon(operation, message);
+  const { isSigning, onSign, network, fee, form } = useSignWithBeacon(operation, message);
   const totalFinalizableAmount = useAccountTotalFinalizableUnstakeAmount(
     operation.signer.address.pkh
   );
   return (
-    <ModalContent>
-      <form>
-        <Header message={message} mode="single" operation={operation} />
-        <ModalBody>
-          <Flex alignItems="center" justifyContent="end" marginTop="12px">
-            <SignPageFee fee={fee} />
-          </Flex>
+    <FormProvider {...form}>
+      <ModalContent>
+        <form>
+          <Header message={message} mode="single" operation={operation} />
+          <ModalBody>
+            <Flex alignItems="center" justifyContent="end" marginTop="12px">
+              <SignPageFee fee={fee} />
+            </Flex>
 
-          <FormLabel marginTop="24px">From</FormLabel>
-          <AddressTile address={operation.sender.address} />
+            <FormLabel marginTop="24px">From</FormLabel>
+            <AddressTile address={operation.sender.address} />
 
-          <FormLabel marginTop="24px">Finalize Unstake</FormLabel>
-          <TezTile mutezAmount={totalFinalizableAmount} />
-        </ModalBody>
-        <ModalFooter>
-          <SignButton
-            isLoading={isSigning}
-            network={network}
-            onSubmit={onSign}
-            signer={operation.signer}
-            text={headerText(operation.type, "single")}
-          />
-        </ModalFooter>
-      </form>
-    </ModalContent>
+            <FormLabel marginTop="24px">Finalize Unstake</FormLabel>
+            <TezTile mutezAmount={totalFinalizableAmount} />
+          </ModalBody>
+          <ModalFooter>
+            <SignButton
+              isLoading={isSigning}
+              network={network}
+              onSubmit={onSign}
+              signer={operation.signer}
+              text={headerText(operation.type, "single")}
+            />
+          </ModalFooter>
+        </form>
+      </ModalContent>
+    </FormProvider>
   );
 };

--- a/apps/desktop/src/components/SendFlow/Beacon/StakeSignPage.tsx
+++ b/apps/desktop/src/components/SendFlow/Beacon/StakeSignPage.tsx
@@ -1,4 +1,5 @@
 import { Flex, FormLabel, ModalBody, ModalContent, ModalFooter } from "@chakra-ui/react";
+import { FormProvider } from "react-hook-form";
 
 import { type BeaconSignPageProps } from "./BeaconSignPageProps";
 import { Header } from "./Header";
@@ -13,33 +14,35 @@ import { headerText } from "../SignPageHeader";
 export const StakeSignPage: React.FC<BeaconSignPageProps> = ({ operation, message }) => {
   const { amount: mutezAmount } = operation.operations[0] as Stake;
 
-  const { isSigning, onSign, network, fee } = useSignWithBeacon(operation, message);
+  const { isSigning, onSign, network, fee, form } = useSignWithBeacon(operation, message);
 
   return (
-    <ModalContent>
-      <form>
-        <Header message={message} mode="single" operation={operation} />
-        <ModalBody>
-          <Flex alignItems="center" justifyContent="end" marginTop="12px">
-            <SignPageFee fee={fee} />
-          </Flex>
+    <FormProvider {...form}>
+      <ModalContent>
+        <form>
+          <Header message={message} mode="single" operation={operation} />
+          <ModalBody>
+            <Flex alignItems="center" justifyContent="end" marginTop="12px">
+              <SignPageFee fee={fee} />
+            </Flex>
 
-          <FormLabel marginTop="24px">From</FormLabel>
-          <AddressTile address={operation.sender.address} />
+            <FormLabel marginTop="24px">From</FormLabel>
+            <AddressTile address={operation.sender.address} />
 
-          <FormLabel marginTop="24px">Stake</FormLabel>
-          <TezTile mutezAmount={mutezAmount} />
-        </ModalBody>
-        <ModalFooter>
-          <SignButton
-            isLoading={isSigning}
-            network={network}
-            onSubmit={onSign}
-            signer={operation.signer}
-            text={headerText(operation.type, "single")}
-          />
-        </ModalFooter>
-      </form>
-    </ModalContent>
+            <FormLabel marginTop="24px">Stake</FormLabel>
+            <TezTile mutezAmount={mutezAmount} />
+          </ModalBody>
+          <ModalFooter>
+            <SignButton
+              isLoading={isSigning}
+              network={network}
+              onSubmit={onSign}
+              signer={operation.signer}
+              text={headerText(operation.type, "single")}
+            />
+          </ModalFooter>
+        </form>
+      </ModalContent>
+    </FormProvider>
   );
 };

--- a/apps/desktop/src/components/SendFlow/Beacon/UnstakeSignPage.tsx
+++ b/apps/desktop/src/components/SendFlow/Beacon/UnstakeSignPage.tsx
@@ -1,4 +1,5 @@
 import { Flex, FormLabel, ModalBody, ModalContent, ModalFooter } from "@chakra-ui/react";
+import { FormProvider } from "react-hook-form";
 
 import { type BeaconSignPageProps } from "./BeaconSignPageProps";
 import { Header } from "./Header";
@@ -13,33 +14,35 @@ import { headerText } from "../SignPageHeader";
 export const UnstakeSignPage: React.FC<BeaconSignPageProps> = ({ operation, message }) => {
   const { amount: mutezAmount } = operation.operations[0] as Unstake;
 
-  const { isSigning, onSign, network, fee } = useSignWithBeacon(operation, message);
+  const { isSigning, onSign, network, fee, form } = useSignWithBeacon(operation, message);
 
   return (
-    <ModalContent>
-      <form>
-        <Header message={message} mode="single" operation={operation} />
-        <ModalBody>
-          <Flex alignItems="center" justifyContent="end" marginTop="12px">
-            <SignPageFee fee={fee} />
-          </Flex>
+    <FormProvider {...form}>
+      <ModalContent>
+        <form>
+          <Header message={message} mode="single" operation={operation} />
+          <ModalBody>
+            <Flex alignItems="center" justifyContent="end" marginTop="12px">
+              <SignPageFee fee={fee} />
+            </Flex>
 
-          <FormLabel marginTop="24px">From</FormLabel>
-          <AddressTile address={operation.sender.address} />
+            <FormLabel marginTop="24px">From</FormLabel>
+            <AddressTile address={operation.sender.address} />
 
-          <FormLabel marginTop="24px">Unstake</FormLabel>
-          <TezTile mutezAmount={mutezAmount} />
-        </ModalBody>
-        <ModalFooter>
-          <SignButton
-            isLoading={isSigning}
-            network={network}
-            onSubmit={onSign}
-            signer={operation.signer}
-            text={headerText(operation.type, "single")}
-          />
-        </ModalFooter>
-      </form>
-    </ModalContent>
+            <FormLabel marginTop="24px">Unstake</FormLabel>
+            <TezTile mutezAmount={mutezAmount} />
+          </ModalBody>
+          <ModalFooter>
+            <SignButton
+              isLoading={isSigning}
+              network={network}
+              onSubmit={onSign}
+              signer={operation.signer}
+              text={headerText(operation.type, "single")}
+            />
+          </ModalFooter>
+        </form>
+      </ModalContent>
+    </FormProvider>
   );
 };

--- a/apps/desktop/src/mocks/modal.tsx
+++ b/apps/desktop/src/mocks/modal.tsx
@@ -1,0 +1,37 @@
+import { type PropsWithChildren, createContext, useContext } from "react";
+
+const ModalContext = createContext<{ onClose: () => void }>({ onClose: () => {} });
+
+export const MockModal = ({
+  children,
+  isOpen,
+  onClose,
+}: PropsWithChildren<{ isOpen: boolean; onClose: () => void }>) => (
+  <ModalContext.Provider value={{ onClose }}>
+    <div data-testid="mock-modal">{isOpen ? children : null}</div>
+  </ModalContext.Provider>
+);
+
+export const MockModalHeader = ({ children }: PropsWithChildren<object>) => (
+  <div id="modal-header">{children}</div>
+);
+
+export const MockModalContent = ({ children }: PropsWithChildren<object>) => (
+  <section aria-labelledby="modal-header" aria-modal role="dialog">
+    {children}
+  </section>
+);
+
+export const MockModalInnerComponent = ({ children }: PropsWithChildren<object>) => (
+  <div>{children}</div>
+);
+
+export const MockModalCloseButton = ({ children }: PropsWithChildren<object>) => {
+  const { onClose } = useContext(ModalContext);
+
+  return (
+    <button aria-label="Close" onClick={onClose} type="button">
+      {children}
+    </button>
+  );
+};

--- a/apps/desktop/src/setupTests.ts
+++ b/apps/desktop/src/setupTests.ts
@@ -10,8 +10,14 @@ import { TextDecoder, TextEncoder } from "util";
 import { setupJestCanvasMock } from "jest-canvas-mock";
 import failOnConsole from "jest-fail-on-console";
 import MockDate from "mockdate";
-import React from "react";
 
+import {
+  MockModal,
+  MockModalCloseButton,
+  MockModalContent,
+  MockModalHeader,
+  MockModalInnerComponent,
+} from "./mocks/modal";
 import { mockUseToast } from "./mocks/toast";
 import { accountsSlice } from "./utils/redux/slices/accountsSlice/accountsSlice";
 import { announcementSlice } from "./utils/redux/slices/announcementSlice";
@@ -70,24 +76,6 @@ beforeEach(() => {
 
   setupJestCanvasMock();
 });
-
-const MockModal = ({ children, isOpen }: any) =>
-  React.createElement("div", { "data-testid": "mock-modal" }, isOpen ? children : null);
-
-const MockModalHeader = ({ children }: any) =>
-  React.createElement("header", { id: "modal-header" }, children);
-
-const MockModalContent = ({ children }: any) =>
-  React.createElement(
-    "section",
-    { role: "dialog", "aria-labelledby": "modal-header", "aria-modal": true },
-    children
-  );
-
-const MockModalInnerComponent = ({ children }: any) => React.createElement("div", {}, children);
-
-const MockModalCloseButton = ({ children }: any) =>
-  React.createElement("button", { "aria-label": "Close" }, children);
 
 jest.mock("@chakra-ui/react", () => ({
   ...jest.requireActual("@chakra-ui/react"),

--- a/apps/desktop/src/utils/beacon/PermissionRequestModal.tsx
+++ b/apps/desktop/src/utils/beacon/PermissionRequestModal.tsx
@@ -1,5 +1,4 @@
 import {
-  BeaconErrorType,
   BeaconMessageType,
   type BeaconResponseInputMessage,
   type PermissionRequestOutput,
@@ -29,7 +28,6 @@ import type React from "react";
 import { useContext } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 
-import { useRemovePeerBySenderId } from "./beacon";
 import { WalletClient } from "./WalletClient";
 import { JsValueWrap } from "../../components/AccountDrawer/JsValueWrap";
 import { OwnedImplicitAccountsAutocomplete } from "../../components/AddressAutocomplete";
@@ -53,16 +51,6 @@ export const PermissionRequestModal: React.FC<{
     getValues,
     formState: { errors, isValid },
   } = form;
-  const removePeer = useRemovePeerBySenderId();
-
-  const onModalClose = () => {
-    void removePeer(request.senderId);
-    void WalletClient.respond({
-      id: request.id,
-      type: BeaconMessageType.Error,
-      errorType: BeaconErrorType.NOT_GRANTED_ERROR,
-    });
-  };
 
   const grant = () =>
     handleAsyncAction(async () => {
@@ -101,7 +89,7 @@ export const PermissionRequestModal: React.FC<{
           </Text>
         </Flex>
       </ModalHeader>
-      <ModalCloseButton onClick={onModalClose} />
+      <ModalCloseButton />
       <ModalBody data-testid="beacon-request-body">
         <Flex
           alignItems="center"

--- a/apps/desktop/src/utils/beacon/SignPayloadRequestModal.tsx
+++ b/apps/desktop/src/utils/beacon/SignPayloadRequestModal.tsx
@@ -1,5 +1,4 @@
 import {
-  BeaconErrorType,
   BeaconMessageType,
   type SignPayloadRequestOutput,
   type SignPayloadResponseInput,
@@ -20,7 +19,6 @@ import type React from "react";
 import { useContext } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 
-import { useRemovePeerBySenderId } from "./beacon";
 import { decodePayload } from "./decodePayload";
 import { WalletClient } from "./WalletClient";
 import { DynamicModalContext } from "../../components/DynamicModal";
@@ -35,17 +33,7 @@ export const SignPayloadRequestModal: React.FC<{
   const getAccount = useGetImplicitAccount();
   const signerAccount = getAccount(request.sourceAddress);
   const toast = useToast();
-  const removePeer = useRemovePeerBySenderId();
   const form = useForm();
-
-  const onModalClose = () => {
-    void removePeer(request.senderId);
-    void WalletClient.respond({
-      id: request.id,
-      type: BeaconMessageType.Error,
-      errorType: BeaconErrorType.ABORTED_ERROR,
-    });
-  };
 
   const sign = async (tezosToolkit: TezosToolkit) => {
     const result = await tezosToolkit.signer.sign(request.payload);
@@ -72,7 +60,7 @@ export const SignPayloadRequestModal: React.FC<{
         <ModalHeader marginBottom="32px" textAlign="center">
           Connect with pairing request
         </ModalHeader>
-        <ModalCloseButton onClick={onModalClose} />
+        <ModalCloseButton />
 
         <ModalBody>
           <Heading marginBottom="12px" size="l">

--- a/apps/desktop/src/views/batch/BatchView.tsx
+++ b/apps/desktop/src/views/batch/BatchView.tsx
@@ -46,7 +46,7 @@ const RightHeader: React.FC<{
         aria-label="remove-batch"
         data-testid="remove-batch"
         icon={<TrashIcon stroke={colors.gray[300]} />}
-        onClick={() => openWith(<ClearBatchConfirmationModal sender={sender} />, "sm")}
+        onClick={() => openWith(<ClearBatchConfirmationModal sender={sender} />, { size: "sm" })}
         variant="circle"
       />
     </Box>


### PR DESCRIPTION
## Proposed changes

1. Beacon staking operations components weren't wrapped into a FormProvider, and signing didn't work.
2. When beacon operation modal was closed, it wouldn't send an error to the dapp

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] UI fix

## Steps to reproduce

## Screenshots

Add the screenshots of how the app used to look like and how it looks now

| Before | Now |
| ------ | --- |
| https://github.com/trilitech/umami-v2/assets/129749432/ad6ca28d-51ce-4a35-9391-ddee1923e130 | https://github.com/trilitech/umami-v2/assets/129749432/5cff1f49-0143-4848-aaef-91f93d175085 |
| https://github.com/trilitech/umami-v2/assets/129749432/934fc9cb-ca88-423d-b2e6-9f44e8993ee8 | https://github.com/trilitech/umami-v2/assets/129749432/6a85c3cb-f743-42cd-8074-b5a6204e8a3c |


## Checklist

- [x] Tests that prove my fix is effective or that my feature works have been added
- [ ] Documentation has been added (if appropriate)
- [x] Screenshots are added (if any UI changes have been made)
