### PR TITLE
Add build:quick turbo task

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   ],
   "scripts": {
     "build": "turbo build",
+    "build:watch": "turbo watch build:quick --filter=./packages/\\*",
     "clean": "rimraf .turbo && turbo clean",
     "test": "turbo test",
     "lint": "turbo lint",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -43,7 +43,8 @@
     "typescript": "^5.5.4"
   },
   "scripts": {
-    "build": "tsup-node",
+    "build": "tsup-node --dts",
+    "build:quick": "tsup-node",
     "clean": "rimraf build dist .turbo",
     "check-circular-deps": "madge --circular src/index.ts",
     "check-types:watch": "yarn check-types --watch",
@@ -64,8 +65,7 @@
     "format": [
       "cjs",
       "esm"
-    ],
-    "dts": true
+    ]
   },
   "dependencies": {
     "@chakra-ui/react": "^2.8.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -33,7 +33,8 @@
     "typescript": "^5.5.4"
   },
   "scripts": {
-    "build": "tsup-node",
+    "build": "tsup-node --dts",
+    "build:quick": "tsup-node",
     "clean": "rimraf build dist .turbo",
     "check-circular-deps": "madge --circular src/index.ts",
     "check-types:watch": "yarn check-types --watch",
@@ -54,8 +55,7 @@
     "format": [
       "cjs",
       "esm"
-    ],
-    "dts": true
+    ]
   },
   "dependencies": {
     "@taquito/rpc": "^20.0.1",

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -32,7 +32,8 @@
     "typescript": "^5.5.4"
   },
   "scripts": {
-    "build": "tsup-node",
+    "build": "tsup-node --dts",
+    "build:quick": "tsup-node",
     "clean": "rimraf build dist .turbo",
     "check-circular-deps": "madge --circular src/index.ts",
     "check-types:watch": "yarn check-types --watch",
@@ -53,8 +54,7 @@
     "format": [
       "cjs",
       "esm"
-    ],
-    "dts": true
+    ]
   },
   "dependencies": {
     "@taquito/utils": "^20.0.1"

--- a/packages/data-polling/package.json
+++ b/packages/data-polling/package.json
@@ -36,7 +36,8 @@
     "typescript": "^5.5.4"
   },
   "scripts": {
-    "build": "tsup-node",
+    "build": "tsup-node --dts",
+    "build:quick": "tsup-node",
     "clean": "rimraf build dist .turbo",
     "check-circular-deps": "madge --circular src/index.ts",
     "check-types:watch": "yarn check-types --watch",
@@ -57,8 +58,7 @@
     "format": [
       "cjs",
       "esm"
-    ],
-    "dts": true
+    ]
   },
   "dependencies": {
     "@chakra-ui/react": "^2.8.2",

--- a/packages/jest-config/package.json
+++ b/packages/jest-config/package.json
@@ -17,7 +17,8 @@
     }
   },
   "scripts": {
-    "build": "tsup"
+    "build": "tsup",
+    "build:quick": "tsup"
   },
   "devDependencies": {
     "jest": "^29.7.0",

--- a/packages/multisig/package.json
+++ b/packages/multisig/package.json
@@ -33,7 +33,8 @@
     "typescript": "^5.5.4"
   },
   "scripts": {
-    "build": "tsup-node",
+    "build": "tsup-node --dts",
+    "build:quick": "tsup-node",
     "clean": "rimraf build dist .turbo",
     "check-circular-deps": "madge --circular src/index.ts",
     "check-types:watch": "yarn check-types --watch",
@@ -54,8 +55,7 @@
     "format": [
       "cjs",
       "esm"
-    ],
-    "dts": true
+    ]
   },
   "dependencies": {
     "@taquito/rpc": "^20.0.1",

--- a/packages/social-auth/package.json
+++ b/packages/social-auth/package.json
@@ -14,7 +14,8 @@
   },
   "type": "module",
   "scripts": {
-    "build": "tsup-node",
+    "build": "tsup-node --dts",
+    "build:quick": "tsup-node",
     "clean": "rimraf build dist .turbo",
     "check-circular-deps": "madge --circular src/index.ts",
     "check-types:watch": "yarn check-types --watch",

--- a/packages/state/package.json
+++ b/packages/state/package.json
@@ -38,7 +38,8 @@
     "typescript": "^5.5.4"
   },
   "scripts": {
-    "build": "tsup-node",
+    "build": "tsup-node --dts",
+    "build:quick": "tsup-node",
     "clean": "rimraf build dist .turbo",
     "check-circular-deps": "madge --circular src/index.ts",
     "check-types:watch": "yarn check-types --watch",
@@ -59,8 +60,7 @@
     "format": [
       "cjs",
       "esm"
-    ],
-    "dts": true
+    ]
   },
   "dependencies": {
     "@airgap/beacon-wallet": "^4.2.2",

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -28,7 +28,8 @@
     "typescript": "^5.5.4"
   },
   "scripts": {
-    "build": "tsup-node",
+    "build": "tsup-node --dts",
+    "build:quick": "tsup-node",
     "clean": "rimraf build dist .turbo",
     "check-circular-deps": "madge --circular src/index.ts",
     "check-types:watch": "yarn check-types --watch",
@@ -49,8 +50,7 @@
     "format": [
       "cjs",
       "esm"
-    ],
-    "dts": true
+    ]
   },
   "dependencies": {
     "@taquito/rpc": "^20.0.1",

--- a/packages/tezos/package.json
+++ b/packages/tezos/package.json
@@ -32,7 +32,8 @@
     "typescript": "^5.5.4"
   },
   "scripts": {
-    "build": "tsup-node",
+    "build": "tsup-node --dts",
+    "build:quick": "tsup-node",
     "clean": "rimraf build dist .turbo",
     "check-circular-deps": "madge --circular src/index.ts",
     "check-types:watch": "yarn check-types --watch",
@@ -53,8 +54,7 @@
     "format": [
       "cjs",
       "esm"
-    ],
-    "dts": true
+    ]
   },
   "dependencies": {
     "@ledgerhq/hw-transport-webusb": "^6.29.2",

--- a/packages/tzkt/package.json
+++ b/packages/tzkt/package.json
@@ -42,7 +42,8 @@
     "typescript": "^5.5.4"
   },
   "scripts": {
-    "build": "tsup-node",
+    "build": "tsup-node --dts",
+    "build:quick": "tsup-node",
     "clean": "rimraf build dist .turbo",
     "check-circular-deps": "madge --circular src/index.ts",
     "check-types:watch": "yarn check-types --watch",
@@ -63,7 +64,6 @@
     "format": [
       "cjs",
       "esm"
-    ],
-    "dts": true
+    ]
   }
 }

--- a/turbo.json
+++ b/turbo.json
@@ -2,6 +2,14 @@
   "$schema": "https://turbo.build/schema.json",
   "tasks": {
     "audit": {},
+    "build:quick": {
+      "outputs": [
+        "dist/**"
+      ],
+      "dependsOn": [
+        "^build:quick"
+      ]
+    },
     "build": {
       "outputs": [
         "dist/**",
@@ -26,7 +34,7 @@
       "persistent": true,
       "cache": false,
       "dependsOn": [
-        "^build"
+        "^check-types"
       ]
     },
     "clean": {
@@ -36,7 +44,7 @@
       "persistent": true,
       "cache": false,
       "dependsOn": [
-        "^build"
+        "^build:quick"
       ]
     },
     "format": {
@@ -74,7 +82,7 @@
         "CI"
       ],
       "dependsOn": [
-        "^build"
+        "^build:quick"
       ]
     },
     "test:e2e": {


### PR DESCRIPTION
this speeds up dev experience. DTS processing takes 10-20x more time than building actual js files.
type-checking might suffer a bit from this change, but VScode consumes the types from the typescript files anyway, not the dts.

the problematic parts are circular deps check and (potentially) linting which relies on types. but it'll be checked properly on CI anyway