### PR TITLE
Remove default imports from react

### DIFF
--- a/apps/desktop/src/assets/icons/Accounts.tsx
+++ b/apps/desktop/src/assets/icons/Accounts.tsx
@@ -2,7 +2,7 @@ import { Icon, type IconProps } from "@chakra-ui/react";
 
 import colors from "../../style/colors";
 
-export const AccountsIcon: React.FC<IconProps> = props => (
+export const AccountsIcon = (props: IconProps) => (
   <Icon
     width="24px"
     height="24px"

--- a/apps/desktop/src/assets/icons/AddAccount.tsx
+++ b/apps/desktop/src/assets/icons/AddAccount.tsx
@@ -2,7 +2,7 @@ import { Icon, type IconProps } from "@chakra-ui/react";
 
 import colors from "../../style/colors";
 
-export const AddAccountIcon: React.FC<IconProps> = props => (
+export const AddAccountIcon = (props: IconProps) => (
   <Icon
     width="18px"
     height="18px"

--- a/apps/desktop/src/assets/icons/AddContact.tsx
+++ b/apps/desktop/src/assets/icons/AddContact.tsx
@@ -1,6 +1,6 @@
 import { Icon, type IconProps } from "@chakra-ui/react";
 
-export const AddContactIcon: React.FC<IconProps> = props => (
+export const AddContactIcon = (props: IconProps) => (
   <Icon fill="none" viewBox="0 0 13 17" xmlns="http://www.w3.org/2000/svg" {...props}>
     <path
       d="M13 12.5L10.75 12.5M10.75 12.5L8.5 12.5M10.75 12.5V10.25M10.75 12.5V14.75M6.25 14.75H1C1 11.8505 3.35051 9.5 6.25 9.5C6.77123 9.5 7.27472 9.57596 7.75 9.71741M9.25 4.25C9.25 5.90685 7.90685 7.25 6.25 7.25C4.59315 7.25 3.25 5.90685 3.25 4.25C3.25 2.59315 4.59315 1.25 6.25 1.25C7.90685 1.25 9.25 2.59315 9.25 4.25Z"

--- a/apps/desktop/src/assets/icons/AddressBook.tsx
+++ b/apps/desktop/src/assets/icons/AddressBook.tsx
@@ -2,7 +2,7 @@ import { Icon, type IconProps } from "@chakra-ui/react";
 
 import colors from "../../style/colors";
 
-export const AddressBookIcon: React.FC<IconProps> = props => (
+export const AddressBookIcon = (props: IconProps) => (
   <Icon
     width="24px"
     height="24px"

--- a/apps/desktop/src/assets/icons/Baker.tsx
+++ b/apps/desktop/src/assets/icons/Baker.tsx
@@ -2,7 +2,7 @@ import { Icon, type IconProps } from "@chakra-ui/react";
 
 import colors from "../../style/colors";
 
-export const BakerIcon: React.FC<IconProps> = props => (
+export const BakerIcon = (props: IconProps) => (
   <Icon
     width="18px"
     height="18px"

--- a/apps/desktop/src/assets/icons/Batch.tsx
+++ b/apps/desktop/src/assets/icons/Batch.tsx
@@ -2,7 +2,7 @@ import { Icon, type IconProps } from "@chakra-ui/react";
 
 import colors from "../../style/colors";
 
-export const BatchIcon: React.FC<IconProps> = props => (
+export const BatchIcon = (props: IconProps) => (
   <Icon
     width="24px"
     height="24px"

--- a/apps/desktop/src/assets/icons/BurgerMenu.tsx
+++ b/apps/desktop/src/assets/icons/BurgerMenu.tsx
@@ -2,7 +2,7 @@ import { Icon, type IconProps } from "@chakra-ui/react";
 
 import colors from "../../style/colors";
 
-export const BurgerMenuIcon: React.FC<IconProps> = props => (
+export const BurgerMenuIcon = (props: IconProps) => (
   <Icon
     width="24px"
     height="24px"

--- a/apps/desktop/src/assets/icons/CheckIcon.tsx
+++ b/apps/desktop/src/assets/icons/CheckIcon.tsx
@@ -1,6 +1,6 @@
 import { Icon, type IconProps } from "@chakra-ui/react";
 
-export const CheckIcon: React.FC<IconProps> = props => (
+export const CheckIcon = (props: IconProps) => (
   <Icon
     width="15px"
     height="11px"

--- a/apps/desktop/src/assets/icons/Checkmark.tsx
+++ b/apps/desktop/src/assets/icons/Checkmark.tsx
@@ -1,6 +1,6 @@
 import { Icon, type IconProps } from "@chakra-ui/react";
 
-export const CheckmarkIcon: React.FC<IconProps> = props => (
+export const CheckmarkIcon = (props: IconProps) => (
   <Icon
     width="18px"
     height="18px"

--- a/apps/desktop/src/assets/icons/ChevronDown.tsx
+++ b/apps/desktop/src/assets/icons/ChevronDown.tsx
@@ -2,7 +2,7 @@ import { Icon, type IconProps } from "@chakra-ui/react";
 
 import colors from "../../style/colors";
 
-export const ChevronDownIcon: React.FC<IconProps> = props => (
+export const ChevronDownIcon = (props: IconProps) => (
   <Icon
     width="18px"
     height="18px"

--- a/apps/desktop/src/assets/icons/ChevronRight.tsx
+++ b/apps/desktop/src/assets/icons/ChevronRight.tsx
@@ -2,7 +2,7 @@ import { Icon, type IconProps } from "@chakra-ui/react";
 
 import colors from "../../style/colors";
 
-export const ChevronRightIcon: React.FC<IconProps> = props => (
+export const ChevronRightIcon = (props: IconProps) => (
   <Icon
     width="18px"
     height="18px"

--- a/apps/desktop/src/assets/icons/ChevronUp.tsx
+++ b/apps/desktop/src/assets/icons/ChevronUp.tsx
@@ -2,7 +2,7 @@ import { Icon, type IconProps } from "@chakra-ui/react";
 
 import colors from "../../style/colors";
 
-export const ChevronUpIcon: React.FC<IconProps> = props => (
+export const ChevronUpIcon = (props: IconProps) => (
   <Icon
     width="18px"
     height="18px"

--- a/apps/desktop/src/assets/icons/Coin.tsx
+++ b/apps/desktop/src/assets/icons/Coin.tsx
@@ -2,7 +2,7 @@ import { Icon, type IconProps } from "@chakra-ui/react";
 
 import colors from "../../style/colors";
 
-export const CoinIcon: React.FC<IconProps> = props => (
+export const CoinIcon = (props: IconProps) => (
   <Icon
     width="24px"
     height="24px"

--- a/apps/desktop/src/assets/icons/Contact.tsx
+++ b/apps/desktop/src/assets/icons/Contact.tsx
@@ -1,6 +1,6 @@
 import { Icon, type IconProps } from "@chakra-ui/react";
 
-export const ContactIcon: React.FC<IconProps> = props => (
+export const ContactIcon = (props: IconProps) => (
   <Icon
     width="18px"
     height="18px"

--- a/apps/desktop/src/assets/icons/Contract.tsx
+++ b/apps/desktop/src/assets/icons/Contract.tsx
@@ -2,7 +2,7 @@ import { Icon, type IconProps } from "@chakra-ui/react";
 
 import colors from "../../style/colors";
 
-export const ContractIcon: React.FC<IconProps> = props => (
+export const ContractIcon = (props: IconProps) => (
   <Icon
     width="18px"
     height="18px"

--- a/apps/desktop/src/assets/icons/CrossedCircle.tsx
+++ b/apps/desktop/src/assets/icons/CrossedCircle.tsx
@@ -1,6 +1,6 @@
 import { Icon, type IconProps } from "@chakra-ui/react";
 
-export const CrossedCircleIcon: React.FC<IconProps> = props => (
+export const CrossedCircleIcon = (props: IconProps) => (
   <Icon
     width="18px"
     height="18px"

--- a/apps/desktop/src/assets/icons/Diamond.tsx
+++ b/apps/desktop/src/assets/icons/Diamond.tsx
@@ -2,7 +2,7 @@ import { Icon, type IconProps } from "@chakra-ui/react";
 
 import colors from "../../style/colors";
 
-export const DiamondIcon: React.FC<IconProps> = props => (
+export const DiamondIcon = (props: IconProps) => (
   <Icon
     width="24px"
     height="24px"

--- a/apps/desktop/src/assets/icons/Document.tsx
+++ b/apps/desktop/src/assets/icons/Document.tsx
@@ -2,7 +2,7 @@ import { Icon, type IconProps } from "@chakra-ui/react";
 
 import colors from "../../style/colors";
 
-export const DocumentIcon: React.FC<IconProps> = props => (
+export const DocumentIcon = (props: IconProps) => (
   <Icon
     width="24px"
     height="24px"

--- a/apps/desktop/src/assets/icons/DoubleCheckmark.tsx
+++ b/apps/desktop/src/assets/icons/DoubleCheckmark.tsx
@@ -2,7 +2,7 @@ import { Icon, type IconProps } from "@chakra-ui/react";
 
 import colors from "../../style/colors";
 
-export const DoubleCheckmarkIcon: React.FC<IconProps> = props => (
+export const DoubleCheckmarkIcon = (props: IconProps) => (
   <Icon
     width="24px"
     height="24px"

--- a/apps/desktop/src/assets/icons/Download.tsx
+++ b/apps/desktop/src/assets/icons/Download.tsx
@@ -2,7 +2,7 @@ import { Icon, type IconProps } from "@chakra-ui/react";
 
 import colors from "../../style/colors";
 
-export const DownloadIcon: React.FC<IconProps> = props => (
+export const DownloadIcon = (props: IconProps) => (
   <Icon
     width="16px"
     height="16px"

--- a/apps/desktop/src/assets/icons/EditAccount.tsx
+++ b/apps/desktop/src/assets/icons/EditAccount.tsx
@@ -2,7 +2,7 @@ import { Icon, type IconProps } from "@chakra-ui/react";
 
 import colors from "../../style/colors";
 
-export const EditAccountIcon: React.FC<IconProps> = props => (
+export const EditAccountIcon = (props: IconProps) => (
   <Icon
     width="24px"
     height="24px"

--- a/apps/desktop/src/assets/icons/Email.tsx
+++ b/apps/desktop/src/assets/icons/Email.tsx
@@ -1,6 +1,6 @@
 import { Icon, type IconProps } from "@chakra-ui/react";
 
-export const EmailIcon: React.FC<IconProps> = props => (
+export const EmailIcon = (props: IconProps) => (
   <Icon
     width="28px"
     height="28px"

--- a/apps/desktop/src/assets/icons/Exclamation.tsx
+++ b/apps/desktop/src/assets/icons/Exclamation.tsx
@@ -2,7 +2,7 @@ import { Icon, type IconProps } from "@chakra-ui/react";
 
 import colors from "../../style/colors";
 
-export const ExclamationIcon: React.FC<IconProps> = props => (
+export const ExclamationIcon = (props: IconProps) => (
   <Icon
     width="12px"
     height="12px"

--- a/apps/desktop/src/assets/icons/ExitArrow.tsx
+++ b/apps/desktop/src/assets/icons/ExitArrow.tsx
@@ -2,7 +2,7 @@ import { Icon, type IconProps } from "@chakra-ui/react";
 
 import colors from "../../style/colors";
 
-export const ExitArrowIcon: React.FC<IconProps> = props => (
+export const ExitArrowIcon = (props: IconProps) => (
   <Icon
     width="24px"
     height="24px"

--- a/apps/desktop/src/assets/icons/ExternalLink.tsx
+++ b/apps/desktop/src/assets/icons/ExternalLink.tsx
@@ -2,7 +2,7 @@ import { Icon, type IconProps } from "@chakra-ui/react";
 
 import colors from "../../style/colors";
 
-export const ExternalLinkIcon: React.FC<IconProps> = props => (
+export const ExternalLinkIcon = (props: IconProps) => (
   <Icon
     width="18px"
     height="18px"

--- a/apps/desktop/src/assets/icons/Eye.tsx
+++ b/apps/desktop/src/assets/icons/Eye.tsx
@@ -2,7 +2,7 @@ import { Icon, type IconProps } from "@chakra-ui/react";
 
 import colors from "../../style/colors";
 
-export const EyeIcon: React.FC<IconProps> = props => (
+export const EyeIcon = (props: IconProps) => (
   <Icon
     width="16px"
     height="12px"

--- a/apps/desktop/src/assets/icons/EyeSlash.tsx
+++ b/apps/desktop/src/assets/icons/EyeSlash.tsx
@@ -2,7 +2,7 @@ import { Icon, type IconProps } from "@chakra-ui/react";
 
 import colors from "../../style/colors";
 
-export const EyeSlashIcon: React.FC<IconProps> = props => (
+export const EyeSlashIcon = (props: IconProps) => (
   <Icon
     width="18px"
     height="18px"

--- a/apps/desktop/src/assets/icons/FA1.2.tsx
+++ b/apps/desktop/src/assets/icons/FA1.2.tsx
@@ -2,7 +2,7 @@ import { Icon, type IconProps } from "@chakra-ui/react";
 
 import colors from "../../style/colors";
 
-export const FA12Icon: React.FC<IconProps> = props => (
+export const FA12Icon = (props: IconProps) => (
   <Icon
     width="30px"
     height="15px"

--- a/apps/desktop/src/assets/icons/FA2.tsx
+++ b/apps/desktop/src/assets/icons/FA2.tsx
@@ -2,7 +2,7 @@ import { Icon, type IconProps } from "@chakra-ui/react";
 
 import colors from "../../style/colors";
 
-export const FA2Icon: React.FC<IconProps> = props => (
+export const FA2Icon = (props: IconProps) => (
   <Icon
     width="23px"
     height="18px"

--- a/apps/desktop/src/assets/icons/Facebook.tsx
+++ b/apps/desktop/src/assets/icons/Facebook.tsx
@@ -1,6 +1,6 @@
 import { Icon, type IconProps } from "@chakra-ui/react";
 
-export const FacebookIcon: React.FC<IconProps> = props => (
+export const FacebookIcon = (props: IconProps) => (
   <Icon
     width="28px"
     height="28px"

--- a/apps/desktop/src/assets/icons/Feedback.tsx
+++ b/apps/desktop/src/assets/icons/Feedback.tsx
@@ -2,7 +2,7 @@ import { Icon, type IconProps } from "@chakra-ui/react";
 
 import colors from "../../style/colors";
 
-export const FeedbackIcon: React.FC<IconProps> = props => (
+export const FeedbackIcon = (props: IconProps) => (
   <Icon
     width="24px"
     height="24px"

--- a/apps/desktop/src/assets/icons/Fetching.tsx
+++ b/apps/desktop/src/assets/icons/Fetching.tsx
@@ -2,7 +2,7 @@ import { Icon, type IconProps } from "@chakra-ui/react";
 
 import colors from "../../style/colors";
 
-export const FetchingIcon: React.FC<IconProps> = props => (
+export const FetchingIcon = (props: IconProps) => (
   <Icon
     width="19px"
     height="19px"

--- a/apps/desktop/src/assets/icons/FileArrowDown.tsx
+++ b/apps/desktop/src/assets/icons/FileArrowDown.tsx
@@ -2,7 +2,7 @@ import { Icon, type IconProps } from "@chakra-ui/react";
 
 import colors from "../../style/colors";
 
-export const FileArrowDownIcon: React.FC<IconProps> = props => (
+export const FileArrowDownIcon = (props: IconProps) => (
   <Icon
     width="18px"
     height="18px"

--- a/apps/desktop/src/assets/icons/FileCopy.tsx
+++ b/apps/desktop/src/assets/icons/FileCopy.tsx
@@ -1,6 +1,6 @@
 import { Icon, type IconProps } from "@chakra-ui/react";
 
-export const FileCopyIcon: React.FC<IconProps> = props => (
+export const FileCopyIcon = (props: IconProps) => (
   <Icon
     width="18px"
     height="18px"

--- a/apps/desktop/src/assets/icons/FlipForwardEnergy.tsx
+++ b/apps/desktop/src/assets/icons/FlipForwardEnergy.tsx
@@ -1,6 +1,6 @@
 import { Icon, type IconProps } from "@chakra-ui/react";
 
-export const FlipForwardEnergy: React.FC<IconProps> = props => (
+export const FlipForwardEnergy = (props: IconProps) => (
   <Icon
     width="18px"
     height="18px"

--- a/apps/desktop/src/assets/icons/FolderInfo.tsx
+++ b/apps/desktop/src/assets/icons/FolderInfo.tsx
@@ -2,7 +2,7 @@ import { Icon, type IconProps } from "@chakra-ui/react";
 
 import colors from "../../style/colors";
 
-export const FolderInfoIcon: React.FC<IconProps> = props => (
+export const FolderInfoIcon = (props: IconProps) => (
   <Icon
     width="24px"
     height="24px"

--- a/apps/desktop/src/assets/icons/Gear.tsx
+++ b/apps/desktop/src/assets/icons/Gear.tsx
@@ -2,7 +2,7 @@ import { Icon, type IconProps } from "@chakra-ui/react";
 
 import colors from "../../style/colors";
 
-export const GearIcon: React.FC<IconProps> = props => (
+export const GearIcon = (props: IconProps) => (
   <Icon
     width="24px"
     height="24px"

--- a/apps/desktop/src/assets/icons/Google.tsx
+++ b/apps/desktop/src/assets/icons/Google.tsx
@@ -1,6 +1,6 @@
 import { Icon, type IconProps } from "@chakra-ui/react";
 
-export const GoogleIcon: React.FC<IconProps> = props => (
+export const GoogleIcon = (props: IconProps) => (
   <Icon
     width="24px"
     height="24px"

--- a/apps/desktop/src/assets/icons/Help.tsx
+++ b/apps/desktop/src/assets/icons/Help.tsx
@@ -2,7 +2,7 @@ import { Icon, type IconProps } from "@chakra-ui/react";
 
 import colors from "../../style/colors";
 
-export const HelpIcon: React.FC<IconProps> = props => (
+export const HelpIcon = (props: IconProps) => (
   <Icon
     width="24px"
     height="24px"

--- a/apps/desktop/src/assets/icons/Hourglass.tsx
+++ b/apps/desktop/src/assets/icons/Hourglass.tsx
@@ -1,6 +1,6 @@
 import { Icon, type IconProps } from "@chakra-ui/react";
 
-export const HourglassIcon: React.FC<IconProps> = props => (
+export const HourglassIcon = (props: IconProps) => (
   <Icon
     width="18px"
     height="18px"

--- a/apps/desktop/src/assets/icons/IncomingArrow.tsx
+++ b/apps/desktop/src/assets/icons/IncomingArrow.tsx
@@ -2,6 +2,6 @@ import { type IconProps } from "@chakra-ui/react";
 
 import { OutgoingArrow } from "./OutgoingArrow";
 
-export const IncomingArrow: React.FC<IconProps> = props => (
+export const IncomingArrow = (props: IconProps) => (
   <OutgoingArrow css={{ rotate: "180deg" }} {...props} />
 );

--- a/apps/desktop/src/assets/icons/Key.tsx
+++ b/apps/desktop/src/assets/icons/Key.tsx
@@ -2,7 +2,7 @@ import { Icon, type IconProps } from "@chakra-ui/react";
 
 import colors from "../../style/colors";
 
-export const KeyIcon: React.FC<IconProps> = props => (
+export const KeyIcon = (props: IconProps) => (
   <Icon
     width="18px"
     height="18px"

--- a/apps/desktop/src/assets/icons/Ledger.tsx
+++ b/apps/desktop/src/assets/icons/Ledger.tsx
@@ -2,7 +2,7 @@ import { Icon, type IconProps } from "@chakra-ui/react";
 
 import colors from "../../style/colors";
 
-export const LedgerIcon: React.FC<IconProps> = props => (
+export const LedgerIcon = (props: IconProps) => (
   <Icon
     width="18px"
     height="18px"

--- a/apps/desktop/src/assets/icons/Link.tsx
+++ b/apps/desktop/src/assets/icons/Link.tsx
@@ -2,7 +2,7 @@ import { Icon, type IconProps } from "@chakra-ui/react";
 
 import colors from "../../style/colors";
 
-export const LinkIcon: React.FC<IconProps> = props => (
+export const LinkIcon = (props: IconProps) => (
   <Icon
     width="24px"
     height="24px"

--- a/apps/desktop/src/assets/icons/Lock.tsx
+++ b/apps/desktop/src/assets/icons/Lock.tsx
@@ -2,7 +2,7 @@ import { Icon, type IconProps } from "@chakra-ui/react";
 
 import colors from "../../style/colors";
 
-export const LockIcon: React.FC<IconProps> = props => (
+export const LockIcon = (props: IconProps) => (
   <Icon
     width="24px"
     height="24px"

--- a/apps/desktop/src/assets/icons/Maintenance.tsx
+++ b/apps/desktop/src/assets/icons/Maintenance.tsx
@@ -1,6 +1,6 @@
 import { Icon, type IconProps } from "@chakra-ui/react";
 
-export const MaintenanceIcon: React.FC<IconProps> = props => (
+export const MaintenanceIcon = (props: IconProps) => (
   <Icon
     width="18px"
     height="18px"

--- a/apps/desktop/src/assets/icons/Maki.tsx
+++ b/apps/desktop/src/assets/icons/Maki.tsx
@@ -1,6 +1,6 @@
 import { Icon, type IconProps } from "@chakra-ui/react";
 
-export const MakiIcon: React.FC<IconProps & { fishColor: string }> = ({ fishColor, ...props }) => (
+export const MakiIcon = ({ fishColor, ...props }: IconProps & { fishColor: string }) => (
   <Icon
     width="38px"
     height="38px"

--- a/apps/desktop/src/assets/icons/Notice.tsx
+++ b/apps/desktop/src/assets/icons/Notice.tsx
@@ -2,7 +2,7 @@ import { Icon, type IconProps } from "@chakra-ui/react";
 
 import colors from "../../style/colors";
 
-export const NoticeIcon: React.FC<IconProps> = props => (
+export const NoticeIcon = (props: IconProps) => (
   <Icon
     width="24px"
     height="24px"

--- a/apps/desktop/src/assets/icons/OutgoingArrow.tsx
+++ b/apps/desktop/src/assets/icons/OutgoingArrow.tsx
@@ -2,7 +2,7 @@ import { Icon, type IconProps } from "@chakra-ui/react";
 
 import colors from "../../style/colors";
 
-export const OutgoingArrow: React.FC<IconProps> = props => (
+export const OutgoingArrow = (props: IconProps) => (
   <Icon
     width="18px"
     height="18px"

--- a/apps/desktop/src/assets/icons/OutlineExclamationCircle.tsx
+++ b/apps/desktop/src/assets/icons/OutlineExclamationCircle.tsx
@@ -2,7 +2,7 @@ import { Icon, type IconProps } from "@chakra-ui/react";
 
 import colors from "../../style/colors";
 
-export const OutlineExclamationCircleIcon: React.FC<IconProps> = props => (
+export const OutlineExclamationCircleIcon = (props: IconProps) => (
   <Icon
     width="16px"
     height="16px"

--- a/apps/desktop/src/assets/icons/Pen.tsx
+++ b/apps/desktop/src/assets/icons/Pen.tsx
@@ -2,7 +2,7 @@ import { Icon, type IconProps } from "@chakra-ui/react";
 
 import colors from "../../style/colors";
 
-export const PenIcon: React.FC<IconProps> = props => (
+export const PenIcon = (props: IconProps) => (
   <Icon
     width="18px"
     height="18px"

--- a/apps/desktop/src/assets/icons/Plus.tsx
+++ b/apps/desktop/src/assets/icons/Plus.tsx
@@ -2,7 +2,7 @@ import { Icon, type IconProps } from "@chakra-ui/react";
 
 import colors from "../../style/colors";
 
-export const PlusIcon: React.FC<IconProps> = props => (
+export const PlusIcon = (props: IconProps) => (
   <Icon
     width="24px"
     height="24px"

--- a/apps/desktop/src/assets/icons/Reddit.tsx
+++ b/apps/desktop/src/assets/icons/Reddit.tsx
@@ -1,6 +1,6 @@
 import { Icon, type IconProps } from "@chakra-ui/react";
 
-export const RedditIcon: React.FC<IconProps> = props => (
+export const RedditIcon = (props: IconProps) => (
   <Icon
     width="24px"
     height="24px"

--- a/apps/desktop/src/assets/icons/RefreshClock.tsx
+++ b/apps/desktop/src/assets/icons/RefreshClock.tsx
@@ -2,7 +2,7 @@ import { Icon, type IconProps } from "@chakra-ui/react";
 
 import colors from "../../style/colors";
 
-export const RefreshClockIcon: React.FC<IconProps> = props => (
+export const RefreshClockIcon = (props: IconProps) => (
   <Icon
     width="18"
     height="18"

--- a/apps/desktop/src/assets/icons/Reload.tsx
+++ b/apps/desktop/src/assets/icons/Reload.tsx
@@ -1,6 +1,6 @@
 import { Icon, type IconProps } from "@chakra-ui/react";
 
-export const ReloadIcon: React.FC<IconProps> = props => (
+export const ReloadIcon = (props: IconProps) => (
   <Icon
     width="22px"
     height="22px"

--- a/apps/desktop/src/assets/icons/Rotate.tsx
+++ b/apps/desktop/src/assets/icons/Rotate.tsx
@@ -2,7 +2,7 @@ import { Icon, type IconProps } from "@chakra-ui/react";
 
 import colors from "../../style/colors";
 
-export const RotateIcon: React.FC<IconProps> = props => (
+export const RotateIcon = (props: IconProps) => (
   <Icon
     width="24px"
     height="24px"

--- a/apps/desktop/src/assets/icons/Slash.tsx
+++ b/apps/desktop/src/assets/icons/Slash.tsx
@@ -2,7 +2,7 @@ import { Icon, type IconProps } from "@chakra-ui/react";
 
 import colors from "../../style/colors";
 
-export const SlashIcon: React.FC<IconProps> = props => (
+export const SlashIcon = (props: IconProps) => (
   <Icon
     width="24px"
     height="24px"

--- a/apps/desktop/src/assets/icons/Sliders.tsx
+++ b/apps/desktop/src/assets/icons/Sliders.tsx
@@ -2,7 +2,7 @@ import { Icon, type IconProps } from "@chakra-ui/react";
 
 import colors from "../../style/colors";
 
-export const SlidersIcon: React.FC<IconProps> = props => (
+export const SlidersIcon = (props: IconProps) => (
   <Icon
     width="32px"
     height="32px"

--- a/apps/desktop/src/assets/icons/ThreeDots.tsx
+++ b/apps/desktop/src/assets/icons/ThreeDots.tsx
@@ -2,7 +2,7 @@ import { Icon, type IconProps } from "@chakra-ui/react";
 
 import colors from "../../style/colors";
 
-export const ThreeDotsIcon: React.FC<IconProps> = props => (
+export const ThreeDotsIcon = (props: IconProps) => (
   <Icon
     width="18px"
     height="18px"

--- a/apps/desktop/src/assets/icons/Token.tsx
+++ b/apps/desktop/src/assets/icons/Token.tsx
@@ -1,7 +1,7 @@
 import { Image, type ImageProps } from "@chakra-ui/react";
 import { type RawPkh } from "@umami/tezos";
 
-export const TokenIcon: React.FC<{ contract: RawPkh } & ImageProps> = ({ contract, ...props }) => {
+export const TokenIcon = ({ contract, ...props }: { contract: RawPkh } & ImageProps) => {
   const url = `https://services.tzkt.io/v1/avatars/${contract}`;
   return <Image fallbackSrc="./static/media/coin-front.svg" src={url} {...props} />;
 };

--- a/apps/desktop/src/assets/icons/Trash.tsx
+++ b/apps/desktop/src/assets/icons/Trash.tsx
@@ -2,7 +2,7 @@ import { Icon, type IconProps } from "@chakra-ui/react";
 
 import colors from "../../style/colors";
 
-export const TrashIcon: React.FC<IconProps> = props => (
+export const TrashIcon = (props: IconProps) => (
   <Icon
     width="18px"
     height="18px"

--- a/apps/desktop/src/assets/icons/Twitter.tsx
+++ b/apps/desktop/src/assets/icons/Twitter.tsx
@@ -1,6 +1,6 @@
 import { Icon, type IconProps } from "@chakra-ui/react";
 
-export const TwitterIcon: React.FC<IconProps> = props => (
+export const TwitterIcon = (props: IconProps) => (
   <Icon
     width="20px"
     height="18px"

--- a/apps/desktop/src/assets/icons/USB.tsx
+++ b/apps/desktop/src/assets/icons/USB.tsx
@@ -2,7 +2,7 @@ import { Icon, type IconProps } from "@chakra-ui/react";
 
 import colors from "../../style/colors";
 
-export const USBIcon: React.FC<IconProps> = props => (
+export const USBIcon = (props: IconProps) => (
   <Icon
     width="24px"
     height="24px"

--- a/apps/desktop/src/assets/icons/UnknownContact.tsx
+++ b/apps/desktop/src/assets/icons/UnknownContact.tsx
@@ -1,6 +1,6 @@
 import { Icon, type IconProps } from "@chakra-ui/react";
 
-export const UnknownContactIcon: React.FC<IconProps> = props => (
+export const UnknownContactIcon = (props: IconProps) => (
   <Icon
     width="18px"
     height="18px"

--- a/apps/desktop/src/assets/icons/Verified.tsx
+++ b/apps/desktop/src/assets/icons/Verified.tsx
@@ -2,7 +2,7 @@ import { Flex, Icon, type IconProps } from "@chakra-ui/react";
 
 import colors from "../../style/colors";
 
-export const VerifiedIcon: React.FC = () => (
+export const VerifiedIcon = () => (
   <Flex position="relative" alignItems="center" justifyContent="center" data-testid="verified-icon">
     <StarIcon />
     <Flex position="absolute" alignItems="center" justifyContent="center">
@@ -11,7 +11,7 @@ export const VerifiedIcon: React.FC = () => (
   </Flex>
 );
 
-const StarIcon: React.FC<IconProps> = props => (
+const StarIcon = (props: IconProps) => (
   <Icon
     width="14px"
     height="14px"
@@ -28,7 +28,7 @@ const StarIcon: React.FC<IconProps> = props => (
   </Icon>
 );
 
-const CheckIcon: React.FC<IconProps> = props => (
+const CheckIcon = (props: IconProps) => (
   <Icon
     width="7px"
     height="5px"

--- a/apps/desktop/src/assets/icons/WalletPlus.tsx
+++ b/apps/desktop/src/assets/icons/WalletPlus.tsx
@@ -2,7 +2,7 @@ import { Icon, type IconProps } from "@chakra-ui/react";
 
 import colors from "../../style/colors";
 
-export const WalletPlusIcon: React.FC<IconProps> = props => (
+export const WalletPlusIcon = (props: IconProps) => (
   <Icon
     width="24px"
     height="24px"

--- a/apps/desktop/src/assets/icons/Warning.tsx
+++ b/apps/desktop/src/assets/icons/Warning.tsx
@@ -2,7 +2,7 @@ import { Icon, type IconProps } from "@chakra-ui/react";
 
 import colors from "../../style/colors";
 
-export const WarningIcon: React.FC<IconProps> = props => (
+export const WarningIcon = (props: IconProps) => (
   <Icon
     width="40px"
     height="40px"

--- a/apps/desktop/src/assets/icons/WindowLink.tsx
+++ b/apps/desktop/src/assets/icons/WindowLink.tsx
@@ -2,7 +2,7 @@ import { Icon, type IconProps } from "@chakra-ui/react";
 
 import colors from "../../style/colors";
 
-export const WindowLinkIcon: React.FC<IconProps> = props => (
+export const WindowLinkIcon = (props: IconProps) => (
   <Icon
     width="14px"
     height="14px"

--- a/apps/desktop/src/assets/icons/XMark.tsx
+++ b/apps/desktop/src/assets/icons/XMark.tsx
@@ -2,7 +2,7 @@ import { Icon, type IconProps } from "@chakra-ui/react";
 
 import colors from "../../style/colors";
 
-export const XMarkIcon: React.FC<IconProps> = props => (
+export const XMarkIcon = (props: IconProps) => (
   <Icon
     width="18px"
     height="18px"

--- a/apps/desktop/src/components/AccountBalance.tsx
+++ b/apps/desktop/src/components/AccountBalance.tsx
@@ -1,13 +1,15 @@
 import { Box, type BoxProps, type FlexProps } from "@chakra-ui/react";
 import { useGetAccountBalance } from "@umami/state";
-import { type RawPkh } from "@umami/tezos";
-import { prettyTezAmount } from "@umami/tezos";
+import { type RawPkh, prettyTezAmount } from "@umami/tezos";
 
 import { PrettyNumber } from "./PrettyNumber";
 
-export const AccountBalance: React.FC<
-  { address: RawPkh; size?: "md" | "lg"; numberProps?: FlexProps } & BoxProps
-> = ({ address, size, numberProps, ...props }) => {
+export const AccountBalance = ({
+  address,
+  size,
+  numberProps,
+  ...props
+}: { address: RawPkh; size?: "md" | "lg"; numberProps?: FlexProps } & BoxProps) => {
   const getBalance = useGetAccountBalance();
   const balance = getBalance(address);
 

--- a/apps/desktop/src/components/AccountDrawer/AccountDrawerDisplay.tsx
+++ b/apps/desktop/src/components/AccountDrawer/AccountDrawerDisplay.tsx
@@ -24,17 +24,20 @@ import { TezRecapDisplay } from "../TezRecapDisplay";
 type Props = {
   onSend: () => void;
   onReceive?: () => void;
-  onBuyTez?: () => void;
   tokens: Array<FA12TokenBalance | FA2TokenBalance>;
   nfts: Array<NFTBalance>;
   account: Account;
 };
 
-const RoundButton: React.FC<{
+const RoundButton = ({
+  icon,
+  label,
+  onClick = () => {},
+}: {
   label: string;
   icon: ReactElement;
   onClick?: () => void;
-}> = ({ icon, label, onClick = () => {} }) => (
+}) => (
   <Box
     className="account-drawer-cta-button"
     color={colors.gray[300]}
@@ -59,13 +62,13 @@ const RoundButton: React.FC<{
   </Box>
 );
 
-export const AccountDrawerDisplay: React.FC<Props> = ({
+export const AccountDrawerDisplay = ({
   onSend,
   onReceive = () => {},
   tokens,
   nfts,
   account,
-}) => {
+}: Props) => {
   const isMultisig = account.type === "multisig";
   const { openWith } = useContext(DynamicModalContext);
   const pkh = account.address.pkh;

--- a/apps/desktop/src/components/AccountDrawer/AssetsPanel/AssetsPanel.tsx
+++ b/apps/desktop/src/components/AccountDrawer/AssetsPanel/AssetsPanel.tsx
@@ -22,7 +22,6 @@ import {
   useGetPendingMultisigOperations,
   useSelectedNetwork,
 } from "@umami/state";
-import type React from "react";
 
 import { EarnTab } from "./EarnTab";
 import { MultisigPendingOperations } from "./MultisigPendingOperations";
@@ -45,11 +44,15 @@ import { SmallTab } from "../../SmallTab";
  * @param account - selected account in the drawer
  * @param delegation - delegation info if exists
  */
-export const AssetsPanel: React.FC<{
+export const AssetsPanel = ({
+  tokens,
+  nfts,
+  account,
+}: {
   tokens: Array<FA12TokenBalance | FA2TokenBalance>;
   nfts: Array<NFTBalance>;
   account: Account;
-}> = ({ tokens, nfts, account }) => {
+}) => {
   const getPendingOperations = useGetPendingMultisigOperations();
   const hasPendingMultisigOperations =
     account.type === "multisig" && getPendingOperations(account).length > 0;

--- a/apps/desktop/src/components/AccountDrawer/AssetsPanel/EarnTab.tsx
+++ b/apps/desktop/src/components/AccountDrawer/AssetsPanel/EarnTab.tsx
@@ -7,7 +7,6 @@ import {
   useSelectedNetwork,
 } from "@umami/state";
 import { prettyTezAmount } from "@umami/tezos";
-import type React from "react";
 import { type ReactNode, useContext } from "react";
 
 import { PendingUnstakeRequests } from "./PendingUnstakeRequests/PendingUnstakeRequests";
@@ -20,12 +19,14 @@ import { NoticeModal as StakeNoticeModal } from "../../SendFlow/Stake/NoticeModa
 import { FormPage as UndelegationFormPage } from "../../SendFlow/Undelegation/FormPage";
 import { NoticeModal as UnstakeNoticeModal } from "../../SendFlow/Unstake/NoticeModal";
 
-const Row: React.FC<
-  {
-    label: string;
-    value: ReactNode;
-  } & FlexProps
-> = ({ label, value, ...props }) => (
+const Row = ({
+  label,
+  value,
+  ...props
+}: {
+  label: string;
+  value: ReactNode;
+} & FlexProps) => (
   <Flex alignItems="center" height="50px" padding="16px" data-testid={label} {...props}>
     <Box flex={1}>
       <Heading color={colors.gray[400]} size="sm">
@@ -47,9 +48,7 @@ const RoundStatusDot = ({ background }: { background: string }) => (
   />
 );
 
-export const EarnTab: React.FC<{
-  account: Account;
-}> = ({ account }) => {
+export const EarnTab = ({ account }: { account: Account }) => {
   const { openWith } = useContext(DynamicModalContext);
   const network = useSelectedNetwork();
   const pkh = account.address.pkh;

--- a/apps/desktop/src/components/AccountDrawer/AssetsPanel/MultisigPendingOperations/MultisigActionButton.tsx
+++ b/apps/desktop/src/components/AccountDrawer/AssetsPanel/MultisigPendingOperations/MultisigActionButton.tsx
@@ -1,5 +1,4 @@
 import { Button, Flex, Text } from "@chakra-ui/react";
-import type React from "react";
 
 import { CheckmarkIcon, HourglassIcon } from "../../../../assets/icons";
 import colors from "../../../../style/colors";
@@ -10,11 +9,15 @@ export type MultisigSignerState =
   | "executable"
   | "approvable";
 
-export const MultisigActionButton: React.FC<{
+export const MultisigActionButton = ({
+  approveOrExecute,
+  isLoading,
+  signerState,
+}: {
   signerState: MultisigSignerState;
   approveOrExecute: () => void;
   isLoading: boolean;
-}> = ({ approveOrExecute, isLoading, signerState }) => {
+}) => {
   switch (signerState) {
     case "awaitingApprovalByExternalSigner": {
       return (

--- a/apps/desktop/src/components/AccountDrawer/AssetsPanel/MultisigPendingOperations/MultisigDecodedOperation.tsx
+++ b/apps/desktop/src/components/AccountDrawer/AssetsPanel/MultisigPendingOperations/MultisigDecodedOperation.tsx
@@ -7,9 +7,7 @@ import { OutgoingArrow } from "../../../../assets/icons";
 import colors from "../../../../style/colors";
 import { AddressPill } from "../../../AddressPill/AddressPill";
 
-export const MultisigDecodedOperation: React.FC<{
-  operation: Operation;
-}> = ({ operation }) => {
+export const MultisigDecodedOperation = ({ operation }: { operation: Operation }) => {
   switch (operation.type) {
     case "delegation":
       return (
@@ -51,9 +49,7 @@ export const MultisigDecodedOperation: React.FC<{
   }
 };
 
-const MultisigOperationAmount: React.FC<{
-  operation: Operation;
-}> = ({ operation }) => {
+const MultisigOperationAmount = ({ operation }: { operation: Operation }) => {
   const getToken = useGetToken();
 
   switch (operation.type) {

--- a/apps/desktop/src/components/AccountDrawer/AssetsPanel/MultisigPendingOperations/MultisigDecodedOperations.tsx
+++ b/apps/desktop/src/components/AccountDrawer/AssetsPanel/MultisigPendingOperations/MultisigDecodedOperations.tsx
@@ -15,10 +15,13 @@ import { MultisigDecodedOperation } from "./MultisigDecodedOperation";
 import colors from "../../../../style/colors";
 import { JsValueWrap } from "../../JsValueWrap";
 
-export const MultisigDecodedOperations: React.FC<{
+export const MultisigDecodedOperations = ({
+  rawMichelson,
+  sender,
+}: {
   rawMichelson: string;
   sender: MultisigAccount;
-}> = ({ rawMichelson, sender }) => {
+}) => {
   try {
     const operations = parseRawMichelson(rawMichelson, sender);
     return (
@@ -51,7 +54,7 @@ export const MultisigDecodedOperations: React.FC<{
   }
 };
 
-const UnrecognizedOperation: React.FC<{ rawMichelson: string }> = ({ rawMichelson }) => (
+const UnrecognizedOperation = ({ rawMichelson }: { rawMichelson: string }) => (
   <Accordion
     width="100%"
     marginBottom="8px"

--- a/apps/desktop/src/components/AccountDrawer/AssetsPanel/MultisigPendingOperations/MultisigPendingOperation.tsx
+++ b/apps/desktop/src/components/AccountDrawer/AssetsPanel/MultisigPendingOperations/MultisigPendingOperation.tsx
@@ -1,16 +1,18 @@
 import { Box, Flex, Heading, Text } from "@chakra-ui/react";
 import { type MultisigAccount } from "@umami/core";
 import { type MultisigOperation } from "@umami/multisig";
-import type React from "react";
 
 import { MultisigDecodedOperations } from "./MultisigDecodedOperations";
 import { MultisigSignerTile } from "./MultisigSignerTile";
 import colors from "../../../../style/colors";
 
-export const MultisigPendingOperation: React.FC<{
+export const MultisigPendingOperation = ({
+  operation,
+  sender,
+}: {
   operation: MultisigOperation;
   sender: MultisigAccount;
-}> = ({ operation, sender }) => {
+}) => {
   const { signers, threshold } = sender;
   const pendingApprovals = Math.max(threshold - operation.approvals.length, 0);
   return (

--- a/apps/desktop/src/components/AccountDrawer/AssetsPanel/MultisigPendingOperations/MultisigSignerTile.tsx
+++ b/apps/desktop/src/components/AccountDrawer/AssetsPanel/MultisigPendingOperations/MultisigSignerTile.tsx
@@ -9,7 +9,6 @@ import {
 import { type MultisigOperation, parseRawMichelson } from "@umami/multisig";
 import { useAsyncActionHandler, useGetImplicitAccountSafe, useSelectedNetwork } from "@umami/state";
 import { type ImplicitAddress } from "@umami/tezos";
-import type React from "react";
 import { useContext } from "react";
 
 import { MultisigActionButton, type MultisigSignerState } from "./MultisigActionButton";
@@ -19,12 +18,17 @@ import { AddressTileIcon } from "../../../AddressTile/AddressTileIcon";
 import { useAddressKind } from "../../../AddressTile/useAddressKind";
 import { SignPage } from "../../../SendFlow/Multisig/SignPage";
 
-export const MultisigSignerTile: React.FC<{
+export const MultisigSignerTile = ({
+  pendingApprovals,
+  sender,
+  operation,
+  signerAddress,
+}: {
   signerAddress: ImplicitAddress;
   pendingApprovals: number;
   operation: MultisigOperation;
   sender: MultisigAccount;
-}> = ({ pendingApprovals, sender, operation, signerAddress }) => {
+}) => {
   const addressKind = useAddressKind(signerAddress);
   const getImplicitAccount = useGetImplicitAccountSafe();
   const { isLoading, handleAsyncAction } = useAsyncActionHandler();

--- a/apps/desktop/src/components/AccountDrawer/AssetsPanel/MultisigPendingOperations/index.tsx
+++ b/apps/desktop/src/components/AccountDrawer/AssetsPanel/MultisigPendingOperations/index.tsx
@@ -1,13 +1,10 @@
 import { Box } from "@chakra-ui/react";
 import { type MultisigAccount } from "@umami/core";
 import { useGetPendingMultisigOperations } from "@umami/state";
-import type React from "react";
 
 import { MultisigPendingOperation } from "./MultisigPendingOperation";
 
-export const MultisigPendingOperations: React.FC<{
-  account: MultisigAccount;
-}> = ({ account }) => {
+export const MultisigPendingOperations = ({ account }: { account: MultisigAccount }) => {
   const getPendingOperations = useGetPendingMultisigOperations();
   const pendingOperations = getPendingOperations(account);
 

--- a/apps/desktop/src/components/AccountDrawer/AssetsPanel/OperationListDisplay.tsx
+++ b/apps/desktop/src/components/AccountDrawer/AssetsPanel/OperationListDisplay.tsx
@@ -1,7 +1,6 @@
 import { Box, Divider } from "@chakra-ui/react";
 import { type RawPkh } from "@umami/tezos";
 import { type TzktCombinedOperation } from "@umami/tzkt";
-import type React from "react";
 
 import { ViewAllLink } from "./ViewAllLink";
 import { NoOperations } from "../../NoItems";
@@ -18,10 +17,13 @@ const MAX_OPERATIONS_SIZE = 20;
  * @param owner - Address of the account for which the drawer was opened.
  * @param operations - List of owner's operations.
  */
-export const OperationListDisplay: React.FC<{
+export const OperationListDisplay = ({
+  owner,
+  operations,
+}: {
   owner: RawPkh;
   operations: TzktCombinedOperation[];
-}> = ({ owner, operations }) => {
+}) => {
   if (operations.length === 0) {
     return <NoOperations size="md" />;
   }

--- a/apps/desktop/src/components/AccountDrawer/AssetsPanel/PendingUnstakeRequests/FinalizableUnstakeRequest.tsx
+++ b/apps/desktop/src/components/AccountDrawer/AssetsPanel/PendingUnstakeRequests/FinalizableUnstakeRequest.tsx
@@ -21,11 +21,12 @@ import { SignPage } from "../../../SendFlow/FinalizeUnstake/SignPage";
  * @param account - account to display the finalizable unstake request for
  */
 // TODO: test
-export const FinalizableUnstakeRequest: React.FC<
-  {
-    account: ImplicitAccount;
-  } & FlexProps
-> = ({ account, ...props }) => {
+export const FinalizableUnstakeRequest = ({
+  account,
+  ...props
+}: {
+  account: ImplicitAccount;
+} & FlexProps) => {
   const { openWith } = useContext(DynamicModalContext);
   const { handleAsyncAction, isLoading } = useAsyncActionHandler();
   const network = useSelectedNetwork();

--- a/apps/desktop/src/components/AccountDrawer/AssetsPanel/PendingUnstakeRequests/PendingUnstakeRequest.tsx
+++ b/apps/desktop/src/components/AccountDrawer/AssetsPanel/PendingUnstakeRequests/PendingUnstakeRequest.tsx
@@ -13,12 +13,14 @@ import { PrettyNumber } from "../../../PrettyNumber";
  * @param request - the unstake request to display (it should not be finalizable yet)
  */
 // TODO: test
-export const PendingUnstakeRequest: React.FC<
-  {
-    account: ImplicitAccount;
-    request: RawTzktUnstakeRequest;
-  } & FlexProps
-> = ({ request, account, ...props }) => {
+export const PendingUnstakeRequest = ({
+  request,
+  account,
+  ...props
+}: {
+  account: ImplicitAccount;
+  request: RawTzktUnstakeRequest;
+} & FlexProps) => {
   const firstFinalizableCycle = useGetFirstFinalizableCycle()(request.cycle);
   const { tzktExplorerUrl } = useSelectedNetwork();
 

--- a/apps/desktop/src/components/AccountDrawer/AssetsPanel/PendingUnstakeRequests/PendingUnstakeRequests.tsx
+++ b/apps/desktop/src/components/AccountDrawer/AssetsPanel/PendingUnstakeRequests/PendingUnstakeRequests.tsx
@@ -18,10 +18,10 @@ import colors from "../../../../style/colors";
  * @param account - account to display the pending unstake requests for
  */
 //TODO: test
-export const PendingUnstakeRequests: React.FC<{ account: ImplicitAccount } & FlexProps> = ({
+export const PendingUnstakeRequests = ({
   account,
   ...props
-}) => {
+}: { account: ImplicitAccount } & FlexProps) => {
   const pendingUnstakeRequests = useAccountPendingUnstakeRequests(account.address.pkh);
   const totalFinalizableAmount = useAccountTotalFinalizableUnstakeAmount(account.address.pkh);
 

--- a/apps/desktop/src/components/AccountDrawer/DerivationInfo/DerivationInfoButton.tsx
+++ b/apps/desktop/src/components/AccountDrawer/DerivationInfo/DerivationInfoButton.tsx
@@ -12,10 +12,7 @@ import { FolderInfoIcon } from "../../../assets/icons";
  * @param account -
  * @returns null if the account's derivation path is unknown, a button to open the modal otherwise
  */
-export const DerivationInfoButton: React.FC<{ account: Account } & ButtonProps> = ({
-  account,
-  ...props
-}) => {
+export const DerivationInfoButton = ({ account, ...props }: { account: Account } & ButtonProps) => {
   const { openWith } = useContext(DynamicModalContext);
 
   switch (account.type) {

--- a/apps/desktop/src/components/AccountDrawer/DerivationInfo/InfoModal.tsx
+++ b/apps/desktop/src/components/AccountDrawer/DerivationInfo/InfoModal.tsx
@@ -19,7 +19,7 @@ import { CircleIcon } from "../../CircleIcon";
  *
  * @param account -
  */
-export const InfoModal: React.FC<{ account: LedgerAccount | MnemonicAccount }> = ({ account }) => {
+export const InfoModal = ({ account }: { account: LedgerAccount | MnemonicAccount }) => {
   const values = [
     {
       title: "Template",

--- a/apps/desktop/src/components/AccountDrawer/JsValueWrap.tsx
+++ b/apps/desktop/src/components/AccountDrawer/JsValueWrap.tsx
@@ -3,11 +3,11 @@ import { Card, CardBody, type CardProps } from "@chakra-ui/react";
 import colors from "../../style/colors";
 
 // Wrapper for any JavaScript value
-export const JsValueWrap: React.FC<{ value: any; space?: number } & CardProps> = ({
+export const JsValueWrap = ({
   value,
   space = 2,
   ...props
-}) => (
+}: { value: any; space?: number } & CardProps) => (
   <Card background={colors.gray[700]} borderRadius="5px" {...props}>
     <CardBody>
       <pre

--- a/apps/desktop/src/components/AccountDrawer/MultisigApprovers.tsx
+++ b/apps/desktop/src/components/AccountDrawer/MultisigApprovers.tsx
@@ -9,14 +9,11 @@ import {
   Wrap,
 } from "@chakra-ui/react";
 import { type ImplicitAddress } from "@umami/tezos";
-import type React from "react";
 
 import colors from "../../style/colors";
 import { AddressPill } from "../AddressPill/AddressPill";
 
-export const MultisigApprovers: React.FC<{
-  signers: ImplicitAddress[];
-}> = ({ signers }) => (
+export const MultisigApprovers = ({ signers }: { signers: ImplicitAddress[] }) => (
   <Box
     width="100%"
     marginTop="40px"

--- a/apps/desktop/src/components/AccountDrawer/RenameRemoveMenuSwitch.tsx
+++ b/apps/desktop/src/components/AccountDrawer/RenameRemoveMenuSwitch.tsx
@@ -8,7 +8,7 @@ import { RenameAccountModal } from "./RenameAccountModal";
 import { ConfirmationModal } from "../ConfirmationModal";
 import { RenameRemoveMenu } from "../RenameRemoveMenu";
 
-export const RenameRemoveMenuSwitch: React.FC<{ account: Account }> = ({ account }) => {
+export const RenameRemoveMenuSwitch = ({ account }: { account: Account }) => {
   const { openWith, onClose: closeModal } = useContext(DynamicModalContext);
   const navigate = useNavigate();
   const isLastImplicitAccount = useImplicitAccounts().length === 1;

--- a/apps/desktop/src/components/AccountDrawer/index.tsx
+++ b/apps/desktop/src/components/AccountDrawer/index.tsx
@@ -9,7 +9,7 @@ import { ReceiveModal } from "../ReceiveModal";
 import { FormPage as SendTezForm } from "../SendFlow/Tez/FormPage";
 
 // TODO: replace current component with the underlying one
-export const AccountCard: React.FC<{ accountPkh: RawPkh }> = ({ accountPkh }) => {
+export const AccountCard = ({ accountPkh }: { accountPkh: RawPkh }) => {
   const getOwnedAccount = useGetOwnedAccount();
 
   const getTokens = useGetAccountAllTokens();

--- a/apps/desktop/src/components/AccountSelector/AccountListDisplay.tsx
+++ b/apps/desktop/src/components/AccountSelector/AccountListDisplay.tsx
@@ -1,14 +1,16 @@
 import { MenuItem, MenuList } from "@chakra-ui/react";
 import { type Account } from "@umami/core";
-import type React from "react";
 
 import colors from "../../style/colors";
 import { AddressTile } from "../AddressTile/AddressTile";
 
-export const AccountListDisplay: React.FC<{
+export const AccountListDisplay = ({
+  accounts,
+  onSelect,
+}: {
   accounts: Account[];
   onSelect: (account: Account) => void;
-}> = ({ accounts, onSelect }) => (
+}) => (
   <MenuList
     zIndex="docked"
     overflowY="scroll"

--- a/apps/desktop/src/components/AccountTile/AccountTile.tsx
+++ b/apps/desktop/src/components/AccountTile/AccountTile.tsx
@@ -11,8 +11,7 @@ import {
 import { type Account, fullId, thumbnailUri } from "@umami/core";
 import { useGetAccountBalance, useGetAccountDelegate, useGetAccountNFTs } from "@umami/state";
 import { formatPkh, prettyTezAmount } from "@umami/tezos";
-import type React from "react";
-import { useContext } from "react";
+import { type ReactNode, useContext } from "react";
 import { Link } from "react-router-dom";
 
 import { AccountTileIcon } from "./AccountTileIcon";
@@ -22,13 +21,16 @@ import { SelectedAccountContext } from "../../views/home/SelectedAccountContext"
 import { useAddressKind } from "../AddressTile/useAddressKind";
 import { color as identiconColor } from "../Identicon";
 
-export const AccountTileBase: React.FC<
-  {
-    icon: React.ReactNode;
-    leftElement: React.ReactNode;
-    rightElement: React.ReactNode;
-  } & FlexProps
-> = ({ icon, leftElement, rightElement, ...flexProps }) => (
+export const AccountTileBase = ({
+  icon,
+  leftElement,
+  rightElement,
+  ...flexProps
+}: {
+  icon: ReactNode;
+  leftElement: ReactNode;
+  rightElement: ReactNode;
+} & FlexProps) => (
   <Flex
     alignItems="center"
     height="90px"
@@ -47,10 +49,7 @@ export const AccountTileBase: React.FC<
   </Flex>
 );
 
-export const LabelAndAddress: React.FC<{ label: string | null; pkh: string }> = ({
-  label,
-  pkh,
-}) => (
+export const LabelAndAddress = ({ label, pkh }: { label: string | null; pkh: string }) => (
   <Box margin={4} data-testid="account-identifier">
     {label && <Heading size="md">{label}</Heading>}
     <Flex alignItems="center">
@@ -109,9 +108,7 @@ export const accountIconGradient = ({
   }px, transparent ${radius}), ${mainBackgroundColor}`;
 };
 
-export const AccountTile: React.FC<{
-  account: Account;
-}> = ({ account }) => {
+export const AccountTile = ({ account }: { account: Account }) => {
   const pkh = account.address.pkh;
   const { selectedAccount, selectAccount } = useContext(SelectedAccountContext);
   const isSelected = selectedAccount?.address.pkh === pkh;

--- a/apps/desktop/src/components/AccountTile/AccountTileIcon.tsx
+++ b/apps/desktop/src/components/AccountTile/AccountTileIcon.tsx
@@ -103,8 +103,8 @@ const SIZES = {
  * @param account - The account to display the icon for.
  * @param size - The size of the icon.
  */
-export const AccountTileIcon: React.FC<{ account: Account; size: AddressTileIconSize }> = memo(
-  ({ account, size }) => {
+export const AccountTileIcon = memo(
+  ({ account, size }: { account: Account; size: AddressTileIconSize }) => {
     const sizeObj = SIZES[size];
     const defaults = sizeObj.defaults;
 

--- a/apps/desktop/src/components/AddressAutocomplete/AddressAutocomplete.test.tsx
+++ b/apps/desktop/src/components/AddressAutocomplete/AddressAutocomplete.test.tsx
@@ -14,18 +14,18 @@ beforeEach(() => {
   store = makeStore();
 });
 
-const TestComponent: React.FC<{
-  defaultDestination?: string;
-  contacts?: Contact[];
-  allowUnknown?: boolean;
-  label?: string;
-  keepValid?: boolean;
-}> = ({
+const TestComponent = ({
   defaultDestination = "",
   allowUnknown = true,
   contacts = [mockImplicitContact(0), mockImplicitContact(1), mockImplicitContact(2)],
   label = "",
   keepValid,
+}: {
+  defaultDestination?: string;
+  contacts?: Contact[];
+  allowUnknown?: boolean;
+  label?: string;
+  keepValid?: boolean;
 }) => {
   const form = useForm<FormFields>({ defaultValues: { destination: defaultDestination } });
 

--- a/apps/desktop/src/components/AddressPill/AddressPill.tsx
+++ b/apps/desktop/src/components/AddressPill/AddressPill.tsx
@@ -22,9 +22,11 @@ import { AddressPillText } from "./AddressPillText";
 import { useAddressKind } from "./useAddressKind";
 import colors from "../../style/colors";
 
-export const AddressPill: React.FC<
-  { address: Address | TzktAlias; mode?: AddressPillMode } & BoxProps
-> = ({ address: rawAddress, mode = { type: "default" }, ...rest }) => {
+export const AddressPill = ({
+  address: rawAddress,
+  mode = { type: "default" },
+  ...rest
+}: { address: Address | TzktAlias; mode?: AddressPillMode } & BoxProps) => {
   const isAlias = !("pkh" in rawAddress && "type" in rawAddress);
   const address = isAlias ? parsePkh(rawAddress.address) : rawAddress;
   const addressKind = useAddressKind(address);

--- a/apps/desktop/src/components/AddressPill/AddressPillIcon.tsx
+++ b/apps/desktop/src/components/AddressPill/AddressPillIcon.tsx
@@ -16,10 +16,10 @@ import {
 } from "../../assets/icons";
 import { UpsertContactModal } from "../UpsertContactModal";
 
-export const LeftIcon: React.FC<{ addressKind: AddressKind } & IconProps> = ({
+export const LeftIcon = ({
   addressKind: { type },
   ...props
-}) => {
+}: { addressKind: AddressKind } & IconProps) => {
   switch (type) {
     case "multisig":
       return <KeyIcon data-testid={`${type}-icon`} {...props} />;
@@ -37,9 +37,11 @@ export const LeftIcon: React.FC<{ addressKind: AddressKind } & IconProps> = ({
   }
 };
 
-export const RightIcon: React.FC<
-  { addressKind: AddressKind; addressPillMode: AddressPillMode } & IconProps
-> = ({ addressKind: { type, pkh }, addressPillMode, ...rest }) => {
+export const RightIcon = ({
+  addressKind: { type, pkh },
+  addressPillMode,
+  ...rest
+}: { addressKind: AddressKind; addressPillMode: AddressPillMode } & IconProps) => {
   const addressExistsInContacts = useAddressExistsInContacts();
   const { openWith } = useContext(DynamicModalContext);
 

--- a/apps/desktop/src/components/AddressPill/AddressPillText.tsx
+++ b/apps/desktop/src/components/AddressPill/AddressPillText.tsx
@@ -4,13 +4,16 @@ import { formatPkh, truncate } from "@umami/tezos";
 
 import { type AddressKind } from "./types";
 
-export const AddressPillText: React.FC<
-  {
-    addressKind: AddressKind;
-    showPkh: boolean;
-    alias?: string;
-  } & TextProps
-> = ({ addressKind: { pkh, label }, showPkh, alias, ...rest }) => {
+export const AddressPillText = ({
+  addressKind: { pkh, label },
+  showPkh,
+  alias,
+  ...rest
+}: {
+  addressKind: AddressKind;
+  showPkh: boolean;
+  alias?: string;
+} & TextProps) => {
   const getContactName = useGetContactName();
   const formattedPkh = formatPkh(pkh);
   const nameOrLabel = getContactName(pkh) || label || alias;

--- a/apps/desktop/src/components/AddressTile/AddressTile.tsx
+++ b/apps/desktop/src/components/AddressTile/AddressTile.tsx
@@ -1,6 +1,5 @@
 import { Box, Flex, type FlexProps, Heading, Text, Tooltip } from "@chakra-ui/react";
-import { type Address } from "@umami/tezos";
-import { formatPkh } from "@umami/tezos";
+import { type Address, formatPkh } from "@umami/tezos";
 
 import { AddressTileIcon } from "./AddressTileIcon";
 import { useAddressKind } from "./useAddressKind";
@@ -17,11 +16,11 @@ import { AccountBalance } from "../AccountBalance";
  * @param flexProps - Defines component style.
  * @param hideBalance - If true, balance will not be displayed.
  */
-export const AddressTile: React.FC<{ address: Address; hideBalance?: boolean } & FlexProps> = ({
+export const AddressTile = ({
   address,
   hideBalance = false,
   ...flexProps
-}) => {
+}: { address: Address; hideBalance?: boolean } & FlexProps) => {
   const addressKind = useAddressKind(address);
 
   return (

--- a/apps/desktop/src/components/AddressTile/AddressTileIcon.tsx
+++ b/apps/desktop/src/components/AddressTile/AddressTileIcon.tsx
@@ -22,56 +22,55 @@ const baseIconProps = {
  * @param addressKind - The address to display the icon for.
  * @param size - The size of the icon.
  */
-export const AddressTileIcon: React.FC<{
-  addressKind: AddressKind;
-  size: AddressTileIconSize;
-}> = memo(({ addressKind, size }) => {
-  const getAccount = useGetOwnedAccountSafe();
-  const account = getAccount(addressKind.pkh);
+export const AddressTileIcon = memo(
+  ({ addressKind, size }: { addressKind: AddressKind; size: AddressTileIconSize }) => {
+    const getAccount = useGetOwnedAccountSafe();
+    const account = getAccount(addressKind.pkh);
 
-  if (account) {
-    return <AccountTileIcon account={account} size={size} />;
-  }
+    if (account) {
+      return <AccountTileIcon account={account} size={size} />;
+    }
 
-  let sizeInPx;
-  let padding;
-  switch (size) {
-    case "sm":
-      sizeInPx = "30px";
-      padding = "5px";
-      break;
-    case "lg":
-      sizeInPx = "48px";
-      padding = "10px";
-  }
+    let sizeInPx;
+    let padding;
+    switch (size) {
+      case "sm":
+        sizeInPx = "30px";
+        padding = "5px";
+        break;
+      case "lg":
+        sizeInPx = "48px";
+        padding = "10px";
+    }
 
-  switch (addressKind.type) {
-    case "contact":
-      return (
-        <ContactIcon width={sizeInPx} height={sizeInPx} padding={padding} {...baseIconProps} />
-      );
-    case "unknown":
-      return (
-        <UnknownContactIcon
-          width={sizeInPx}
-          height={sizeInPx}
-          padding={padding}
-          {...baseIconProps}
-        />
-      );
-    case "baker":
-      return (
-        <Image
-          height={sizeInPx}
-          data-testid="baker-icon"
-          src={`https://services.tzkt.io/v1/avatars/${addressKind.pkh}`}
-        />
-      );
-    case "secret_key":
-    case "mnemonic":
-    case "social":
-    case "ledger":
-    case "multisig":
-      return null; // impossible state
+    switch (addressKind.type) {
+      case "contact":
+        return (
+          <ContactIcon width={sizeInPx} height={sizeInPx} padding={padding} {...baseIconProps} />
+        );
+      case "unknown":
+        return (
+          <UnknownContactIcon
+            width={sizeInPx}
+            height={sizeInPx}
+            padding={padding}
+            {...baseIconProps}
+          />
+        );
+      case "baker":
+        return (
+          <Image
+            height={sizeInPx}
+            data-testid="baker-icon"
+            src={`https://services.tzkt.io/v1/avatars/${addressKind.pkh}`}
+          />
+        );
+      case "secret_key":
+      case "mnemonic":
+      case "social":
+      case "ledger":
+      case "multisig":
+        return null; // impossible state
+    }
   }
-});
+);

--- a/apps/desktop/src/components/AdvancedSettingsAccordion.tsx
+++ b/apps/desktop/src/components/AdvancedSettingsAccordion.tsx
@@ -11,9 +11,8 @@ import {
   InputGroup,
   InputRightElement,
 } from "@chakra-ui/react";
-import { type Estimation, TEZ_DECIMALS } from "@umami/tezos";
-import { mutezToTez, tezToMutez } from "@umami/tezos";
-import { useState } from "react";
+import { type Estimation, TEZ_DECIMALS, mutezToTez, tezToMutez } from "@umami/tezos";
+import { type ChangeEvent, useState } from "react";
 import { useFormContext } from "react-hook-form";
 
 import { getSmallestUnit, makeValidateDecimals } from "./SendFlow/utils";
@@ -37,7 +36,7 @@ export const AdvancedSettingsAccordion = ({ index = 0 }: AdvancedSettingsAccordi
     mutezToTez(getValues().executeParams[index].fee).toFixed()
   );
 
-  const handleFeeChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleFeeChange = (event: ChangeEvent<HTMLInputElement>) => {
     const newFeeValue = event.target.value;
 
     if (makeValidateDecimals(TEZ_DECIMALS)(newFeeValue) === true) {

--- a/apps/desktop/src/components/AnnouncementBanner.tsx
+++ b/apps/desktop/src/components/AnnouncementBanner.tsx
@@ -15,7 +15,7 @@ const ANNOUNCEMENT_FILE_URL = "https://storage.googleapis.com/umami-artifacts/an
  * Once the user closes the notification, it won't show up again until
  * we post a new one
  */
-export const AnnouncementBanner: React.FC = () => {
+export const AnnouncementBanner = () => {
   const { html: announcementHTML, seen } = useAppSelector(s => s.announcement);
   const dispatch = useAppDispatch();
 

--- a/apps/desktop/src/components/AssetTiles/TezTile.tsx
+++ b/apps/desktop/src/components/AssetTiles/TezTile.tsx
@@ -6,9 +6,7 @@ import { TezIcon } from "../../assets/icons";
 import colors from "../../style/colors";
 import { PrettyNumber } from "../PrettyNumber";
 
-export const TezTile: React.FC<{ mutezAmount: string | number | BigNumber }> = ({
-  mutezAmount,
-}) => (
+export const TezTile = ({ mutezAmount }: { mutezAmount: string | number | BigNumber }) => (
   <Flex
     alignItems="center"
     height="60px"

--- a/apps/desktop/src/components/BuyTez/BuyTezForm.tsx
+++ b/apps/desktop/src/components/BuyTez/BuyTezForm.tsx
@@ -17,9 +17,7 @@ import colors from "../../style/colors";
 import { OwnedImplicitAccountsAutocomplete } from "../AddressAutocomplete";
 import { FormErrorMessage } from "../FormErrorMessage";
 
-export const BuyTezForm: React.FC<{
-  recipient?: RawPkh;
-}> = ({ recipient: defaultRecipient = "" }) => {
+export const BuyTezForm = ({ recipient: defaultRecipient = "" }: { recipient?: RawPkh }) => {
   const network = useSelectedNetwork();
   const isMainnet = network.name === "mainnet";
   const title = isMainnet ? "Buy Tez" : "Request Tez from faucet";

--- a/apps/desktop/src/components/CSVFileUploader/utils.ts
+++ b/apps/desktop/src/components/CSVFileUploader/utils.ts
@@ -6,8 +6,8 @@ import {
   isValidContractPkh,
   parseContractPkh,
   parsePkh,
+  tezToMutez,
 } from "@umami/tezos";
-import { tezToMutez } from "@umami/tezos";
 
 import { validateNonNegativeNumber } from "../../utils/helpers";
 

--- a/apps/desktop/src/components/ChangePassword/ChangePasswordForm.tsx
+++ b/apps/desktop/src/components/ChangePassword/ChangePasswordForm.tsx
@@ -24,7 +24,7 @@ type ChangePasswordFormValues = {
   newPasswordConfirmation: string;
 };
 
-export const ChangePasswordForm: React.FC = () => {
+export const ChangePasswordForm = () => {
   const { onClose } = useContext(DynamicModalContext);
   const form = useForm<ChangePasswordFormValues>({ mode: "onBlur" });
   const toast = useToast();

--- a/apps/desktop/src/components/ClickableCard.tsx
+++ b/apps/desktop/src/components/ClickableCard.tsx
@@ -4,14 +4,17 @@ import { type PropsWithChildren } from "react";
 import { ChevronRightIcon } from "../assets/icons";
 import colors from "../style/colors";
 
-export const ClickableCard: React.FC<
-  PropsWithChildren<
-    {
-      onClick?: () => void;
-      isSelected: boolean;
-    } & CardProps
-  >
-> = ({ onClick, children, isSelected, ...props }) => (
+export const ClickableCard = ({
+  onClick,
+  children,
+  isSelected,
+  ...props
+}: PropsWithChildren<
+  {
+    onClick?: () => void;
+    isSelected: boolean;
+  } & CardProps
+>) => (
   <Card
     justifyContent="center"
     height="66px"
@@ -30,11 +33,15 @@ export const ClickableCard: React.FC<
   </Card>
 );
 
-export const SettingsCardWithDrawerIcon: React.FC<{
+export const SettingsCardWithDrawerIcon = ({
+  left,
+  isSelected,
+  onClick,
+}: {
   left: string;
   isSelected: boolean;
   onClick?: () => void;
-}> = ({ left, isSelected, onClick }) => (
+}) => (
   <ClickableCard isSelected={isSelected} onClick={onClick}>
     <Flex alignItems="center" height="100%">
       <Flex alignItems="center" justifyContent="space-between" width="100%">

--- a/apps/desktop/src/components/ConfirmationModal.tsx
+++ b/apps/desktop/src/components/ConfirmationModal.tsx
@@ -15,12 +15,17 @@ import { useContext } from "react";
 import { WarningIcon } from "../assets/icons";
 import colors from "../style/colors";
 
-export const ConfirmationModal: React.FC<{
+export const ConfirmationModal = ({
+  title,
+  description,
+  buttonLabel,
+  onSubmit,
+}: {
   title: string;
   buttonLabel: string;
   description?: string;
   onSubmit: () => void;
-}> = ({ title, description, buttonLabel, onSubmit }) => {
+}) => {
   const { onClose } = useContext(DynamicModalContext);
   const onClick = () => {
     onSubmit();

--- a/apps/desktop/src/components/CopyableText.tsx
+++ b/apps/desktop/src/components/CopyableText.tsx
@@ -1,20 +1,23 @@
 import { Flex, type FlexProps, Text, useToast } from "@chakra-ui/react";
 import { formatPkh } from "@umami/tezos";
-import type React from "react";
 
 import { FileCopyIcon } from "../assets/icons";
 import colors from "../style/colors";
 
 const TOAST_ID = "TOAST_ID";
 
-export const CopyableAddress: React.FC<
-  {
-    pkh: string;
-    formatAddress?: boolean;
-    copyable?: boolean;
-    iconColor?: string;
-  } & FlexProps
-> = ({ pkh, formatAddress = true, copyable = true, iconColor = colors.gray[600], ...rest }) => (
+export const CopyableAddress = ({
+  pkh,
+  formatAddress = true,
+  copyable = true,
+  iconColor = colors.gray[600],
+  ...rest
+}: {
+  pkh: string;
+  formatAddress?: boolean;
+  copyable?: boolean;
+  iconColor?: string;
+} & FlexProps) => (
   <CopyableText
     copyValue={copyable ? pkh : undefined}
     displayText={formatAddress ? formatPkh(pkh) : pkh}
@@ -24,14 +27,18 @@ export const CopyableAddress: React.FC<
   />
 );
 
-const CopyableText: React.FC<
-  {
-    displayText: string;
-    copyValue?: string;
-    toastMessage?: string;
-    iconColor?: string;
-  } & FlexProps
-> = ({ displayText, copyValue, toastMessage, iconColor, ...rest }) => {
+const CopyableText = ({
+  displayText,
+  copyValue,
+  toastMessage,
+  iconColor,
+  ...rest
+}: {
+  displayText: string;
+  copyValue?: string;
+  toastMessage?: string;
+  iconColor?: string;
+} & FlexProps) => {
   const toast = useToast();
   const onClickCopyIcon = async () => {
     if (!copyValue) {

--- a/apps/desktop/src/components/DrawerTopButtons.tsx
+++ b/apps/desktop/src/components/DrawerTopButtons.tsx
@@ -1,13 +1,13 @@
 import { Flex, type FlexProps } from "@chakra-ui/react";
-import type React from "react";
 
 import { CloseDrawerButton } from "./CloseDrawerButton";
 
-export const DrawerTopButtons: React.FC<
-  {
-    onClose: () => void;
-  } & FlexProps
-> = ({ onClose, ...props }) => (
+export const DrawerTopButtons = ({
+  onClose,
+  ...props
+}: {
+  onClose: () => void;
+} & FlexProps) => (
   <Flex justifyContent="flex-end" paddingBottom="30px" cursor="pointer" {...props}>
     <CloseDrawerButton onClose={onClose} />
   </Flex>

--- a/apps/desktop/src/components/ErrorPage.tsx
+++ b/apps/desktop/src/components/ErrorPage.tsx
@@ -14,7 +14,7 @@ const refresh = () => {
   window.location.href = "/";
 };
 
-export const ErrorPage: React.FC = () => {
+export const ErrorPage = () => {
   const { modalElement: OffboardingModal, onOpen: onOpenOffboardingModal } = useOffboardingModal();
 
   return (

--- a/apps/desktop/src/components/ExternalLink.tsx
+++ b/apps/desktop/src/components/ExternalLink.tsx
@@ -1,11 +1,11 @@
 import { Link, type LinkProps } from "@chakra-ui/react";
 import { type PropsWithChildren } from "react";
 
-export const ExternalLink: React.FC<PropsWithChildren<{ href: string } & LinkProps>> = ({
+export const ExternalLink = ({
   href,
   children,
   ...props
-}) => (
+}: PropsWithChildren<{ href: string } & LinkProps>) => (
   <Link
     alignItems="center"
     display="flex"

--- a/apps/desktop/src/components/Identicon.tsx
+++ b/apps/desktop/src/components/Identicon.tsx
@@ -1,18 +1,19 @@
 import { Box, type ChakraProps } from "@chakra-ui/react";
 import { type Address, type RawPkh } from "@umami/tezos";
 import md5 from "md5";
-import type React from "react";
 
 import { ReactIdenticon } from "./ReactIdenticon";
 
 export const color = (address: RawPkh) => `#${md5(address).slice(0, 6)}`;
 
-export const Identicon: React.FC<
-  {
-    address: Address;
-    identiconSize: number;
-  } & ChakraProps
-> = ({ address, identiconSize, ...props }) => (
+export const Identicon = ({
+  address,
+  identiconSize,
+  ...props
+}: {
+  address: Address;
+  identiconSize: number;
+} & ChakraProps) => (
   <Box
     sx={{
       canvas: {
@@ -25,13 +26,6 @@ export const Identicon: React.FC<
     data-testid="identicon"
     {...props}
   >
-    <ReactIdenticon
-      background="white"
-      size={identiconSize}
-      string={address.pkh}
-      style={{
-        borderRadius: 4,
-      }}
-    />
+    <ReactIdenticon background="white" size={identiconSize} string={address.pkh} />
   </Box>
 );

--- a/apps/desktop/src/components/MakiLogo.tsx
+++ b/apps/desktop/src/components/MakiLogo.tsx
@@ -1,12 +1,11 @@
 import { type IconProps } from "@chakra-ui/react";
 import { useSelectedNetwork } from "@umami/state";
-import type React from "react";
 
 import { MakiIcon } from "../assets/icons";
 
 const ORANGE = "#F74F18";
 
-export const MakiLogo: React.FC<IconProps> = props => {
+export const MakiLogo = (props: IconProps) => {
   const network = useSelectedNetwork();
 
   return (

--- a/apps/desktop/src/components/NestedScroll.tsx
+++ b/apps/desktop/src/components/NestedScroll.tsx
@@ -1,8 +1,7 @@
 import { Box } from "@chakra-ui/react";
-import type React from "react";
 import { type ReactNode } from "react";
 
-export const NestedScroll: React.FC<{ children: ReactNode }> = props => (
+export const NestedScroll = (props: { children: ReactNode }) => (
   <Box overflowY="auto" height="100%">
     {props.children}
   </Box>

--- a/apps/desktop/src/components/NoItems/index.tsx
+++ b/apps/desktop/src/components/NoItems/index.tsx
@@ -19,13 +19,16 @@ const SIZES = {
 };
 type AvailableSizes = keyof typeof SIZES;
 
-export const NoItems: React.FC<
-  PropsWithChildren<{
-    title: string;
-    description: string;
-    size: AvailableSizes;
-  }>
-> = ({ title, description, children, size }) => (
+export const NoItems = ({
+  title,
+  description,
+  children,
+  size,
+}: PropsWithChildren<{
+  title: string;
+  description: string;
+  size: AvailableSizes;
+}>) => (
   <Flex alignItems="center" justifyContent="center" width="100%" height="100%">
     <Box padding="30px" data-testid="empty-state-message">
       <Heading marginBottom="10px" textAlign="center" size={SIZES[size].heading}>
@@ -44,7 +47,7 @@ export const NoItems: React.FC<
   </Flex>
 );
 
-export const NoOperations: React.FC<{ size: AvailableSizes }> = ({ size }) => (
+export const NoOperations = ({ size }: { size: AvailableSizes }) => (
   <NoItems
     description="Your operations history will appear here..."
     size={size}
@@ -52,7 +55,7 @@ export const NoOperations: React.FC<{ size: AvailableSizes }> = ({ size }) => (
   />
 );
 
-export const NoNFTs: React.FC<{ size: AvailableSizes }> = ({ size }) => (
+export const NoNFTs = ({ size }: { size: AvailableSizes }) => (
   <NoItems
     description="Your NFT collection will appear here..."
     size={size}
@@ -64,7 +67,7 @@ export const NoNFTs: React.FC<{ size: AvailableSizes }> = ({ size }) => (
   </NoItems>
 );
 
-export const NoTokens: React.FC<{ size: AvailableSizes }> = ({ size }) => (
+export const NoTokens = ({ size }: { size: AvailableSizes }) => (
   <NoItems
     description="All of your tokens will appear here..."
     size={size}

--- a/apps/desktop/src/components/Onboarding/eula/Eula.tsx
+++ b/apps/desktop/src/components/Onboarding/eula/Eula.tsx
@@ -1,15 +1,13 @@
 import { Box, Button, Checkbox, Link } from "@chakra-ui/react";
-import React from "react";
+import { useState } from "react";
 
 import { DocumentIcon } from "../../../assets/icons";
 import colors from "../../../style/colors";
 import { ModalContentWrapper } from "../ModalContentWrapper";
 import { type OnboardingStep } from "../OnboardingStep";
 
-export const Eula: React.FC<{
-  goToStep: (step: OnboardingStep) => void;
-}> = ({ goToStep }) => {
-  const [isChecked, setIsChecked] = React.useState(false);
+export const Eula = ({ goToStep }: { goToStep: (step: OnboardingStep) => void }) => {
+  const [isChecked, setIsChecked] = useState(false);
   return (
     <ModalContentWrapper icon={<DocumentIcon />} title="Accept to Continue">
       <>

--- a/apps/desktop/src/components/Onboarding/masterPassword/password/EnterAndConfirmPassword.tsx
+++ b/apps/desktop/src/components/Onboarding/masterPassword/password/EnterAndConfirmPassword.tsx
@@ -6,10 +6,13 @@ import { FormErrorMessage } from "../../../FormErrorMessage";
 import { PasswordInput } from "../../../PasswordInput";
 import { ModalContentWrapper } from "../../ModalContentWrapper";
 
-export const EnterAndConfirmPassword: React.FC<{
+export const EnterAndConfirmPassword = ({
+  onSubmit: onSubmitPassword,
+  isLoading,
+}: {
   onSubmit: (password: string) => void;
   isLoading: boolean;
-}> = ({ onSubmit: onSubmitPassword, isLoading }) => {
+}) => {
   type ConfirmPasswordFormValues = {
     password: string;
     confirm: string;

--- a/apps/desktop/src/components/Onboarding/notice/Notice.tsx
+++ b/apps/desktop/src/components/Onboarding/notice/Notice.tsx
@@ -1,14 +1,11 @@
 import { Box, Button, ListItem, OrderedList } from "@chakra-ui/react";
 import { generate24WordMnemonic } from "@umami/state";
-import type React from "react";
 
 import { NoticeIcon } from "../../../assets/icons";
 import { ModalContentWrapper } from "../ModalContentWrapper";
 import { type OnboardingStep } from "../OnboardingStep";
 
-export const Notice: React.FC<{
-  goToStep: (step: OnboardingStep) => void;
-}> = ({ goToStep }) => {
+export const Notice = ({ goToStep }: { goToStep: (step: OnboardingStep) => void }) => {
   const noticeItems = [
     {
       content: "Write down your seed phrase and store it in a safe place.",

--- a/apps/desktop/src/components/OperationTile/ContractCallTile.tsx
+++ b/apps/desktop/src/components/OperationTile/ContractCallTile.tsx
@@ -11,9 +11,7 @@ import { ContractIcon } from "../../assets/icons";
 import colors from "../../style/colors";
 import { AddressPill } from "../AddressPill/AddressPill";
 
-export const ContractCallTile: React.FC<{
-  operation: TransactionOperation;
-}> = ({ operation }) => (
+export const ContractCallTile = ({ operation }: { operation: TransactionOperation }) => (
   <Flex flexDirection="column" width="100%" data-testid="operation-tile-contract-call">
     <Flex justifyContent="space-between" marginBottom="10px">
       <Center>

--- a/apps/desktop/src/components/OperationTile/DelegationTile.tsx
+++ b/apps/desktop/src/components/OperationTile/DelegationTile.tsx
@@ -11,7 +11,7 @@ import { BakerIcon } from "../../assets/icons";
 import colors from "../../style/colors";
 import { AddressPill } from "../AddressPill/AddressPill";
 
-export const DelegationTile: React.FC<{ operation: DelegationOperation }> = ({ operation }) => {
+export const DelegationTile = ({ operation }: { operation: DelegationOperation }) => {
   const operationType = operation.newDelegate ? "Delegate" : "Delegation Ended";
 
   return (

--- a/apps/desktop/src/components/OperationTile/Fee.tsx
+++ b/apps/desktop/src/components/OperationTile/Fee.tsx
@@ -11,7 +11,6 @@ import {
 } from "@umami/tzkt";
 import { BigNumber } from "bignumber.js";
 import { get } from "lodash";
-import type React from "react";
 import { useContext } from "react";
 
 import { OperationTileContext } from "./OperationTileContext";
@@ -19,7 +18,9 @@ import colors from "../../style/colors";
 
 const FEE_FIELDS = ["bakerFee", "storageFee", "allocationFee"];
 
-export const Fee: React.FC<{
+export const Fee = ({
+  operation,
+}: {
   operation:
     | TransactionOperation
     | DelegationOperation
@@ -27,7 +28,7 @@ export const Fee: React.FC<{
     | StakeOperation
     | UnstakeOperation
     | FinalizeUnstakeOperation;
-}> = ({ operation }) => {
+}) => {
   const tileContext = useContext(OperationTileContext);
   const isOwned = useIsOwnedAddress();
   const isOutgoing = isOwned(operation.sender.address);

--- a/apps/desktop/src/components/OperationTile/FinalizeUnstakeTile.tsx
+++ b/apps/desktop/src/components/OperationTile/FinalizeUnstakeTile.tsx
@@ -13,8 +13,8 @@ import { BakerIcon } from "../../assets/icons";
 import colors from "../../style/colors";
 import { AddressPill } from "../AddressPill/AddressPill";
 
-export const FinalizeUnstakeTile: React.FC<{ operation: FinalizeUnstakeOperation }> = memo(
-  ({ operation }) => {
+export const FinalizeUnstakeTile = memo(
+  ({ operation }: { operation: FinalizeUnstakeOperation }) => {
     const amount = prettyTezAmount(String(operation.amount));
 
     return (

--- a/apps/desktop/src/components/OperationTile/InternalPrefix.tsx
+++ b/apps/desktop/src/components/OperationTile/InternalPrefix.tsx
@@ -11,9 +11,7 @@ import colors from "../../style/colors";
  *
  * @param operation -
  */
-export const InternalPrefix: React.FC<{
-  operation: TzktCombinedOperation;
-}> = ({ operation }) => {
+export const InternalPrefix = ({ operation }: { operation: TzktCombinedOperation }) => {
   let target;
   let sender;
 

--- a/apps/desktop/src/components/OperationTile/OperationStatus.tsx
+++ b/apps/desktop/src/components/OperationTile/OperationStatus.tsx
@@ -2,10 +2,7 @@ import { useIsBlockFinalised } from "@umami/state";
 
 import { CheckmarkIcon, CrossedCircleIcon, HourglassIcon } from "../../assets/icons";
 
-export const OperationStatus: React.FC<{ level: number; status?: string }> = ({
-  level,
-  status,
-}) => {
+export const OperationStatus = ({ level, status }: { level: number; status?: string }) => {
   const isFinalised = useIsBlockFinalised(level);
 
   // if we don't know the status we assume it's applied

--- a/apps/desktop/src/components/OperationTile/OperationTile.tsx
+++ b/apps/desktop/src/components/OperationTile/OperationTile.tsx
@@ -1,7 +1,6 @@
 import { fromRawToken } from "@umami/core";
 import { useGetTokenTransfer } from "@umami/state";
 import { type TzktCombinedOperation } from "@umami/tzkt";
-import type React from "react";
 
 import { ContractCallTile } from "./ContractCallTile";
 import { DelegationTile } from "./DelegationTile";
@@ -12,9 +11,7 @@ import { TokenTransferTile } from "./TokenTransferTile";
 import { TransactionTile } from "./TransactionTile";
 import { UnstakeTile } from "./UnstakeTile";
 
-export const OperationTile: React.FC<{
-  operation: TzktCombinedOperation;
-}> = ({ operation }) => {
+export const OperationTile = ({ operation }: { operation: TzktCombinedOperation }) => {
   const getTokenTransfer = useGetTokenTransfer();
 
   switch (operation.type) {

--- a/apps/desktop/src/components/OperationTile/OperationTileContext.ts
+++ b/apps/desktop/src/components/OperationTile/OperationTileContext.ts
@@ -1,10 +1,10 @@
 import { type Address } from "@umami/tezos";
-import React from "react";
+import { createContext } from "react";
 
 export type OperationTileContextType =
   | { mode: "page" }
   | { mode: "drawer"; selectedAddress: Address };
 
-export const OperationTileContext = React.createContext<OperationTileContextType>({
+export const OperationTileContext = createContext<OperationTileContextType>({
   mode: "page",
 });

--- a/apps/desktop/src/components/OperationTile/OperationTypeWrapper.tsx
+++ b/apps/desktop/src/components/OperationTile/OperationTypeWrapper.tsx
@@ -5,7 +5,7 @@ import { OperationTileContext } from "./OperationTileContext";
 import colors from "../../style/colors";
 
 // It hides the operation type in the drawer to save space
-export const OperationTypeWrapper: React.FC<PropsWithChildren> = ({ children }) => {
+export const OperationTypeWrapper = ({ children }: PropsWithChildren) => {
   const tileContext = useContext(OperationTileContext);
 
   if (tileContext.mode === "drawer") {

--- a/apps/desktop/src/components/OperationTile/OriginationTile.tsx
+++ b/apps/desktop/src/components/OperationTile/OriginationTile.tsx
@@ -12,7 +12,7 @@ import { ContractIcon } from "../../assets/icons";
 import colors from "../../style/colors";
 import { AddressPill } from "../AddressPill/AddressPill";
 
-export const OriginationTile: React.FC<{ operation: OriginationOperation }> = ({ operation }) => {
+export const OriginationTile = ({ operation }: { operation: OriginationOperation }) => {
   const isMultisig =
     operation.originatedContract.codeHash === CODE_HASH &&
     operation.originatedContract.typeHash === TYPE_HASH;

--- a/apps/desktop/src/components/OperationTile/StakeTile.tsx
+++ b/apps/desktop/src/components/OperationTile/StakeTile.tsx
@@ -13,7 +13,7 @@ import { BakerIcon } from "../../assets/icons";
 import colors from "../../style/colors";
 import { AddressPill } from "../AddressPill/AddressPill";
 
-export const StakeTile: React.FC<{ operation: StakeOperation }> = memo(({ operation }) => {
+export const StakeTile = memo(({ operation }: { operation: StakeOperation }) => {
   const amount = prettyTezAmount(String(operation.amount));
 
   return (

--- a/apps/desktop/src/components/OperationTile/Timestamp.tsx
+++ b/apps/desktop/src/components/OperationTile/Timestamp.tsx
@@ -3,7 +3,7 @@ import { differenceInDays, format, formatDistance } from "date-fns";
 
 import colors from "../../style/colors";
 
-export const Timestamp: React.FC<{ timestamp: string | undefined }> = ({ timestamp }) => {
+export const Timestamp = ({ timestamp }: { timestamp: string | undefined }) => {
   if (!timestamp) {
     return null;
   }

--- a/apps/desktop/src/components/OperationTile/TokenTransferTile.tsx
+++ b/apps/desktop/src/components/OperationTile/TokenTransferTile.tsx
@@ -18,7 +18,11 @@ import colors from "../../style/colors";
 import { getIPFSurl } from "../../utils/token/utils";
 import { AddressPill } from "../AddressPill/AddressPill";
 
-export const TokenTransferTile: React.FC<{
+export const TokenTransferTile = ({
+  operation,
+  tokenTransfer,
+  token,
+}: {
   // externally originated token transfers
   // do not have a corresponding operation in the list
   // in fact, they might not even have a corresponding transaction
@@ -26,7 +30,7 @@ export const TokenTransferTile: React.FC<{
   operation?: TransactionOperation;
   tokenTransfer: TokenTransferOperation;
   token: Token;
-}> = ({ operation, tokenTransfer, token }) => {
+}) => {
   const rawAmount = tokenTransfer.amount;
 
   const operationDestination = useGetOperationDestination(

--- a/apps/desktop/src/components/OperationTile/TransactionTile.tsx
+++ b/apps/desktop/src/components/OperationTile/TransactionTile.tsx
@@ -17,7 +17,7 @@ import {
 import colors from "../../style/colors";
 import { AddressPill } from "../AddressPill/AddressPill";
 
-export const TransactionTile: React.FC<{ operation: TransactionOperation }> = ({ operation }) => {
+export const TransactionTile = ({ operation }: { operation: TransactionOperation }) => {
   const operationDestination = useGetOperationDestination(
     operation.sender.address,
     operation.target?.address

--- a/apps/desktop/src/components/OperationTile/TzktLink.tsx
+++ b/apps/desktop/src/components/OperationTile/TzktLink.tsx
@@ -22,7 +22,7 @@ type OperationIdProps = {
 
 type Props = OperationHashProps | OperationIdProps;
 
-export const TzktLink: React.FC<PropsWithChildren<Props & LinkProps>> = ({
+export const TzktLink = ({
   hash,
   counter,
   transactionId,
@@ -30,7 +30,7 @@ export const TzktLink: React.FC<PropsWithChildren<Props & LinkProps>> = ({
   migrationId,
   children,
   ...props
-}) => {
+}: PropsWithChildren<Props & LinkProps>) => {
   const { tzktExplorerUrl } = useSelectedNetwork();
   let url = tzktExplorerUrl;
 

--- a/apps/desktop/src/components/OperationTile/UnstakeTile.tsx
+++ b/apps/desktop/src/components/OperationTile/UnstakeTile.tsx
@@ -13,7 +13,7 @@ import { BakerIcon } from "../../assets/icons";
 import colors from "../../style/colors";
 import { AddressPill } from "../AddressPill/AddressPill";
 
-export const UnstakeTile: React.FC<{ operation: UnstakeOperation }> = memo(({ operation }) => {
+export const UnstakeTile = memo(({ operation }: { operation: UnstakeOperation }) => {
   const amount = prettyTezAmount(String(operation.amount));
 
   return (

--- a/apps/desktop/src/components/OperationTile/useShowAddress.test.tsx
+++ b/apps/desktop/src/components/OperationTile/useShowAddress.test.tsx
@@ -1,14 +1,15 @@
 import { mockImplicitAddress } from "@umami/tezos";
+import { type PropsWithChildren } from "react";
 
 import { OperationTileContext } from "./OperationTileContext";
 import { useShowAddress } from "./useShowAddress";
 import { renderHook } from "../../mocks/testUtils";
 
-const PageWrapper = ({ children }: { children: React.ReactNode }) => (
+const PageWrapper = ({ children }: PropsWithChildren) => (
   <OperationTileContext.Provider value={{ mode: "page" }}>{children}</OperationTileContext.Provider>
 );
 
-const DrawerWrapper = ({ children }: { children: React.ReactNode }) => (
+const DrawerWrapper = ({ children }: PropsWithChildren) => (
   <OperationTileContext.Provider
     value={{ mode: "drawer", selectedAddress: mockImplicitAddress(0) }}
   >

--- a/apps/desktop/src/components/PopoverMenu.tsx
+++ b/apps/desktop/src/components/PopoverMenu.tsx
@@ -7,14 +7,12 @@ import {
   PopoverTrigger,
   useDisclosure,
 } from "@chakra-ui/react";
-import { type ReactNode } from "react";
+import { type PropsWithChildren } from "react";
 
 import { ThreeDotsIcon } from "../assets/icons";
 import colors from "../style/colors";
 
-export const PopoverMenu: React.FC<{
-  children: ReactNode;
-}> = props => {
+export const PopoverMenu = (props: PropsWithChildren) => {
   const { onOpen, onClose, isOpen } = useDisclosure();
   return (
     <Popover isOpen={isOpen} onClose={onClose} onOpen={onOpen} placement="bottom-start">

--- a/apps/desktop/src/components/PrettyNumber.tsx
+++ b/apps/desktop/src/components/PrettyNumber.tsx
@@ -5,12 +5,14 @@ const splitNumber = (num: string) => {
   return { integer, decimal };
 };
 
-export const PrettyNumber: React.FC<
-  {
-    number: string;
-    size?: "md" | "lg";
-  } & FlexProps
-> = ({ number, size = "md", ...props }) => {
+export const PrettyNumber = ({
+  number,
+  size = "md",
+  ...props
+}: {
+  number: string;
+  size?: "md" | "lg";
+} & FlexProps) => {
   const intSize = size === "md" ? "md" : "lg";
   const fractionSize = size === "md" ? "sm" : "md";
 

--- a/apps/desktop/src/components/ReactIdenticon.tsx
+++ b/apps/desktop/src/components/ReactIdenticon.tsx
@@ -2,61 +2,58 @@
 // the library is unmaintained, but it's a simple component
 // and will stop working with the next major React release
 import md5 from "md5";
-import React, { type CSSProperties, useEffect, useRef } from "react";
+import { memo, useEffect, useRef } from "react";
 
 type Props = {
   count?: number;
   background: string;
   size: number;
   string: string;
-  style?: CSSProperties;
 };
 
-export const ReactIdenticon: React.FC<Props> = React.memo(
-  ({ count = 5, background, string, size }) => {
-    const canvasRef = useRef<HTMLCanvasElement>(null);
+export const ReactIdenticon = memo(({ count = 5, background, string, size }: Props) => {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
 
-    useEffect(() => {
-      updateCanvas();
-    });
+  useEffect(() => {
+    updateCanvas();
+  });
 
-    const updateCanvas = () => {
-      const hash = md5(string);
-      const block = Math.floor(size / count);
-      const hashcolor = hash.slice(0, 6);
+  const updateCanvas = () => {
+    const hash = md5(string);
+    const block = Math.floor(size / count);
+    const hashcolor = hash.slice(0, 6);
 
-      const canvas = canvasRef.current!;
+    const canvas = canvasRef.current!;
 
-      canvas.width = block * count;
-      canvas.height = block * count;
-      const arr = hash
-        .split("")
-        .map(el => parseInt(el, 16))
-        .map(n => (n < 8 ? 0 : 1));
+    canvas.width = block * count;
+    canvas.height = block * count;
+    const arr = hash
+      .split("")
+      .map(el => parseInt(el, 16))
+      .map(n => (n < 8 ? 0 : 1));
 
-      const map = [];
+    const map = [];
 
-      map[0] = map[4] = arr.slice(0, 5);
-      map[1] = map[3] = arr.slice(5, 10);
-      map[2] = arr.slice(10, 15);
+    map[0] = map[4] = arr.slice(0, 5);
+    map[1] = map[3] = arr.slice(5, 10);
+    map[2] = arr.slice(10, 15);
 
-      const ctx = canvas.getContext("2d")!;
-      ctx.imageSmoothingEnabled = false;
-      ctx.clearRect(0, 0, canvas.width, canvas.height);
+    const ctx = canvas.getContext("2d")!;
+    ctx.imageSmoothingEnabled = false;
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
 
-      map.forEach((row, i) => {
-        row.forEach((el, j) => {
-          if (el) {
-            ctx.fillStyle = "#" + hashcolor;
-            ctx.fillRect(block * i, block * j, block, block);
-          } else {
-            ctx.fillStyle = background;
-            ctx.fillRect(block * i, block * j, block, block);
-          }
-        });
+    map.forEach((row, i) => {
+      row.forEach((el, j) => {
+        if (el) {
+          ctx.fillStyle = "#" + hashcolor;
+          ctx.fillRect(block * i, block * j, block, block);
+        } else {
+          ctx.fillStyle = background;
+          ctx.fillRect(block * i, block * j, block, block);
+        }
       });
-    };
+    });
+  };
 
-    return <canvas ref={canvasRef} style={{ width: size, height: size }} />;
-  }
-);
+  return <canvas ref={canvasRef} style={{ width: size, height: size }} />;
+});

--- a/apps/desktop/src/components/RenameRemoveMenu.tsx
+++ b/apps/desktop/src/components/RenameRemoveMenu.tsx
@@ -3,9 +3,12 @@ import { Box, Button, Divider, Flex, Text } from "@chakra-ui/react";
 import { PopoverMenu } from "./PopoverMenu";
 import { PenIcon, TrashIcon } from "../assets/icons";
 
-export const RenameRemoveMenu: React.FC<{ onRename: () => void; onRemove?: () => void }> = ({
+export const RenameRemoveMenu = ({
   onRename,
   onRemove,
+}: {
+  onRename: () => void;
+  onRemove?: () => void;
 }) => (
   <Flex alignItems="center">
     <PopoverMenu>

--- a/apps/desktop/src/components/Select.tsx
+++ b/apps/desktop/src/components/Select.tsx
@@ -5,11 +5,15 @@ import { ChevronDownIcon } from "../assets/icons";
 import colors from "../style/colors";
 
 type Option = { label: string; value: string };
-export const Select: React.FC<{
+export const Select = ({
+  selected,
+  options,
+  onChange,
+}: {
   selected: Option;
   options: Option[];
   onChange: (newValue: string) => void;
-}> = ({ selected, options, onChange }) => {
+}) => {
   const [currentOption, setCurrentOption] = useState(selected);
   const [showOptions, setShowOptions] = useState(false);
 

--- a/apps/desktop/src/components/SendButton.tsx
+++ b/apps/desktop/src/components/SendButton.tsx
@@ -2,11 +2,12 @@ import { Button, type ButtonProps, Text } from "@chakra-ui/react";
 
 import { OutgoingArrow } from "../assets/icons";
 
-export const SendButton: React.FC<
-  {
-    onClick: () => void;
-  } & ButtonProps
-> = ({ onClick, ...buttonProps }) => (
+export const SendButton = ({
+  onClick,
+  ...buttonProps
+}: {
+  onClick: () => void;
+} & ButtonProps) => (
   <Button width="60px" onClick={onClick} variant="specialCTA" {...buttonProps}>
     <OutgoingArrow stroke="currentcolor" />
     <Text marginLeft="4px">Send</Text>

--- a/apps/desktop/src/components/SendFlow/Batch/SignPage.tsx
+++ b/apps/desktop/src/components/SendFlow/Batch/SignPage.tsx
@@ -1,6 +1,5 @@
 import { ModalContent, ModalFooter } from "@chakra-ui/react";
 import { type EstimatedAccountOperations } from "@umami/core";
-import type React from "react";
 import { FormProvider } from "react-hook-form";
 
 import { BatchModalBody } from "../BatchModalBody";
@@ -9,9 +8,11 @@ import { SignButton } from "../SignButton";
 import { headerText } from "../SignPageHeader";
 import { useSignPageHelpers } from "../utils";
 
-export const SignPage: React.FC<{
+export const SignPage = ({
+  initialOperations,
+}: {
   initialOperations: EstimatedAccountOperations;
-}> = ({ initialOperations }) => {
+}) => {
   const { operations, estimationFailed, isLoading, signer, form, reEstimate, onSign } =
     useSignPageHelpers(initialOperations, "batch");
   const title = headerText(operations.type, "batch");

--- a/apps/desktop/src/components/SendFlow/BatchModalBody.tsx
+++ b/apps/desktop/src/components/SendFlow/BatchModalBody.tsx
@@ -1,6 +1,6 @@
 import { Flex, FormLabel, ModalBody, Text } from "@chakra-ui/react";
 import { type EstimatedAccountOperations, totalFee } from "@umami/core";
-import type React from "react";
+import { type PropsWithChildren } from "react";
 
 import { FormPageHeader } from "./FormPageHeader";
 import { SignPageFee } from "./SignPageFee";
@@ -8,12 +8,16 @@ import { subTitle } from "./SignPageHeader";
 import colors from "../../style/colors";
 import { AddressTile } from "../AddressTile/AddressTile";
 
-export const BatchModalBody: React.FC<{
+export const BatchModalBody = ({
+  title,
+  operation,
+  transactionCount,
+  children,
+}: PropsWithChildren<{
   title: string;
   operation: EstimatedAccountOperations;
   transactionCount: number;
-  children?: React.ReactNode;
-}> = ({ title, operation, transactionCount, children }) => (
+}>) => (
   <>
     <FormPageHeader subTitle={subTitle(operation.signer)} title={title} />
     <ModalBody>

--- a/apps/desktop/src/components/SendFlow/Beacon/BatchSignPage.tsx
+++ b/apps/desktop/src/components/SendFlow/Beacon/BatchSignPage.tsx
@@ -24,7 +24,7 @@ import { SignButton } from "../SignButton";
 import { SignPageFee } from "../SignPageFee";
 import { headerText } from "../SignPageHeader";
 
-export const BatchSignPage: React.FC<BeaconSignPageProps> = ({ operation, message }) => {
+export const BatchSignPage = ({ operation, message }: BeaconSignPageProps) => {
   const { isSigning, onSign, network, fee, form } = useSignWithBeacon(operation, message);
   const { signer } = operation;
   const transactionCount = operation.operations.length;

--- a/apps/desktop/src/components/SendFlow/Beacon/BeaconSignPage.tsx
+++ b/apps/desktop/src/components/SendFlow/Beacon/BeaconSignPage.tsx
@@ -8,7 +8,7 @@ import { TezSignPage as BeaconTezSignPage } from "./TezSignPage";
 import { UndelegationSignPage } from "./UndelegationSignPage";
 import { UnstakeSignPage } from "./UnstakeSignPage";
 
-export const BeaconSignPage: React.FC<BeaconSignPageProps> = ({ operation, message }) => {
+export const BeaconSignPage = ({ operation, message }: BeaconSignPageProps) => {
   const operationType = operation.operations[0].type;
 
   switch (operationType) {

--- a/apps/desktop/src/components/SendFlow/Beacon/ContractCallSignPage.tsx
+++ b/apps/desktop/src/components/SendFlow/Beacon/ContractCallSignPage.tsx
@@ -26,7 +26,7 @@ import { SignButton } from "../SignButton";
 import { SignPageFee } from "../SignPageFee";
 import { headerText } from "../SignPageHeader";
 
-export const ContractCallSignPage: React.FC<BeaconSignPageProps> = ({ operation, message }) => {
+export const ContractCallSignPage = ({ operation, message }: BeaconSignPageProps) => {
   const {
     amount: mutezAmount,
     contract,

--- a/apps/desktop/src/components/SendFlow/Beacon/DelegationSignPage.tsx
+++ b/apps/desktop/src/components/SendFlow/Beacon/DelegationSignPage.tsx
@@ -11,7 +11,7 @@ import { SignButton } from "../SignButton";
 import { SignPageFee } from "../SignPageFee";
 import { headerText } from "../SignPageHeader";
 
-export const DelegationSignPage: React.FC<BeaconSignPageProps> = ({ operation, message }) => {
+export const DelegationSignPage = ({ operation, message }: BeaconSignPageProps) => {
   const { recipient } = operation.operations[0] as Delegation;
 
   const { isSigning, onSign, network, fee, form } = useSignWithBeacon(operation, message);

--- a/apps/desktop/src/components/SendFlow/Beacon/FinalizeUnstakeSignPage.tsx
+++ b/apps/desktop/src/components/SendFlow/Beacon/FinalizeUnstakeSignPage.tsx
@@ -11,7 +11,7 @@ import { SignButton } from "../SignButton";
 import { SignPageFee } from "../SignPageFee";
 import { headerText } from "../SignPageHeader";
 
-export const FinalizeUnstakeSignPage: React.FC<BeaconSignPageProps> = ({ operation, message }) => {
+export const FinalizeUnstakeSignPage = ({ operation, message }: BeaconSignPageProps) => {
   const { isSigning, onSign, network, fee, form } = useSignWithBeacon(operation, message);
   const totalFinalizableAmount = useAccountTotalFinalizableUnstakeAmount(
     operation.signer.address.pkh

--- a/apps/desktop/src/components/SendFlow/Beacon/Header.tsx
+++ b/apps/desktop/src/components/SendFlow/Beacon/Header.tsx
@@ -7,11 +7,15 @@ import colors from "../../../style/colors";
 import { SignPageHeader } from "../SignPageHeader";
 import { type SignPageMode } from "../utils";
 
-export const Header: React.FC<{
+export const Header = ({
+  operation,
+  message,
+  mode,
+}: {
   operation: AccountOperations;
   message: OperationRequestOutput;
   mode: SignPageMode;
-}> = ({ operation, message, mode }) => (
+}) => (
   <SignPageHeader mode={mode} operationsType={operation.type} signer={operation.signer}>
     <Flex alignItems="center" justifyContent="center" marginTop="10px">
       <Heading marginRight="4px" color={colors.gray[450]} size="sm">

--- a/apps/desktop/src/components/SendFlow/Beacon/OriginationOperationSignPage.tsx
+++ b/apps/desktop/src/components/SendFlow/Beacon/OriginationOperationSignPage.tsx
@@ -28,10 +28,7 @@ import { SignButton } from "../SignButton";
 import { SignPageFee } from "../SignPageFee";
 import { headerText } from "../SignPageHeader";
 
-export const OriginationOperationSignPage: React.FC<BeaconSignPageProps> = ({
-  operation,
-  message,
-}) => {
+export const OriginationOperationSignPage = ({ operation, message }: BeaconSignPageProps) => {
   const { isSigning, onSign, network, form, fee } = useSignWithBeacon(operation, message);
   const { code, storage } = operation.operations[0] as ContractOrigination;
 

--- a/apps/desktop/src/components/SendFlow/Beacon/StakeSignPage.tsx
+++ b/apps/desktop/src/components/SendFlow/Beacon/StakeSignPage.tsx
@@ -11,7 +11,7 @@ import { SignButton } from "../SignButton";
 import { SignPageFee } from "../SignPageFee";
 import { headerText } from "../SignPageHeader";
 
-export const StakeSignPage: React.FC<BeaconSignPageProps> = ({ operation, message }) => {
+export const StakeSignPage = ({ operation, message }: BeaconSignPageProps) => {
   const { amount: mutezAmount } = operation.operations[0] as Stake;
 
   const { isSigning, onSign, network, fee, form } = useSignWithBeacon(operation, message);

--- a/apps/desktop/src/components/SendFlow/Beacon/TezSignPage.tsx
+++ b/apps/desktop/src/components/SendFlow/Beacon/TezSignPage.tsx
@@ -12,7 +12,7 @@ import { SignButton } from "../SignButton";
 import { SignPageFee } from "../SignPageFee";
 import { headerText } from "../SignPageHeader";
 
-export const TezSignPage: React.FC<BeaconSignPageProps> = ({ operation, message }) => {
+export const TezSignPage = ({ operation, message }: BeaconSignPageProps) => {
   const { amount: mutezAmount, recipient } = operation.operations[0] as TezTransfer;
 
   const { isSigning, onSign, network, fee, form } = useSignWithBeacon(operation, message);

--- a/apps/desktop/src/components/SendFlow/Beacon/UndelegationSignPage.tsx
+++ b/apps/desktop/src/components/SendFlow/Beacon/UndelegationSignPage.tsx
@@ -10,7 +10,7 @@ import { SignButton } from "../SignButton";
 import { SignPageFee } from "../SignPageFee";
 import { headerText } from "../SignPageHeader";
 
-export const UndelegationSignPage: React.FC<BeaconSignPageProps> = ({ operation, message }) => {
+export const UndelegationSignPage = ({ operation, message }: BeaconSignPageProps) => {
   const { isSigning, onSign, network, form, fee } = useSignWithBeacon(operation, message);
 
   return (

--- a/apps/desktop/src/components/SendFlow/Beacon/UnstakeSignPage.tsx
+++ b/apps/desktop/src/components/SendFlow/Beacon/UnstakeSignPage.tsx
@@ -11,7 +11,7 @@ import { SignButton } from "../SignButton";
 import { SignPageFee } from "../SignPageFee";
 import { headerText } from "../SignPageHeader";
 
-export const UnstakeSignPage: React.FC<BeaconSignPageProps> = ({ operation, message }) => {
+export const UnstakeSignPage = ({ operation, message }: BeaconSignPageProps) => {
   const { amount: mutezAmount } = operation.operations[0] as Unstake;
 
   const { isSigning, onSign, network, fee, form } = useSignWithBeacon(operation, message);

--- a/apps/desktop/src/components/SendFlow/Delegation/FormPage.tsx
+++ b/apps/desktop/src/components/SendFlow/Delegation/FormPage.tsx
@@ -8,7 +8,6 @@ import {
 } from "@chakra-ui/react";
 import { type Delegation } from "@umami/core";
 import { type RawPkh, parseImplicitPkh, parsePkh } from "@umami/tezos";
-import type React from "react";
 import { FormProvider, useForm } from "react-hook-form";
 
 import { SignPage } from "./SignPage";
@@ -27,7 +26,7 @@ export type FormValues = {
   baker: RawPkh;
 };
 
-export const FormPage: React.FC<FormPageProps<FormValues>> = props => {
+export const FormPage = (props: FormPageProps<FormValues>) => {
   const baker = props.form?.baker;
 
   const openSignPage = useOpenSignPageFormAction({

--- a/apps/desktop/src/components/SendFlow/Delegation/SignPage.tsx
+++ b/apps/desktop/src/components/SendFlow/Delegation/SignPage.tsx
@@ -10,7 +10,7 @@ import { SignPageFee } from "../SignPageFee";
 import { SignPageHeader, headerText } from "../SignPageHeader";
 import { type SignPageProps, useSignPageHelpers } from "../utils";
 
-export const SignPage: React.FC<SignPageProps> = props => {
+export const SignPage = (props: SignPageProps) => {
   const { mode, operations: initialOperations } = props;
   const { fee, operations, estimationFailed, isLoading, form, signer, reEstimate, onSign } =
     useSignPageHelpers(initialOperations, mode);

--- a/apps/desktop/src/components/SendFlow/FinalizeUnstake/SignPage.tsx
+++ b/apps/desktop/src/components/SendFlow/FinalizeUnstake/SignPage.tsx
@@ -21,7 +21,7 @@ import { headerText } from "../SignPageHeader";
 import { type SignPageProps, useSignPageHelpers } from "../utils";
 
 // TODO: test
-export const SignPage: React.FC<SignPageProps<{ finalizableAmount: BigNumber }>> = props => {
+export const SignPage = (props: SignPageProps<{ finalizableAmount: BigNumber }>) => {
   const {
     mode,
     operations,

--- a/apps/desktop/src/components/SendFlow/FormPageHeader.tsx
+++ b/apps/desktop/src/components/SendFlow/FormPageHeader.tsx
@@ -10,10 +10,13 @@ export const HeaderWrapper = chakra(ModalHeader, {
   },
 });
 
-export const FormPageHeader: React.FC<{
+export const FormPageHeader = ({
+  title = "Send",
+  subTitle = "Send one or insert into batch",
+}: {
   title?: string;
   subTitle?: string;
-}> = ({ title = "Send", subTitle = "Send one or insert into batch" }) => (
+}) => (
   <HeaderWrapper>
     <Heading size="2xl">{title}</Heading>
     <Text marginTop="10px" color={colors.gray[400]} textAlign="center" size="sm">

--- a/apps/desktop/src/components/SendFlow/Multisig/SignPage.tsx
+++ b/apps/desktop/src/components/SendFlow/Multisig/SignPage.tsx
@@ -9,7 +9,6 @@ import {
 } from "@umami/core";
 import { useAsyncActionHandler } from "@umami/state";
 import { capitalize } from "lodash";
-import type React from "react";
 import { useContext } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 
@@ -18,14 +17,19 @@ import { BatchModalBody } from "../BatchModalBody";
 import { SignButton } from "../SignButton";
 import { SuccessStep } from "../SuccessStep";
 
-export const SignPage: React.FC<{
+export const SignPage = ({
+  signer,
+  operation,
+  actionType,
+  transactionCount,
+}: {
   operation: EstimatedAccountOperations;
   actionType: ApproveOrExecute;
   signer: ImplicitAccount;
   // A single approve/execute `ContractCall` operation could contain multiple transactions
   // so we need to pass the transaction count by decoding the proposed multisig action separately
   transactionCount: number;
-}> = ({ signer, operation, actionType, transactionCount }) => {
+}) => {
   const { handleAsyncAction } = useAsyncActionHandler();
   const { openWith } = useContext(DynamicModalContext);
   const form = useForm({

--- a/apps/desktop/src/components/SendFlow/MultisigAccount/NameMultisigFormPage.tsx
+++ b/apps/desktop/src/components/SendFlow/MultisigAccount/NameMultisigFormPage.tsx
@@ -25,7 +25,7 @@ type FormValues = {
   name: string;
 };
 
-export const NameMultisigFormPage: React.FC<{ name?: string }> = ({ name }) => {
+export const NameMultisigFormPage = ({ name }: { name?: string }) => {
   const form = useForm<FormValues>({
     mode: "onBlur",
     defaultValues: { name: name || "" },

--- a/apps/desktop/src/components/SendFlow/MultisigAccount/SelectApproversFormPage.tsx
+++ b/apps/desktop/src/components/SendFlow/MultisigAccount/SelectApproversFormPage.tsx
@@ -41,9 +41,9 @@ const toOperation = (formValues: FormValues) => ({
   ),
 });
 
-export const SelectApproversFormPage: React.FC<
-  FormPageProps<FormValues> & { sender: ImplicitAccount; goBack: () => void }
-> = props => {
+export const SelectApproversFormPage = (
+  props: FormPageProps<FormValues> & { sender: ImplicitAccount; goBack: () => void }
+) => {
   const { goBack, sender, ...formValues } = props;
   const form = useForm<FormValues>({
     mode: "onBlur",

--- a/apps/desktop/src/components/SendFlow/MultisigAccount/SignTransactionFormPage.tsx
+++ b/apps/desktop/src/components/SendFlow/MultisigAccount/SignTransactionFormPage.tsx
@@ -24,7 +24,7 @@ import { SignPageFee } from "../SignPageFee";
 import { SignPageHeader } from "../SignPageHeader";
 import { type SignPageProps, useSignPageHelpers } from "../utils";
 
-export const SignTransactionFormPage: React.FC<SignPageProps<FormValues>> = props => {
+export const SignTransactionFormPage = (props: SignPageProps<FormValues>) => {
   const dispatch = useAppDispatch();
 
   const { isLoading: contractNameObtainingIsLoading, handleAsyncAction } = useAsyncActionHandler();
@@ -142,10 +142,7 @@ export const SignTransactionFormPage: React.FC<SignPageProps<FormValues>> = prop
   );
 };
 
-const Threshold: React.FC<{ threshold: number; signersAmount: number }> = ({
-  threshold,
-  signersAmount,
-}) => (
+const Threshold = ({ threshold, signersAmount }: { threshold: number; signersAmount: number }) => (
   <Flex alignItems="center" data-testid="threshold">
     <Heading marginRight="4px" color={colors.gray[450]} size="sm">
       No. of approvals:

--- a/apps/desktop/src/components/SendFlow/NFT/FormPage.tsx
+++ b/apps/desktop/src/components/SendFlow/NFT/FormPage.tsx
@@ -12,7 +12,6 @@ import {
 } from "@chakra-ui/react";
 import { type FA2Transfer, type NFTBalance } from "@umami/core";
 import { type RawPkh, parseContractPkh, parsePkh } from "@umami/tezos";
-import type React from "react";
 import { FormProvider, useForm } from "react-hook-form";
 
 import { SignPage } from "./SignPage";
@@ -34,9 +33,7 @@ export type FormValues = {
   recipient: RawPkh;
 };
 
-export const FormPage: React.FC<
-  FormPagePropsWithSender<FormValues> & { nft: NFTBalance }
-> = props => {
+export const FormPage = (props: FormPagePropsWithSender<FormValues> & { nft: NFTBalance }) => {
   const { nft } = props;
 
   const openSignPage = useOpenSignPageFormAction({

--- a/apps/desktop/src/components/SendFlow/NFT/SignPage.tsx
+++ b/apps/desktop/src/components/SendFlow/NFT/SignPage.tsx
@@ -21,7 +21,7 @@ import { SignPageFee } from "../SignPageFee";
 import { SignPageHeader, headerText } from "../SignPageHeader";
 import { type SignPageProps, useSignPageHelpers } from "../utils";
 
-export const SignPage: React.FC<SignPageProps<{ nft: NFTBalance }>> = props => {
+export const SignPage = (props: SignPageProps<{ nft: NFTBalance }>) => {
   const {
     mode,
     operations: initialOperations,

--- a/apps/desktop/src/components/SendFlow/SignButton.tsx
+++ b/apps/desktop/src/components/SendFlow/SignButton.tsx
@@ -11,26 +11,25 @@ import {
 import * as Auth from "@umami/social-auth";
 import { useAsyncActionHandler, useGetSecretKey, useSelectedNetwork } from "@umami/state";
 import { type Network, makeToolkit } from "@umami/tezos";
-import type React from "react";
 import { FormProvider, useForm, useFormContext } from "react-hook-form";
 
 import { FormErrorMessage } from "../FormErrorMessage";
 import { PasswordInput } from "../PasswordInput";
 
-export const SignButton: React.FC<{
-  onSubmit: (tezosToolkit: TezosToolkit) => Promise<BatchWalletOperation | void>;
-  signer: ImplicitAccount;
-  isLoading?: boolean;
-  isDisabled?: boolean;
-  text?: string; // TODO: after FillStep migration change to the header value from SignPage
-  network?: Network;
-}> = ({
+export const SignButton = ({
   signer,
   onSubmit,
   isLoading: externalIsLoading,
   isDisabled,
   text,
   network: preferredNetwork,
+}: {
+  onSubmit: (tezosToolkit: TezosToolkit) => Promise<BatchWalletOperation | void>;
+  signer: ImplicitAccount;
+  isLoading?: boolean;
+  isDisabled?: boolean;
+  text?: string; // TODO: after FillStep migration change to the header value from SignPage
+  network?: Network;
 }) => {
   const form = useForm<{ password: string }>({ mode: "onBlur", defaultValues: { password: "" } });
   const {

--- a/apps/desktop/src/components/SendFlow/SignPageFee.tsx
+++ b/apps/desktop/src/components/SendFlow/SignPageFee.tsx
@@ -3,7 +3,7 @@ import { prettyTezAmount } from "@umami/tezos";
 
 import colors from "../../style/colors";
 
-export const SignPageFee: React.FC<{ fee: string | number }> = ({ fee }) => (
+export const SignPageFee = ({ fee }: { fee: string | number }) => (
   <Flex alignItems="center">
     <Heading marginRight="4px" color={colors.gray[450]} size="sm">
       Fee:

--- a/apps/desktop/src/components/SendFlow/SignPageHeader.tsx
+++ b/apps/desktop/src/components/SendFlow/SignPageHeader.tsx
@@ -39,16 +39,22 @@ export const subTitle = (signer: ImplicitAccount): string | undefined => {
 };
 
 // TODO: pass in AccountOperations instead of signer & operationsType
-export const SignPageHeader: React.FC<
-  PropsWithChildren<{
-    goBack?: () => void;
-    mode: SignPageMode;
-    operationsType: AccountOperations["type"];
-    signer: ImplicitAccount;
-    title?: string;
-    description?: string;
-  }>
-> = ({ goBack, mode, operationsType, signer, title, description, children }) => (
+export const SignPageHeader = ({
+  goBack,
+  mode,
+  operationsType,
+  signer,
+  title,
+  description,
+  children,
+}: PropsWithChildren<{
+  goBack?: () => void;
+  mode: SignPageMode;
+  operationsType: AccountOperations["type"];
+  signer: ImplicitAccount;
+  title?: string;
+  description?: string;
+}>) => (
   <HeaderWrapper>
     {goBack && <ModalBackButton onClick={goBack} />}
     <Heading data-testid="sign-page-header" size="2xl">

--- a/apps/desktop/src/components/SendFlow/Stake/FormPage.tsx
+++ b/apps/desktop/src/components/SendFlow/Stake/FormPage.tsx
@@ -13,9 +13,7 @@ import {
   ModalHeader,
 } from "@chakra-ui/react";
 import { type Stake } from "@umami/core";
-import { type RawPkh, TEZ, TEZ_DECIMALS, parsePkh } from "@umami/tezos";
-import { tezToMutez } from "@umami/tezos";
-import type React from "react";
+import { type RawPkh, TEZ, TEZ_DECIMALS, parsePkh, tezToMutez } from "@umami/tezos";
 import { FormProvider, useForm } from "react-hook-form";
 
 import { SignPage } from "./SignPage";
@@ -40,7 +38,7 @@ type FormValues = {
 };
 
 // TODO: test
-export const FormPage: React.FC<FormPageProps<FormValues>> = props => {
+export const FormPage = (props: FormPageProps<FormValues>) => {
   const openSignPage = useOpenSignPageFormAction({
     SignPage,
     signPageExtraData: undefined,

--- a/apps/desktop/src/components/SendFlow/Stake/SignPage.tsx
+++ b/apps/desktop/src/components/SendFlow/Stake/SignPage.tsx
@@ -11,7 +11,7 @@ import { SignPageHeader, headerText } from "../SignPageHeader";
 import { type SignPageProps, useSignPageHelpers } from "../utils";
 
 // TODO: test
-export const SignPage: React.FC<SignPageProps> = props => {
+export const SignPage = (props: SignPageProps) => {
   const { mode, operations } = props;
   const { isLoading, form, signer, onSign, fee } = useSignPageHelpers(operations, mode);
 

--- a/apps/desktop/src/components/SendFlow/SuccessStep.tsx
+++ b/apps/desktop/src/components/SendFlow/SuccessStep.tsx
@@ -11,13 +11,12 @@ import {
 } from "@chakra-ui/react";
 import { DynamicModalContext } from "@umami/components";
 import { useSelectedNetwork } from "@umami/state";
-import type React from "react";
 import { useContext } from "react";
 import { Link, useNavigate } from "react-router-dom";
 
 import { WindowLinkIcon } from "../../assets/icons/WindowLink";
 
-export const SuccessStep: React.FC<{ hash: string }> = ({ hash }) => {
+export const SuccessStep = ({ hash }: { hash: string }) => {
   const network = useSelectedNetwork();
   const tzktUrl = `${network.tzktExplorerUrl}/${hash}`;
   const { onClose } = useContext(DynamicModalContext);

--- a/apps/desktop/src/components/SendFlow/Tez/FormPage.tsx
+++ b/apps/desktop/src/components/SendFlow/Tez/FormPage.tsx
@@ -9,9 +9,7 @@ import {
   ModalFooter,
 } from "@chakra-ui/react";
 import { type TezTransfer } from "@umami/core";
-import { type RawPkh, TEZ, TEZ_DECIMALS, parsePkh } from "@umami/tezos";
-import { tezToMutez } from "@umami/tezos";
-import type React from "react";
+import { type RawPkh, TEZ, TEZ_DECIMALS, parsePkh, tezToMutez } from "@umami/tezos";
 import { FormProvider, useForm } from "react-hook-form";
 
 import { SignPage } from "./SignPage";
@@ -37,10 +35,10 @@ export type FormValues = {
   prettyAmount: string;
 };
 
-export const FormPage: React.FC<FormPageProps<FormValues> & { showPreview?: boolean }> = ({
+export const FormPage = ({
   showPreview = true,
   ...props
-}) => {
+}: FormPageProps<FormValues> & { showPreview?: boolean }) => {
   const openSignPage = useOpenSignPageFormAction({
     SignPage,
     signPageExtraData: undefined,

--- a/apps/desktop/src/components/SendFlow/Tez/SignPage.tsx
+++ b/apps/desktop/src/components/SendFlow/Tez/SignPage.tsx
@@ -11,7 +11,7 @@ import { SignPageFee } from "../SignPageFee";
 import { SignPageHeader, headerText } from "../SignPageHeader";
 import { type SignPageProps, useSignPageHelpers } from "../utils";
 
-export const SignPage: React.FC<SignPageProps> = props => {
+export const SignPage = (props: SignPageProps) => {
   const { mode, operations: initialOperations } = props;
   const { fee, operations, estimationFailed, isLoading, form, signer, reEstimate, onSign } =
     useSignPageHelpers(initialOperations, mode);

--- a/apps/desktop/src/components/SendFlow/Token/FormPage.tsx
+++ b/apps/desktop/src/components/SendFlow/Token/FormPage.tsx
@@ -19,7 +19,6 @@ import {
   tokenSymbolSafe,
 } from "@umami/core";
 import { type RawPkh, parseContractPkh, parsePkh } from "@umami/tezos";
-import type React from "react";
 import { FormProvider, useForm } from "react-hook-form";
 
 import { SignPage } from "./SignPage";
@@ -45,9 +44,9 @@ export type FormValues = {
   prettyAmount: string;
 };
 
-export const FormPage: React.FC<
-  FormPagePropsWithSender<FormValues> & { token: FA12TokenBalance | FA2TokenBalance }
-> = props => {
+export const FormPage = (
+  props: FormPagePropsWithSender<FormValues> & { token: FA12TokenBalance | FA2TokenBalance }
+) => {
   const { token } = props;
   const openSignPage = useOpenSignPageFormAction({
     SignPage,

--- a/apps/desktop/src/components/SendFlow/Token/SignPage.tsx
+++ b/apps/desktop/src/components/SendFlow/Token/SignPage.tsx
@@ -11,9 +11,7 @@ import { SignPageFee } from "../SignPageFee";
 import { SignPageHeader, headerText } from "../SignPageHeader";
 import { type SignPageProps, useSignPageHelpers } from "../utils";
 
-export const SignPage: React.FC<
-  SignPageProps<{ token: FA12TokenBalance | FA2TokenBalance }>
-> = props => {
+export const SignPage = (props: SignPageProps<{ token: FA12TokenBalance | FA2TokenBalance }>) => {
   const {
     mode,
     operations: initialOperations,

--- a/apps/desktop/src/components/SendFlow/Undelegation/FormPage.tsx
+++ b/apps/desktop/src/components/SendFlow/Undelegation/FormPage.tsx
@@ -1,7 +1,6 @@
 import { FormControl, FormLabel, ModalBody, ModalContent, ModalFooter } from "@chakra-ui/react";
 import { type Undelegation } from "@umami/core";
 import { type RawPkh, parsePkh } from "@umami/tezos";
-import type React from "react";
 import { FormProvider, useForm } from "react-hook-form";
 
 import { SignPage } from "./SignPage";
@@ -20,7 +19,7 @@ export type FormValues = {
   baker: RawPkh;
 };
 
-export const FormPage: React.FC<FormPagePropsWithSender<FormValues>> = props => {
+export const FormPage = (props: FormPagePropsWithSender<FormValues>) => {
   const { sender } = props;
   // it must always be passed in from the parent component
   const baker = props.form?.baker;

--- a/apps/desktop/src/components/SendFlow/Undelegation/SignPage.tsx
+++ b/apps/desktop/src/components/SendFlow/Undelegation/SignPage.tsx
@@ -9,7 +9,7 @@ import { SignPageFee } from "../SignPageFee";
 import { SignPageHeader, headerText } from "../SignPageHeader";
 import { type SignPageProps, useSignPageHelpers } from "../utils";
 
-export const SignPage: React.FC<SignPageProps> = props => {
+export const SignPage = (props: SignPageProps) => {
   const { mode, operations: initialOperations } = props;
 
   const { fee, operations, estimationFailed, isLoading, form, signer, reEstimate, onSign } =

--- a/apps/desktop/src/components/SendFlow/Unstake/FormPage.tsx
+++ b/apps/desktop/src/components/SendFlow/Unstake/FormPage.tsx
@@ -13,10 +13,8 @@ import {
   ModalHeader,
 } from "@chakra-ui/react";
 import { type Unstake } from "@umami/core";
-import { type RawPkh, TEZ, TEZ_DECIMALS, parsePkh } from "@umami/tezos";
-import { tezToMutez } from "@umami/tezos";
+import { type RawPkh, TEZ, TEZ_DECIMALS, parsePkh, tezToMutez } from "@umami/tezos";
 import BigNumber from "bignumber.js";
-import type React from "react";
 import { FormProvider, useForm } from "react-hook-form";
 
 import { SignPage } from "./SignPage";
@@ -41,7 +39,7 @@ type FormValues = {
 };
 
 // TODO: test
-export const FormPage: React.FC<FormPageProps<FormValues> & { stakedBalance: number }> = props => {
+export const FormPage = (props: FormPageProps<FormValues> & { stakedBalance: number }) => {
   const stakedBalance = props.stakedBalance;
 
   const openSignPage = useOpenSignPageFormAction({

--- a/apps/desktop/src/components/SendFlow/Unstake/SignPage.tsx
+++ b/apps/desktop/src/components/SendFlow/Unstake/SignPage.tsx
@@ -10,7 +10,7 @@ import { SignPageFee } from "../SignPageFee";
 import { SignPageHeader, headerText } from "../SignPageHeader";
 import { type SignPageProps, useSignPageHelpers } from "../utils";
 // TODO: test
-export const SignPage: React.FC<SignPageProps<{ stakedBalance: number }>> = props => {
+export const SignPage = (props: SignPageProps<{ stakedBalance: number }>) => {
   const {
     mode,
     operations,

--- a/apps/desktop/src/components/SendFlow/onSubmitFormActionHooks.tsx
+++ b/apps/desktop/src/components/SendFlow/onSubmitFormActionHooks.tsx
@@ -7,7 +7,7 @@ import {
   useAsyncActionHandler,
   useSelectedNetwork,
 } from "@umami/state";
-import { useContext } from "react";
+import { type FunctionComponent, useContext } from "react";
 
 import {
   type BaseFormValues,
@@ -28,11 +28,11 @@ type UseOpenSignPageArgs<
   FormProps extends FormPageProps<FormValues>,
 > = {
   // Sign page component to render.
-  SignPage: React.FC<SignPageProps<ExtraData>>;
+  SignPage: FunctionComponent<SignPageProps<ExtraData>>;
   // Extra data to pass to the Sign page component (e.g. NFT or Token)
   signPageExtraData: ExtraData;
   // Form page component to render when the user goes back from the sign page.
-  FormPage: React.FC<FormProps>;
+  FormPage: FunctionComponent<FormProps>;
   // Form page props, used to render the form page again when the user goes back from the sign page
   defaultFormPageProps: FormProps;
   // Function to convert raw form values to the Operation type we can work with

--- a/apps/desktop/src/components/SideNavbar.tsx
+++ b/apps/desktop/src/components/SideNavbar.tsx
@@ -1,6 +1,6 @@
 import { Box, Divider, Flex, type FlexProps, Text, useMediaQuery } from "@chakra-ui/react";
 import { useTotalBalance } from "@umami/state";
-import type React from "react";
+import { type ReactElement } from "react";
 import { Link, useLocation } from "react-router-dom";
 
 import { AppVersion } from "./AppVersion";
@@ -112,14 +112,18 @@ export const SideNavbar = () => {
   );
 };
 
-const MenuItem: React.FC<
-  {
-    label: string;
-    icon: React.ReactElement;
-    to: string;
-    isCollapsed: boolean;
-  } & FlexProps
-> = ({ icon, label, to, isCollapsed, ...flexProps }) => {
+const MenuItem = ({
+  icon,
+  label,
+  to,
+  isCollapsed,
+  ...flexProps
+}: {
+  label: string;
+  icon: ReactElement;
+  to: string;
+  isCollapsed: boolean;
+} & FlexProps) => {
   const currentLocation = useLocation();
   // TODO: check if there are named routes in react-router-dom
   const isSelected = currentLocation.pathname.startsWith(to);

--- a/apps/desktop/src/components/SmallTab.tsx
+++ b/apps/desktop/src/components/SmallTab.tsx
@@ -1,9 +1,8 @@
 import { Tab, type TabProps } from "@chakra-ui/react";
-import type React from "react";
-import { type ReactNode } from "react";
+import { type PropsWithChildren } from "react";
 
-export const SmallTab: React.FC<{ children: ReactNode } & TabProps> = ({ children, ...props }) => (
-  <Tab {...props} fontSize="sm" paddingX={3}>
+export const SmallTab = ({ children, ...props }: PropsWithChildren<TabProps>) => (
+  <Tab {...props} fontSize="sm" paddingX="12px">
     {children}
   </Tab>
 );

--- a/apps/desktop/src/components/TezRecapDisplay.tsx
+++ b/apps/desktop/src/components/TezRecapDisplay.tsx
@@ -1,15 +1,14 @@
 import { Box, Heading, Text } from "@chakra-ui/react";
 import { prettyTezAmount } from "@umami/tezos";
 import type { BigNumber } from "bignumber.js";
-import type React from "react";
 
 import colors from "../style/colors";
 
-export const TezRecapDisplay: React.FC<{
+export const TezRecapDisplay = (props: {
   balance: BigNumber | number | string;
   dollarBalance: BigNumber | undefined;
   center?: boolean;
-}> = props => (
+}) => (
   <Box textAlign={props.center ? "center" : "initial"}>
     <Heading size="md">{prettyTezAmount(props.balance)}</Heading>
     {props.dollarBalance !== undefined && (

--- a/apps/desktop/src/components/TokenTile.tsx
+++ b/apps/desktop/src/components/TokenTile.tsx
@@ -10,9 +10,11 @@ import { PrettyNumber } from "./PrettyNumber";
 import { TokenIcon } from "../assets/icons";
 import colors from "../style/colors";
 
-export const TokenTile: React.FC<
-  { token: FA12TokenBalance | FA2TokenBalance; amount: string } & FlexProps
-> = ({ token, amount, ...flexProps }) => {
+export const TokenTile = ({
+  token,
+  amount,
+  ...flexProps
+}: { token: FA12TokenBalance | FA2TokenBalance; amount: string } & FlexProps) => {
   const { contract } = token;
 
   const prettyAmount = tokenPrettyAmount(amount, token);

--- a/apps/desktop/src/components/TopBar.tsx
+++ b/apps/desktop/src/components/TopBar.tsx
@@ -11,7 +11,6 @@ import {
 import { DynamicModalContext } from "@umami/components";
 import { assetsActions, useAppDispatch, useIsLoading, useLastTimeUpdated } from "@umami/state";
 import { differenceInMinutes, differenceInSeconds, formatDistance } from "date-fns";
-import type React from "react";
 import { useContext, useEffect, useState } from "react";
 
 import { BuyTezForm } from "./BuyTez/BuyTezForm";
@@ -91,7 +90,7 @@ const UpdateButton = () => {
   );
 };
 
-export const TopBar: React.FC<{ title: string; subtitle?: string }> = ({ title, subtitle }) => {
+export const TopBar = ({ title, subtitle }: { title: string; subtitle?: string }) => {
   const { openWith } = useContext(DynamicModalContext);
 
   return (

--- a/apps/desktop/src/components/TruncatedTextWithTooltip.tsx
+++ b/apps/desktop/src/components/TruncatedTextWithTooltip.tsx
@@ -1,11 +1,13 @@
 import { Text, Tooltip } from "@chakra-ui/react";
 import { truncate } from "@umami/tezos";
-import type React from "react";
 
-export const TruncatedTextWithTooltip: React.FC<{
+export const TruncatedTextWithTooltip = ({
+  text,
+  maxLength,
+}: {
   text: string;
   maxLength: number;
-}> = ({ text, maxLength }) => {
+}) => {
   if (text.length <= maxLength) {
     return <Text data-testid="truncated-text">{text}</Text>;
   }

--- a/apps/desktop/src/mocks/testUtils.tsx
+++ b/apps/desktop/src/mocks/testUtils.tsx
@@ -1,7 +1,7 @@
 import * as testLib from "@testing-library/react";
 import { DynamicModalContext, useDynamicModal } from "@umami/components";
 import { type UmamiStore, makeStore } from "@umami/state";
-import { type PropsWithChildren, act } from "react";
+import { type PropsWithChildren, type ReactNode, act } from "react";
 import { Provider } from "react-redux";
 import { HashRouter } from "react-router-dom";
 
@@ -51,7 +51,7 @@ const customRender = <
   Container extends Element | DocumentFragment = HTMLElement,
   BaseElement extends Element | DocumentFragment = Container,
 >(
-  ui: React.ReactNode,
+  ui: ReactNode,
   options?: testLib.RenderOptions<Q, Container, BaseElement> & { store?: UmamiStore }
 ): testLib.RenderResult<Q, Container, BaseElement> & { store: UmamiStore } => {
   const store = options?.store ?? makeStore();

--- a/apps/desktop/src/utils/beacon/BeaconProvider.tsx
+++ b/apps/desktop/src/utils/beacon/BeaconProvider.tsx
@@ -4,7 +4,7 @@ import { type PropsWithChildren, useEffect } from "react";
 
 import { useHandleBeaconMessage } from "./useHandleBeaconMessage";
 
-export const BeaconProvider: React.FC<PropsWithChildren> = ({ children }) => {
+export const BeaconProvider = ({ children }: PropsWithChildren) => {
   const toast = useToast();
 
   const handleBeaconMessage = useHandleBeaconMessage();

--- a/apps/desktop/src/utils/beacon/PermissionRequestModal.tsx
+++ b/apps/desktop/src/utils/beacon/PermissionRequestModal.tsx
@@ -31,7 +31,6 @@ import {
   useGetImplicitAccount,
 } from "@umami/state";
 import { capitalize } from "lodash";
-import type React from "react";
 import { useContext } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 
@@ -39,9 +38,7 @@ import { JsValueWrap } from "../../components/AccountDrawer/JsValueWrap";
 import { OwnedImplicitAccountsAutocomplete } from "../../components/AddressAutocomplete";
 import colors from "../../style/colors";
 
-export const PermissionRequestModal: React.FC<{
-  request: PermissionRequestOutput;
-}> = ({ request }) => {
+export const PermissionRequestModal = ({ request }: { request: PermissionRequestOutput }) => {
   const addConnectionToBeaconSlice = useAddConnection();
   const getAccount = useGetImplicitAccount();
   const { onClose } = useContext(DynamicModalContext);

--- a/apps/desktop/src/utils/beacon/SignPayloadRequestModal.tsx
+++ b/apps/desktop/src/utils/beacon/SignPayloadRequestModal.tsx
@@ -17,7 +17,6 @@ import {
 import { type TezosToolkit } from "@taquito/taquito";
 import { DynamicModalContext } from "@umami/components";
 import { WalletClient, useGetImplicitAccount } from "@umami/state";
-import type React from "react";
 import { useContext } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 
@@ -25,9 +24,7 @@ import { decodePayload } from "./decodePayload";
 import { SignButton } from "../../components/SendFlow/SignButton";
 import colors from "../../style/colors";
 
-export const SignPayloadRequestModal: React.FC<{
-  request: SignPayloadRequestOutput;
-}> = ({ request }) => {
+export const SignPayloadRequestModal = ({ request }: { request: SignPayloadRequestOutput }) => {
   const { onClose } = useContext(DynamicModalContext);
   const getAccount = useGetImplicitAccount();
   const signerAccount = getAccount(request.sourceAddress);

--- a/apps/desktop/src/views/addressBook/AddressBookView.tsx
+++ b/apps/desktop/src/views/addressBook/AddressBookView.tsx
@@ -9,7 +9,7 @@ import { NoItems } from "../../components/NoItems";
 import { TopBar } from "../../components/TopBar";
 import { UpsertContactModal } from "../../components/UpsertContactModal";
 
-const AddContact: React.FC = () => {
+const AddContact = () => {
   const { openWith } = useContext(DynamicModalContext);
   return (
     <Button

--- a/apps/desktop/src/views/addressBook/ContactTable.tsx
+++ b/apps/desktop/src/views/addressBook/ContactTable.tsx
@@ -11,7 +11,7 @@ import { FormPage } from "../../components/SendFlow/Tez/FormPage";
 import { UpsertContactModal } from "../../components/UpsertContactModal";
 import colors from "../../style/colors";
 
-export const ContactTable: React.FC<{ contacts: Contact[] }> = ({ contacts }) => {
+export const ContactTable = ({ contacts }: { contacts: Contact[] }) => {
   const { openWith } = useContext(DynamicModalContext);
   return (
     <Box overflow="auto" background={colors.gray[900]} borderRadius="8px" paddingX="30px">

--- a/apps/desktop/src/views/batch/BatchView.tsx
+++ b/apps/desktop/src/views/batch/BatchView.tsx
@@ -12,7 +12,7 @@ import {
 } from "@umami/state";
 import { TEZ } from "@umami/tezos";
 import pluralize from "pluralize";
-import React, { useContext, useEffect } from "react";
+import { useContext, useEffect, useState } from "react";
 
 import { AccountSmallTile } from "./AccountSmallTile";
 import { OperationEstimationStatus } from "./OperationEstimationStatus";
@@ -25,11 +25,15 @@ import { SignPage } from "../../components/SendFlow/Batch/SignPage";
 import { headerText } from "../../components/SendFlow/SignPageHeader";
 import colors from "../../style/colors";
 
-const RightHeader: React.FC<{
+const RightHeader = ({
+  operations: accountOperations,
+  onSubmit,
+  isLoading,
+}: {
   operations: AccountOperations;
   onSubmit: () => Promise<void>;
   isLoading: boolean;
-}> = ({ operations: accountOperations, onSubmit, isLoading }) => {
+}) => {
   const { type: operationsType, sender, operations } = accountOperations;
   const { openWith } = useContext(DynamicModalContext);
 
@@ -93,16 +97,14 @@ const SUCCESSFUL_ESTIMATION_RESULT = {
   metadata: { operation_result: { status: "applied" } },
 } as OperationContentsAndResult;
 
-export const BatchView: React.FC<{
-  operations: AccountOperations;
-}> = ({ operations: accountOperations }) => {
+export const BatchView = ({ operations: accountOperations }: { operations: AccountOperations }) => {
   const { operations, sender } = accountOperations;
   const showFooter = operations.length > 9;
 
   const removeItem = useRemoveBatchItem();
   const { openWith } = useContext(DynamicModalContext);
   const network = useSelectedNetwork();
-  const [operationsEstimationResults, setOperationsEstimationResults] = React.useState<
+  const [operationsEstimationResults, setOperationsEstimationResults] = useState<
     OperationContentsAndResult[]
   >([]);
 

--- a/apps/desktop/src/views/batch/OperationEstimationStatus.tsx
+++ b/apps/desktop/src/views/batch/OperationEstimationStatus.tsx
@@ -1,6 +1,7 @@
 import { Center, Flex, Text } from "@chakra-ui/react";
 import type { OperationContentsAndResult, OperationResultStatusEnum } from "@taquito/rpc";
 import { get } from "lodash";
+import { type ReactNode } from "react";
 
 import { CheckmarkIcon, ExclamationIcon, WarningIcon } from "../../assets/icons";
 import colors from "../../style/colors";
@@ -21,7 +22,7 @@ export const OperationEstimationStatus = ({
     return null;
   }
 
-  let icon: React.ReactNode;
+  let icon: ReactNode;
   let textColor: string;
   let description: string;
 

--- a/apps/desktop/src/views/help/HelpView.tsx
+++ b/apps/desktop/src/views/help/HelpView.tsx
@@ -1,5 +1,5 @@
 import { Box, Flex, Grid, GridItem, Heading, Text } from "@chakra-ui/react";
-import type React from "react";
+import { type PropsWithChildren } from "react";
 import { Link } from "react-router-dom";
 
 import { ExternalLinkIcon } from "../../assets/icons";
@@ -55,11 +55,15 @@ export const HelpView = () => (
   </Grid>
 );
 
-const HelpLinkRow: React.FC<{
+const HelpLinkRow = ({
+  about,
+  externalLink,
+  linkDescription,
+}: {
   about: string;
   externalLink: string;
   linkDescription?: string;
-}> = ({ about, externalLink, linkDescription }) => (
+}) => (
   <Link rel="noopener noreferrer" target="_blank" to={externalLink}>
     <ClickableCard cursor="pointer" isSelected={false}>
       <Flex alignItems="center" justifyContent="space-between">
@@ -78,10 +82,12 @@ const HelpLinkRow: React.FC<{
   </Link>
 );
 
-const HelpCard: React.FC<{
+const HelpCard = ({
+  title,
+  children,
+}: PropsWithChildren<{
   title: string;
-  children: React.ReactNode;
-}> = ({ title, children }) => (
+}>) => (
   <Box data-testid="help-card" marginY="10px">
     <Flex>
       <Box width="550px">

--- a/apps/desktop/src/views/home/AccountGroup.tsx
+++ b/apps/desktop/src/views/home/AccountGroup.tsx
@@ -10,10 +10,13 @@ import { getAccountGroupLabel } from "./getAccountGroupLabel";
 import { AccountTile } from "../../components/AccountTile/AccountTile";
 import { ConfirmationModal } from "../../components/ConfirmationModal";
 
-export const AccountGroup: React.FC<{
+export const AccountGroup = ({
+  groupLabel,
+  accounts,
+}: {
   accounts: Account[];
   groupLabel: string;
-}> = ({ groupLabel, accounts }) => {
+}) => {
   const first = accounts[0];
   const isMultisig = first.type === "multisig";
   const isMnemonic = first.type === "mnemonic";

--- a/apps/desktop/src/views/home/AccountGroupPopover.tsx
+++ b/apps/desktop/src/views/home/AccountGroupPopover.tsx
@@ -4,10 +4,13 @@ import { PlusIcon } from "../../assets/icons";
 import { TrashIcon } from "../../assets/icons/Trash";
 import { PopoverMenu } from "../../components/PopoverMenu";
 
-export const AccountGroupPopover: React.FC<{
+export const AccountGroupPopover = ({
+  onRemove,
+  onCreate,
+}: {
   onRemove: () => void;
   onCreate?: () => void;
-}> = ({ onRemove, onCreate }) => (
+}) => (
   <PopoverMenu>
     <Box paddingY="0">
       <Button

--- a/apps/desktop/src/views/home/AccountListWithDrawer.tsx
+++ b/apps/desktop/src/views/home/AccountListWithDrawer.tsx
@@ -19,7 +19,7 @@ import { DerivationInfoButton } from "../../components/AccountDrawer/DerivationI
 import { CloseDrawerButton } from "../../components/CloseDrawerButton";
 import { NFTDrawerBody } from "../nfts/NFTDrawerBody";
 
-export const AccountListWithDrawer: React.FC = () => {
+export const AccountListWithDrawer = () => {
   const [selectedAccount, setSelectedAccount] = useState<Account | null>(null);
 
   const { ownerPkh, nftId } = useParams();

--- a/apps/desktop/src/views/nfts/NFTCard.tsx
+++ b/apps/desktop/src/views/nfts/NFTCard.tsx
@@ -8,9 +8,7 @@ import { AddressPill } from "../../components/AddressPill/AddressPill";
 import colors from "../../style/colors";
 import { type NFTWithOwner, getIPFSurl } from "../../utils/token/utils";
 
-export const NFTCard: React.FC<{
-  nft: NFTWithOwner;
-}> = ({ nft }) => {
+export const NFTCard = ({ nft }: { nft: NFTWithOwner }) => {
   const { selectedNFT, setSelectedNFT: select } = useContext(SelectedNFTContext);
   const url = getIPFSurl(thumbnailUri(nft));
   const fallbackUrl = getIPFSurl(nft.displayUri);

--- a/apps/desktop/src/views/nfts/NFTGallery.tsx
+++ b/apps/desktop/src/views/nfts/NFTGallery.tsx
@@ -1,14 +1,15 @@
 import { SimpleGrid } from "@chakra-ui/react";
 import { type NFTBalance, fullId } from "@umami/core";
 import { type RawPkh } from "@umami/tezos";
-import type React from "react";
 
 import { NFTCard } from "./NFTCard";
 import { sortedByLastUpdate } from "../../utils/token/utils";
 
-export const NFTGallery: React.FC<{
+export const NFTGallery = ({
+  nftsByOwner,
+}: {
   nftsByOwner: Record<RawPkh, NFTBalance[] | undefined>;
-}> = ({ nftsByOwner }) => {
+}) => {
   const allNFTs = Object.entries(nftsByOwner).flatMap(([owner, nfts]) =>
     (nfts || []).map(nft => ({ owner, ...nft }))
   );

--- a/apps/desktop/src/views/operations/OperationsView.tsx
+++ b/apps/desktop/src/views/operations/OperationsView.tsx
@@ -1,5 +1,5 @@
 import { Box, Center, Divider, Flex, Image } from "@chakra-ui/react";
-import { useRef } from "react";
+import { type UIEvent, useRef } from "react";
 
 import { useGetOperations } from "./useGetOperations";
 import { NoOperations } from "../../components/NoItems";
@@ -16,7 +16,7 @@ export const OperationsView = () => {
   // otherwise it might be called multiple times which would trigger multiple fetches
   const skipLoadMore = useRef<boolean>(false);
 
-  const onScroll = (e: React.UIEvent<HTMLDivElement, UIEvent>) => {
+  const onScroll = (e: UIEvent<HTMLDivElement>) => {
     if (skipLoadMore.current || !hasMore || isLoading) {
       return;
     }

--- a/apps/desktop/src/views/operations/useGetOperations.tsx
+++ b/apps/desktop/src/views/operations/useGetOperations.tsx
@@ -1,10 +1,14 @@
 import { useInfiniteQuery } from "@tanstack/react-query";
 import { type Account } from "@umami/core";
 import { useReactQueryErrorHandler, useRefetchTrigger } from "@umami/data-polling";
-import { useSelectedNetwork } from "@umami/state";
-import { type AppDispatch, assetsActions, tokensActions, useAppDispatch } from "@umami/state";
-import { type Network } from "@umami/tezos";
-import { BLOCK_TIME } from "@umami/tezos";
+import {
+  type AppDispatch,
+  assetsActions,
+  tokensActions,
+  useAppDispatch,
+  useSelectedNetwork,
+} from "@umami/state";
+import { BLOCK_TIME, type Network } from "@umami/tezos";
 import {
   type TokenTransferOperation,
   type TzktCombinedOperation,

--- a/apps/desktop/src/views/settings/ErrorLogsDrawerCard.tsx
+++ b/apps/desktop/src/views/settings/ErrorLogsDrawerCard.tsx
@@ -72,9 +72,7 @@ const ErrorLogsDrawerBody = () => {
   );
 };
 
-const ErrorLogRow: React.FC<{
-  errorLog: ErrorContext;
-}> = ({ errorLog }) => (
+const ErrorLogRow = ({ errorLog }: { errorLog: ErrorContext }) => (
   <>
     <Divider marginY={1} />
     <Flex justifyContent="space-between" paddingY="12px">

--- a/apps/desktop/src/views/settings/SettingsView.tsx
+++ b/apps/desktop/src/views/settings/SettingsView.tsx
@@ -1,6 +1,6 @@
 import { Box, Button, Flex, Heading } from "@chakra-ui/react";
 import { DynamicModalContext } from "@umami/components";
-import { useContext } from "react";
+import { type PropsWithChildren, useContext } from "react";
 
 import { DAppsDrawerCard } from "./DAppsDrawerCard";
 import { ErrorLogsDrawerCard } from "./ErrorLogsDrawerCard";
@@ -81,10 +81,12 @@ const AdvancedSection = () => {
   );
 };
 
-const SectionContainer: React.FC<{
+const SectionContainer = ({
+  title,
+  children,
+}: PropsWithChildren<{
   title: string;
-  children: React.ReactNode;
-}> = ({ title, children }) => (
+}>) => (
   <Box marginTop="8px">
     <Flex>
       <Box width="550px">

--- a/apps/desktop/src/views/tokens/AccountTokens.tsx
+++ b/apps/desktop/src/views/tokens/AccountTokens.tsx
@@ -19,7 +19,6 @@ import {
   tokenPrettyAmount,
 } from "@umami/core";
 import { formatPkh, parseContractPkh } from "@umami/tezos";
-import type React from "react";
 import { useContext } from "react";
 
 import { TokenNameWithIcon } from "./TokenNameWithIcon";
@@ -32,9 +31,7 @@ import { SendButton } from "../../components/SendButton";
 import { FormPage as SendTokenFormPage } from "../../components/SendFlow/Token/FormPage";
 import colors from "../../style/colors";
 
-const Header: React.FC<{
-  account: Account;
-}> = ({ account }) => {
+const Header = ({ account }: { account: Account }) => {
   const { address, label } = account;
   return (
     <Flex
@@ -70,10 +67,13 @@ const Header: React.FC<{
   );
 };
 
-export const AccountTokens: React.FC<{
+export const AccountTokens = ({
+  account,
+  tokens,
+}: {
   account: Account;
   tokens: (FA12TokenBalance | FA2TokenBalance)[];
-}> = ({ account, tokens }) => {
+}) => {
   const { openWith } = useContext(DynamicModalContext);
 
   return (

--- a/apps/desktop/src/views/withSideMenu.tsx
+++ b/apps/desktop/src/views/withSideMenu.tsx
@@ -1,8 +1,9 @@
 import { Box, Flex } from "@chakra-ui/react";
+import { type ReactElement } from "react";
 
 import { SideNavbar } from "../components/SideNavbar";
 
-export const withSideMenu = (body: React.ReactElement) => (
+export const withSideMenu = (body: ReactElement) => (
   <Flex height="100vh">
     <SideNavbar />
     <Box

--- a/apps/embed-iframe/src/LoginButtonComponent.tsx
+++ b/apps/embed-iframe/src/LoginButtonComponent.tsx
@@ -3,10 +3,13 @@ import { type TypeOfLogin } from "@trilitech-umami/umami-embed/types";
 
 import { FacebookLogoIcon, GoogleLogoIcon, RedditLogoIcon, TwitterLogoIcon } from "./assets/icons";
 
-export const LoginButtonComponent: React.FC<{
+export const LoginButtonComponent = ({
+  onClick,
+  loginType,
+}: {
   onClick: () => void;
   loginType: TypeOfLogin;
-}> = ({ onClick, loginType }) => (
+}) => (
   <Button
     position="relative"
     width="100%"
@@ -24,9 +27,7 @@ export const LoginButtonComponent: React.FC<{
   </Button>
 );
 
-const LogoIconWithBackground: React.FC<{
-  loginType: TypeOfLogin;
-}> = ({ loginType }) => (
+const LogoIconWithBackground = ({ loginType }: { loginType: TypeOfLogin }) => (
   <Flex
     alignItems="center"
     justifyContent="center"
@@ -40,9 +41,7 @@ const LogoIconWithBackground: React.FC<{
   </Flex>
 );
 
-const LogoIcon: React.FC<{
-  loginType: TypeOfLogin;
-}> = ({ loginType }) => {
+const LogoIcon = ({ loginType }: { loginType: TypeOfLogin }) => {
   switch (loginType) {
     case "facebook":
       return <FacebookLogoIcon />;

--- a/apps/embed-iframe/src/LoginModalContent.tsx
+++ b/apps/embed-iframe/src/LoginModalContent.tsx
@@ -13,10 +13,13 @@ import { sendLoginErrorResponse, sendResponse } from "./utils";
 
 const LOGIN_TIMEOUT = 3 * 60 * 1000; // 3 minutes
 
-export const LoginModalContent: React.FC<{
+export const LoginModalContent = ({
+  closeModal,
+  onLoginCallback,
+}: {
   closeModal: () => void;
   onLoginCallback: (loginType: TypeOfLogin) => void;
-}> = ({ closeModal, onLoginCallback }) => {
+}) => {
   const [isLoading, setIsLoading] = useState(false);
 
   const onLoginClick = async (loginType: TypeOfLogin) => {

--- a/apps/embed-iframe/src/SignOperationModalContent.tsx
+++ b/apps/embed-iframe/src/SignOperationModalContent.tsx
@@ -30,11 +30,15 @@ import { sendOperationErrorResponse, sendResponse } from "./utils";
 
 const SIGN_TIMEOUT = 5 * 60 * 1000; // 5 minutes
 
-export const OperationModalContent: React.FC<{
+export const OperationModalContent = ({
+  operations,
+  closeModal,
+  loginType,
+}: {
   operations: PartialTezosOperation[];
   closeModal: () => void;
   loginType: TypeOfLogin;
-}> = ({ operations, closeModal, loginType }) => {
+}) => {
   const [isLoading, setIsLoading] = useState(false);
 
   console.log(operations);

--- a/apps/embed-iframe/src/imported/JsValueWrap.tsx
+++ b/apps/embed-iframe/src/imported/JsValueWrap.tsx
@@ -3,11 +3,11 @@ import { Card, CardBody, type CardProps } from "@chakra-ui/react";
 import colors from "./style/colors";
 
 // Wrapper for any JavaScript value
-export const JsValueWrap: React.FC<{ value: any; space?: number } & CardProps> = ({
+export const JsValueWrap = ({
   value,
   space = 2,
   ...props
-}) => (
+}: { value: any; space?: number } & CardProps) => (
   <Card background={colors.grey[100]} borderRadius="5px" {...props}>
     <CardBody>
       <pre

--- a/apps/embed-iframe/src/main.tsx
+++ b/apps/embed-iframe/src/main.tsx
@@ -1,5 +1,5 @@
 import { ChakraProvider, ColorModeScript } from "@chakra-ui/react";
-import React from "react";
+import { StrictMode } from "react";
 import ReactDOM from "react-dom/client";
 
 import { EmbeddedComponent } from "./EmbeddedComponent";
@@ -8,10 +8,10 @@ import theme from "./imported/style/theme";
 
 const rootElement = document.getElementById("root");
 ReactDOM.createRoot(rootElement!).render(
-  <React.StrictMode>
+  <StrictMode>
     <ChakraProvider theme={theme}>
       <ColorModeScript initialColorMode={theme.config.initialColorMode} />
       <EmbeddedComponent />
     </ChakraProvider>
-  </React.StrictMode>
+  </StrictMode>
 );

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,7 +1,7 @@
 import { getErrorContext } from "@umami/core";
 import { accountsActions, errorsActions } from "@umami/state";
 import { encryptedMnemonic1 } from "@umami/test-utils";
-import React from "react";
+import { StrictMode } from "react";
 import ReactDOM from "react-dom/client";
 import { ErrorBoundary } from "react-error-boundary";
 import { BrowserRouter } from "react-router-dom";
@@ -53,7 +53,7 @@ if (IS_DEV) {
 }
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
-  <React.StrictMode>
+  <StrictMode>
     <UmamiTheme>
       <ReduxStore>
         <PersistGate loading={<div>loading</div>} persistor={persistor}>
@@ -69,5 +69,5 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
         </PersistGate>
       </ReduxStore>
     </UmamiTheme>
-  </React.StrictMode>
+  </StrictMode>
 );

--- a/apps/web/src/providers/ReduxStore.tsx
+++ b/apps/web/src/providers/ReduxStore.tsx
@@ -1,8 +1,8 @@
-import type React from "react";
+import { type PropsWithChildren } from "react";
 import { Provider } from "react-redux";
 
 import { store } from "../utils/store";
 
-export const ReduxStore = (props: { children: React.ReactElement }) => (
+export const ReduxStore = (props: PropsWithChildren) => (
   <Provider store={store}>{props.children}</Provider>
 );

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -86,9 +86,9 @@ module.exports = {
     "import/no-unresolved": "off",
     "import/no-cycle": "warn",
     "import/no-self-import": "warn",
-    // TODO: enable after React.FC occurrences are removed
-    // "import/no-duplicates": ["warn", { "prefer-inline": true }],
-    // "no-duplicate-imports": "warn",
+
+    "import/no-duplicates": ["warn", { "prefer-inline": true }],
+    "no-duplicate-imports": "warn",
     "import/order": [
       "warn",
       {
@@ -118,6 +118,15 @@ module.exports = {
     "react-redux/useSelector-prefer-selectors": "off",
     eqeqeq: ["warn", "always"],
     "@typescript-eslint/consistent-type-imports": ["error", { fixStyle: "inline-type-imports" }],
+    "no-restricted-imports": [
+      "warn", {
+        "paths": [{
+          "name": "react",
+          "importNames": ["default"],
+          "message": "use `import { <...> } from 'react'` instead"
+        }]
+      }
+    ]
   },
   overrides: [
     {


### PR DESCRIPTION
import React from "react" is now restricted as everything can be imported by destructuring anyway, but it confuses the eslint rule for the type imports

cleaning it allows us to automatically merge duplicated imports, import only types where possible 