### PR TITLE
Run test jobs in CI sequentially

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -36,4 +36,4 @@ jobs:
 
       - run: yarn ci
 
-      - run: yarn test
+      - run: yarn test --concurrency 1

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "build": "turbo build",
     "clean": "rimraf .turbo && turbo clean",
-    "test": "turbo test --concurrency 2",
+    "test": "turbo test",
     "lint": "turbo lint",
     "format": "turbo format",
     "ci": "turbo check-types lint:ci format:ci audit check-circular-deps",


### PR DESCRIPTION
these jobs underneath use concurrency/parallelism themselves. so, even if we have just 2 jobs, 4 CPU cores, they both would compete for all 4 cores, and it leads, sometimes, to timeouts