### PR TITLE
Add password step for seedphrase import

### DIFF
--- a/apps/desktop-e2e/src/helpers/AccountGroup.ts
+++ b/apps/desktop-e2e/src/helpers/AccountGroup.ts
@@ -93,7 +93,8 @@ export class AccountGroupBuilder {
     for (let i = 0; i < this.accountGroup.accounts.length; i++) {
       const keyPair = await derivePublicKeyPair(
         this.seedPhrase.join(" "),
-        makeDerivationPath(this.derivationPathTemplate, i)
+        makeDerivationPath(this.derivationPathTemplate, i),
+        "ed25519"
       );
       this.accountGroup.accounts[i].pkh = keyPair.pkh;
     }

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -31,7 +31,7 @@
     "lint:ci": "eslint src --ext .js,.jsx,.ts,.tsx --max-warnings=0",
     "lint": "eslint src --ext .js,.jsx,.ts,.tsx --fix",
     "preview": "vite preview --host 127.0.0.1 --port 3000",
-    "test:watch": "cross-env DEV=true pnpm test --watch",
+    "test:watch": "cross-env DEV=true pnpm run test --watch",
     "test": "cross-env TZ=CET jest",
     "theme:watch": "chakra-cli tokens src/style/theme.ts --watch",
     "theme": "chakra-cli tokens src/style/theme.ts"

--- a/apps/desktop/src/components/Onboarding/masterPassword/MasterPassword.tsx
+++ b/apps/desktop/src/components/Onboarding/masterPassword/MasterPassword.tsx
@@ -37,6 +37,7 @@ export const MasterPassword = ({
           await restoreFromMnemonic({
             ...account,
             password,
+            curve: "ed25519", // TODO: add support for other curves
           });
       }
       toast({ description: "Account successfully created!", status: "success" });

--- a/apps/desktop/src/components/Onboarding/restoreMnemonic/RestoreMnemonic.test.tsx
+++ b/apps/desktop/src/components/Onboarding/restoreMnemonic/RestoreMnemonic.test.tsx
@@ -51,8 +51,7 @@ describe("<RestoreMnemonic />", () => {
       await act(() => user.click(confirmBtn));
 
       expect(mockToast).toHaveBeenCalledWith({
-        description:
-          'Invalid Mnemonic: "test test test test test test test test test test test test test test test test test test test test test test test test"',
+        description: "Invalid Mnemonic",
         status: "error",
         isClosable: true,
       });

--- a/apps/desktop/src/components/Onboarding/restoreMnemonic/RestoreMnemonic.tsx
+++ b/apps/desktop/src/components/Onboarding/restoreMnemonic/RestoreMnemonic.tsx
@@ -65,7 +65,7 @@ export const RestoreMnemonic = ({ goToStep }: { goToStep: (step: OnboardingStep)
     handleAsyncAction(async () => {
       const mnemonic = Object.values(data).join(" ").trim();
       if (!validateMnemonic(mnemonic)) {
-        throw new Error(`Invalid Mnemonic: "${mnemonic}"`);
+        throw new Error("Invalid Mnemonic");
       }
       goToStep({
         type: "nameAccount",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,7 +16,7 @@
     "lint:ci": "eslint src --ext .ts,.tsx --max-warnings=0",
     "lint": "eslint src --ext .ts,.tsx --fix",
     "preview": "vite preview",
-    "test:watch": "cross-env DEV=true pnpm test --watch",
+    "test:watch": "cross-env DEV=true pnpm run test --watch",
     "test": "cross-env TZ=CET jest",
     "storybook": "storybook dev -p 6006",
     "build:storybook": "storybook build"

--- a/apps/web/src/components/Onboarding/ImportWallet/SeedPhraseTabPanel.test.tsx
+++ b/apps/web/src/components/Onboarding/ImportWallet/SeedPhraseTabPanel.test.tsx
@@ -31,12 +31,20 @@ describe("<SeedPhraseTabPanel />", () => {
     render(<TestComponent />);
 
     await act(() => user.click(screen.getByText("24 word seed phrase")));
-    const changeSizeButton = await screen.findByRole("button", { name: "12" });
-    await act(() => user.click(changeSizeButton));
+    const changeTo12Button = await screen.findByRole("button", { name: "12" });
+    await act(() => user.click(changeTo12Button));
 
     expect(screen.queryByText("24 word seed phrase")).not.toBeInTheDocument();
     expect(screen.getByText("12 word seed phrase")).toBeVisible();
     expect(screen.getAllByRole("textbox")).toHaveLength(12);
+
+    const changeTo15Button = await screen.findByRole("button", { name: "15" });
+    await act(() => user.click(changeTo15Button));
+
+    expect(screen.queryByText("24 word seed phrase")).not.toBeInTheDocument();
+    expect(screen.queryByText("12 word seed phrase")).not.toBeInTheDocument();
+    expect(screen.getByText("15 word seed phrase")).toBeVisible();
+    expect(screen.getAllByRole("textbox")).toHaveLength(15);
   });
 
   it("validates the presence of the words", async () => {

--- a/apps/web/src/components/Onboarding/ImportWallet/SeedPhraseTabPanel.tsx
+++ b/apps/web/src/components/Onboarding/ImportWallet/SeedPhraseTabPanel.tsx
@@ -13,48 +13,51 @@ import {
   TabPanel,
   Text,
 } from "@chakra-ui/react";
-import { MnemonicAutocomplete } from "@umami/components";
+import { MnemonicAutocomplete, useDynamicModalContext, useMultiForm } from "@umami/components";
 import { useAsyncActionHandler } from "@umami/state";
 import { range } from "lodash";
-import { useState } from "react";
-import { FormProvider, useForm } from "react-hook-form";
+import { FormProvider, useFieldArray } from "react-hook-form";
 
 import { CloseIcon } from "../../../assets/icons";
 import { useColor } from "../../../styles/useColor";
+import { RadioButtons } from "../../RadioButtons/RadioButtons";
+import { SetupPassword } from "../SetupPassword";
 
 const MNEMONIC_SIZE_OPTIONS = [12, 15, 18, 21, 24];
 
 export const SeedPhraseTabPanel = () => {
   const color = useColor();
-  const [mnemonicSize, setMnemonicSize] = useState(24);
   const { handleAsyncAction } = useAsyncActionHandler();
-  const form = useForm({
+  const form = useMultiForm<{ mnemonicSize: number; mnemonic: { val: string }[] }>({
     mode: "onBlur",
+    defaultValues: {
+      mnemonicSize: 24,
+      mnemonic: range(24).map(() => ({ val: "" })),
+    },
   });
+  const { openWith } = useDynamicModalContext();
 
   const {
     handleSubmit,
-    setValue,
-    trigger,
+    register,
+    control,
     formState: { isValid },
   } = form;
 
-  const changeMnemonicSize = (size: number) => {
-    if (!MNEMONIC_SIZE_OPTIONS.includes(size)) {
-      return;
+  const { fields, remove, append, update } = useFieldArray({
+    control,
+    name: "mnemonic",
+    rules: { required: true, minLength: 12, maxLength: 24 },
+  });
+
+  const mnemonicSize = form.watch("mnemonicSize");
+
+  const changeMnemonicSize = (newSize: number) => {
+    if (newSize > mnemonicSize) {
+      append(range(mnemonicSize, newSize).map(() => ({ val: "" })));
+    } else {
+      remove(range(newSize - 1, mnemonicSize));
     }
-
-    setMnemonicSize(prevSize => {
-      // If the users reduces the size, we will trim the words down to the new size
-      if (prevSize > size) {
-        range(size, Math.max(...MNEMONIC_SIZE_OPTIONS)).forEach(index =>
-          setValue(`word${index}`, undefined)
-        );
-      }
-
-      return size;
-    });
-    return trigger();
   };
 
   const pasteMnemonic = (mnemonic: string) =>
@@ -63,14 +66,14 @@ export const SeedPhraseTabPanel = () => {
       if (!MNEMONIC_SIZE_OPTIONS.includes(words.length)) {
         throw new Error(`the mnemonic must be ${MNEMONIC_SIZE_OPTIONS.join(", ")} words long`);
       }
-      words.slice(0, mnemonicSize).forEach((word, i) => setValue(`word${i}`, word));
-      return trigger();
+      words.slice(0, mnemonicSize).forEach((word, i) => update(i, { val: word }));
+      return Promise.resolve();
     });
 
   return (
     <TabPanel>
       <FormProvider {...form}>
-        <form onSubmit={handleSubmit(() => {})}>
+        <form onSubmit={handleSubmit(() => openWith(<SetupPassword type="mnemonic" />))}>
           <Flex flexDirection="column" gap="30px">
             <Accordion allowToggle>
               <AccordionItem>
@@ -78,31 +81,22 @@ export const SeedPhraseTabPanel = () => {
                   <Heading size="md">{mnemonicSize} word seed phrase</Heading>
                   <AccordionIcon />
                 </AccordionButton>
+
                 <AccordionPanel>
                   <Flex gap="8px">
-                    {MNEMONIC_SIZE_OPTIONS.map(size => {
-                      const isSelected = size === mnemonicSize;
-                      return (
-                        <Button
-                          key={size}
-                          width="full"
-                          borderColor={color("100")}
-                          borderRadius="4px"
-                          onClick={() => changeMnemonicSize(size)}
-                          variant={isSelected ? "solid" : "outline"}
-                        >
-                          {size}
-                        </Button>
-                      );
-                    })}
+                    <RadioButtons
+                      inputName="mnemonicSize"
+                      onSelect={changeMnemonicSize}
+                      options={MNEMONIC_SIZE_OPTIONS}
+                    />
                   </Flex>
                 </AccordionPanel>
               </AccordionItem>
             </Accordion>
 
             <Grid gridRowGap="16px" gridColumnGap="12px" gridTemplateColumns="repeat(3, 1fr)">
-              {range(mnemonicSize).map(index => (
-                <GridItem key={index}>
+              {fields.map((field, index) => (
+                <GridItem key={field.id}>
                   <Text
                     position="absolute"
                     zIndex={1}
@@ -115,8 +109,9 @@ export const SeedPhraseTabPanel = () => {
                     {String(index + 1).padStart(2, "0")}.
                   </Text>
                   <MnemonicAutocomplete
-                    inputName={`word${index}`}
+                    inputName={`mnemonic.${index}.val`}
                     inputProps={{
+                      ...register(`mnemonic.${index}.val`, { required: true }),
                       // eslint-disable-next-line @typescript-eslint/no-misused-promises
                       onPaste: async e => {
                         e.preventDefault();
@@ -129,7 +124,7 @@ export const SeedPhraseTabPanel = () => {
                 </GridItem>
               ))}
             </Grid>
-            <Button gap="4px" onClick={() => form.reset()} variant="ghost">
+            <Button gap="4px" onClick={() => form.resetField("mnemonic")} variant="ghost">
               <Icon as={CloseIcon} />
               Clear All
             </Button>

--- a/apps/web/src/components/Onboarding/SetupPassword/SetupPassword.test.tsx
+++ b/apps/web/src/components/Onboarding/SetupPassword/SetupPassword.test.tsx
@@ -1,0 +1,201 @@
+import {
+  type UmamiStore,
+  makeStore,
+  useRestoreFromMnemonic,
+  useRestoreFromSecretKey,
+} from "@umami/state";
+import { mnemonic1 } from "@umami/test-utils";
+
+import { CURVES, SetupPassword } from "./SetupPassword";
+import { act, fireEvent, renderInModal, screen, userEvent, waitFor } from "../../../testUtils";
+
+jest.mock("@umami/state", () => ({
+  ...jest.requireActual("@umami/state"),
+  useRestoreFromMnemonic: jest.fn(),
+  useRestoreFromSecretKey: jest.fn(),
+}));
+
+const password = "password";
+
+describe("<SetupPassword />", () => {
+  describe.each(["mnemonic", "secret_key"] as const)("%s mode", mode => {
+    describe("validations", () => {
+      it("requires a password", async () => {
+        await renderInModal(<SetupPassword mode={mode} />);
+
+        const passwordInput = screen.getByLabelText("Set Password");
+        fireEvent.click(passwordInput);
+        fireEvent.blur(passwordInput);
+
+        await waitFor(() => expect(screen.getByText("Password is required")).toBeVisible());
+      });
+
+      it("requires a password confirmation", async () => {
+        await renderInModal(<SetupPassword mode={mode} />);
+
+        const passwordConfirmationInput = screen.getByLabelText("Confirm Password");
+
+        fireEvent.click(passwordConfirmationInput);
+        fireEvent.blur(passwordConfirmationInput);
+
+        await waitFor(() =>
+          expect(screen.getByText("Password confirmation is required")).toBeVisible()
+        );
+      });
+
+      it("requires the password and confirmation to match", async () => {
+        await renderInModal(<SetupPassword mode={mode} />);
+
+        const passwordInput = screen.getByLabelText("Set Password");
+        const passwordConfirmationInput = screen.getByLabelText("Confirm Password");
+
+        fireEvent.input(passwordInput, { target: { value: password } });
+        fireEvent.blur(passwordInput);
+        fireEvent.input(passwordConfirmationInput, { target: { value: "password_" } });
+
+        fireEvent.blur(passwordConfirmationInput);
+
+        await waitFor(() => expect(screen.getByText("Passwords do not match")).toBeVisible());
+
+        fireEvent.input(passwordConfirmationInput, { target: { value: password } });
+        fireEvent.blur(passwordConfirmationInput);
+
+        await waitFor(() =>
+          expect(screen.queryByText("Passwords do not match")).not.toBeInTheDocument()
+        );
+      });
+    });
+  });
+
+  describe("secret_key mode", () => {
+    it("doesn't render advanced section", async () => {
+      await renderInModal(<SetupPassword mode="secret_key" />);
+
+      expect(screen.queryByTestId("advanced-section")).not.toBeInTheDocument();
+    });
+
+    it("calls restoreFromSecretKey with default parameters", async () => {
+      const user = userEvent.setup();
+      const store = makeStore();
+      const allFormValues = { secretKey: "some secret key" };
+      const mockRestoreFromSecretKey = jest.fn();
+      jest.mocked(useRestoreFromSecretKey).mockReturnValue(mockRestoreFromSecretKey);
+
+      await renderInModal(<SetupPassword mode="secret_key" />, store, allFormValues);
+
+      const passwordInput = screen.getByLabelText("Set Password");
+      const passwordConfirmationInput = screen.getByLabelText("Confirm Password");
+
+      await act(() => user.type(passwordInput, password));
+      await act(() => user.type(passwordConfirmationInput, password));
+
+      const submitButton = screen.getByRole("button", { name: "Import Wallet" });
+
+      await act(() => user.click(submitButton));
+
+      await waitFor(() => expect(mockRestoreFromSecretKey).toHaveBeenCalledTimes(1));
+      expect(mockRestoreFromSecretKey).toHaveBeenCalledWith(
+        allFormValues.secretKey,
+        password,
+        "Account"
+      );
+    });
+  });
+
+  describe("mnemonic mode", () => {
+    let store: UmamiStore;
+    const allFormValues = { mnemonic: mnemonic1.split(" ").map(word => ({ val: word })) };
+    const mockRestoreFromMnemonic = jest.fn();
+
+    beforeEach(() => {
+      store = makeStore();
+      jest.mocked(useRestoreFromMnemonic).mockReturnValue(mockRestoreFromMnemonic);
+    });
+
+    it("renders advanced section", async () => {
+      await renderInModal(<SetupPassword mode="mnemonic" />, store, allFormValues);
+
+      expect(screen.getByTestId("advanced-section")).toBeVisible();
+    });
+
+    it("calls restoreFromMnemonic with default parameters", async () => {
+      const user = userEvent.setup();
+      await renderInModal(<SetupPassword mode="mnemonic" />, store, allFormValues);
+
+      const passwordInput = screen.getByLabelText("Set Password");
+      const passwordConfirmationInput = screen.getByLabelText("Confirm Password");
+
+      await act(() => user.type(passwordInput, password));
+      await act(() => user.type(passwordConfirmationInput, password));
+
+      const submitButton = screen.getByRole("button", { name: "Import Wallet" });
+      await act(() => user.click(submitButton));
+
+      await waitFor(() => expect(mockRestoreFromMnemonic).toHaveBeenCalledTimes(1));
+      expect(mockRestoreFromMnemonic).toHaveBeenCalledWith({
+        mnemonic: mnemonic1,
+        password: password,
+        derivationPathTemplate: "44'/1729'/?'/0'",
+        label: "Account",
+        curve: "ed25519",
+      });
+    });
+
+    it.each(CURVES)("calls restoreFromMnemonic with curve %s", async curve => {
+      const user = userEvent.setup();
+      await renderInModal(<SetupPassword mode="mnemonic" />, store, allFormValues);
+
+      const passwordInput = screen.getByLabelText("Set Password");
+      const passwordConfirmationInput = screen.getByLabelText("Confirm Password");
+
+      await act(() => user.type(passwordInput, password));
+      await act(() => user.type(passwordConfirmationInput, password));
+
+      await act(() => user.click(screen.getByRole("button", { name: "Advanced" })));
+
+      const curveButton = await screen.findByRole("button", { name: curve });
+      await act(() => user.click(curveButton));
+
+      const submitButton = screen.getByRole("button", { name: "Import Wallet" });
+      await act(() => user.click(submitButton));
+
+      await waitFor(() => expect(mockRestoreFromMnemonic).toHaveBeenCalledTimes(1));
+      expect(mockRestoreFromMnemonic).toHaveBeenCalledWith({
+        mnemonic: mnemonic1,
+        password: password,
+        derivationPathTemplate: "44'/1729'/?'/0'",
+        label: "Account",
+        curve,
+      });
+    });
+
+    it("allows to amend the default derivation path", async () => {
+      const user = userEvent.setup();
+      await renderInModal(<SetupPassword mode="mnemonic" />, store, allFormValues);
+
+      const passwordInput = screen.getByLabelText("Set Password");
+      const passwordConfirmationInput = screen.getByLabelText("Confirm Password");
+
+      await act(() => user.type(passwordInput, password));
+      await act(() => user.type(passwordConfirmationInput, password));
+
+      await act(() => user.click(screen.getByRole("button", { name: "Advanced" })));
+
+      const derivationPathInput = screen.getByLabelText("Derivation Path");
+      await act(() => user.clear(derivationPathInput));
+      await act(() => user.type(derivationPathInput, "m/44'/1729'/0'/0'/0'"));
+
+      const submitButton = screen.getByRole("button", { name: "Import Wallet" });
+      await act(() => user.click(submitButton));
+
+      await waitFor(() => expect(mockRestoreFromMnemonic).toHaveBeenCalledTimes(1));
+      expect(mockRestoreFromMnemonic).toHaveBeenCalledWith({
+        mnemonic: mnemonic1,
+        password: password,
+        derivationPathTemplate: "m/44'/1729'/0'/0'/0'",
+        label: "Account",
+        curve: "ed25519",
+      });
+    });
+  });
+});

--- a/apps/web/src/components/Onboarding/SetupPassword/SetupPassword.tsx
+++ b/apps/web/src/components/Onboarding/SetupPassword/SetupPassword.tsx
@@ -1,0 +1,187 @@
+import {
+  Accordion,
+  AccordionButton,
+  AccordionIcon,
+  AccordionItem,
+  AccordionPanel,
+  Button,
+  Center,
+  Flex,
+  FormControl,
+  FormErrorMessage,
+  FormLabel,
+  Heading,
+  Icon,
+  Input,
+  InputGroup,
+  InputRightElement,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalHeader,
+} from "@chakra-ui/react";
+import { type Curves } from "@taquito/signer";
+import { useDynamicModalContext, useMultiForm } from "@umami/components";
+import { DEFAULT_ACCOUNT_LABEL } from "@umami/core";
+import {
+  useAsyncActionHandler,
+  useRestoreFromMnemonic,
+  useRestoreFromSecretKey,
+} from "@umami/state";
+import { defaultDerivationPathTemplate } from "@umami/tezos";
+import { FormProvider } from "react-hook-form";
+
+import { LockIcon } from "../../../assets/icons";
+import { useColor } from "../../../styles/useColor";
+import { ModalBackButton } from "../../BackButton";
+import { PasswordInput } from "../../PasswordInput";
+import { RadioButtons } from "../../RadioButtons";
+
+type FormFields = {
+  password: string;
+  passwordConfirmation: string;
+  derivationPath: string;
+  curve: Exclude<Curves, "bip25519">;
+};
+
+export const CURVES = ["ed25519", "secp256k1", "p256"];
+
+export const SetupPassword = ({ mode }: { mode: "mnemonic" | "secret_key" }) => {
+  const color = useColor();
+  const { handleAsyncAction, isLoading } = useAsyncActionHandler();
+  const { allFormValues, onClose } = useDynamicModalContext();
+  const restoreFromMnemonic = useRestoreFromMnemonic();
+  const restoreFromSecretKey = useRestoreFromSecretKey();
+  const form = useMultiForm<FormFields>({
+    mode: "onBlur",
+    defaultValues: {
+      derivationPath: defaultDerivationPathTemplate,
+      curve: "ed25519",
+    },
+  });
+
+  const {
+    formState: { errors, isValid },
+    register,
+    resetField,
+    getValues,
+  } = form;
+
+  const onSubmit = ({ password, curve, derivationPath }: FormFields) =>
+    handleAsyncAction(async () => {
+      switch (mode) {
+        case "mnemonic": {
+          const mnemonic = allFormValues.mnemonic.map(({ val }: { val: string }) => val).join(" ");
+
+          await restoreFromMnemonic({
+            mnemonic,
+            password,
+            derivationPathTemplate: derivationPath,
+            label: DEFAULT_ACCOUNT_LABEL,
+            curve,
+          });
+          break;
+        }
+        case "secret_key": {
+          await restoreFromSecretKey(allFormValues.secretKey, password, DEFAULT_ACCOUNT_LABEL);
+        }
+      }
+      return onClose();
+    });
+
+  return (
+    <ModalContent>
+      <ModalHeader>
+        <ModalBackButton />
+        <ModalCloseButton />
+        <Center flexDirection="column" gap="16px">
+          <Icon as={LockIcon} width="24px" height="24px" color={color("blue")} />
+          <Heading size="xl">Almost there</Heading>
+        </Center>
+      </ModalHeader>
+      <ModalBody>
+        <FormProvider {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)}>
+            <Flex flexDirection="column" gap="24px">
+              <PasswordInput inputName="password" label="Set Password" />
+
+              <PasswordInput
+                inputName="passwordConfirmation"
+                label="Confirm Password"
+                required="Password confirmation is required"
+                validate={value => value === getValues("password") || "Passwords do not match"}
+              />
+
+              {mode === "mnemonic" && (
+                <Accordion marginTop="6px" allowToggle data-testid="advanced-section">
+                  <AccordionItem>
+                    <AccordionButton justifyContent="center" color={color("900")}>
+                      <Heading size="md">Advanced</Heading>
+                      <AccordionIcon />
+                    </AccordionButton>
+
+                    <AccordionPanel>
+                      <Flex flexDirection="column" gap="24px">
+                        <FormControl isInvalid={!!errors.curve}>
+                          <FormLabel>Elliptic Curve</FormLabel>
+                          <Flex gap="8px">
+                            <RadioButtons
+                              fontSize="sm"
+                              fontWeight="400"
+                              inputName="curve"
+                              options={CURVES}
+                            />
+                          </Flex>
+                        </FormControl>
+
+                        <FormControl isInvalid={!!errors.derivationPath}>
+                          <FormLabel>Derivation Path</FormLabel>
+
+                          <InputGroup>
+                            <Input
+                              {...register("derivationPath", {
+                                required: "Derivation path is required",
+                              })}
+                              placeholder="m/44'/1729'/?'/0' (default)"
+                            />
+                            <InputRightElement>
+                              <Button
+                                marginRight="10px"
+                                color={color("200")}
+                                fontWeight="600"
+                                background={color("black")}
+                                borderRadius="4px"
+                                _hover={{ background: color("400") }}
+                                onClick={() => resetField("derivationPath")}
+                                size="sm"
+                              >
+                                Reset
+                              </Button>
+                            </InputRightElement>
+                          </InputGroup>
+                          {errors.derivationPath && (
+                            <FormErrorMessage>{errors.derivationPath.message}</FormErrorMessage>
+                          )}
+                        </FormControl>
+                      </Flex>
+                    </AccordionPanel>
+                  </AccordionItem>
+                </Accordion>
+              )}
+
+              <Button
+                width="full"
+                isDisabled={!isValid}
+                isLoading={isLoading}
+                type="submit"
+                variant="primary"
+              >
+                Import Wallet
+              </Button>
+            </Flex>
+          </form>
+        </FormProvider>
+      </ModalBody>
+    </ModalContent>
+  );
+};

--- a/apps/web/src/components/Onboarding/SetupPassword/index.ts
+++ b/apps/web/src/components/Onboarding/SetupPassword/index.ts
@@ -1,0 +1,1 @@
+export * from "./SetupPassword";

--- a/apps/web/src/components/Onboarding/masterPassword/MasterPassword.tsx
+++ b/apps/web/src/components/Onboarding/masterPassword/MasterPassword.tsx
@@ -37,6 +37,7 @@ export const MasterPassword = ({
           await restoreFromMnemonic({
             ...account,
             password,
+            curve: "ed25519",
           });
       }
       toast({ description: "Account successfully created!", status: "success" });

--- a/apps/web/src/components/Onboarding/restoreMnemonic/RestoreMnemonic.test.tsx
+++ b/apps/web/src/components/Onboarding/restoreMnemonic/RestoreMnemonic.test.tsx
@@ -51,8 +51,7 @@ describe("<RestoreMnemonic />", () => {
       await act(() => user.click(confirmBtn));
 
       expect(mockToast).toHaveBeenCalledWith({
-        description:
-          'Invalid Mnemonic: "test test test test test test test test test test test test test test test test test test test test test test test test"',
+        description: "Invalid Mnemonic",
         status: "error",
         isClosable: true,
       });

--- a/apps/web/src/components/Onboarding/restoreMnemonic/RestoreMnemonic.tsx
+++ b/apps/web/src/components/Onboarding/restoreMnemonic/RestoreMnemonic.tsx
@@ -66,7 +66,7 @@ export const RestoreMnemonic = ({ goToStep }: { goToStep: (step: OnboardingStep)
     handleAsyncAction(async () => {
       const mnemonic = Object.values(data).join(" ").trim();
       if (!validateMnemonic(mnemonic)) {
-        throw new Error(`Invalid Mnemonic: "${mnemonic}"`);
+        throw new Error("Invalid Mnemonic");
       }
       goToStep({
         type: "nameAccount",

--- a/apps/web/src/components/RadioButtons/RadioButtons.test.tsx
+++ b/apps/web/src/components/RadioButtons/RadioButtons.test.tsx
@@ -1,0 +1,68 @@
+import { Box } from "@chakra-ui/react";
+import { FormProvider, useForm } from "react-hook-form";
+
+import { RadioButtons } from "./RadioButtons";
+import { act, render, screen, userEvent } from "../../testUtils";
+
+const TestComponent = ({
+  options,
+  defaultValue,
+  onSelect,
+}: {
+  options: string[];
+  defaultValue: string;
+  onSelect?: (value: string) => void;
+}) => {
+  const form = useForm({ mode: "onBlur", defaultValues: { value: defaultValue } });
+
+  return (
+    <FormProvider {...form}>
+      <form>
+        <RadioButtons inputName="value" onSelect={onSelect} options={options} />
+        <Box data-testid="current-value">{form.watch("value")}</Box>
+      </form>
+    </FormProvider>
+  );
+};
+describe("<RadioButtons />", () => {
+  it("renders all options", () => {
+    const options = ["1", "2", "3", "4"];
+
+    render(<TestComponent defaultValue="1" options={options} />);
+
+    options.forEach(option => {
+      expect(screen.getByRole("button", { name: String(option) })).toBeVisible();
+    });
+  });
+
+  it("selects the default button", () => {
+    const options = ["1", "2", "3", "4"];
+
+    render(<TestComponent defaultValue="2" options={options} />);
+
+    expect(screen.getByTestId("radio-button-selected")).toHaveTextContent("2");
+  });
+
+  it("changes the value on a button click", async () => {
+    const user = userEvent.setup();
+    const options = ["1", "2", "3", "4"];
+
+    render(<TestComponent defaultValue="3" options={options} />);
+
+    await act(() => user.click(screen.getByRole("button", { name: "2" })));
+
+    expect(screen.getByTestId("radio-button-selected")).toHaveTextContent("2");
+    expect(screen.getByTestId("current-value")).toHaveTextContent("2");
+  });
+
+  it("calls onSelect when a button is clicked", async () => {
+    const user = userEvent.setup();
+    const onSelect = jest.fn();
+    const options = ["1", "2", "3", "4"];
+
+    render(<TestComponent defaultValue="3" onSelect={onSelect} options={options} />);
+
+    await act(() => user.click(screen.getByRole("button", { name: "2" })));
+    expect(onSelect).toHaveBeenCalledWith("2");
+  });
+});

--- a/apps/web/src/components/RadioButtons/RadioButtons.tsx
+++ b/apps/web/src/components/RadioButtons/RadioButtons.tsx
@@ -1,0 +1,43 @@
+import { Button, type ButtonProps } from "@chakra-ui/react";
+import { type FieldValues, type Path, type PathValue, useFormContext } from "react-hook-form";
+
+import { useColor } from "../../styles/useColor";
+
+export const RadioButtons = <T extends FieldValues, U extends Path<T>, V extends PathValue<T, U>>({
+  options,
+  inputName,
+  onSelect,
+  ...props
+}: {
+  options: V[];
+  inputName: U;
+  onSelect?: (value: V) => void;
+} & Omit<ButtonProps, "onSelect">) => {
+  const form = useFormContext<T>();
+  const color = useColor();
+
+  return (
+    <>
+      {options.map(option => {
+        const isSelected = form.getValues(inputName) === option;
+
+        return (
+          <Button
+            key={option}
+            width="full"
+            borderColor={color("100")}
+            borderRadius="4px"
+            onClick={() => {
+              onSelect?.(option);
+              form.setValue(inputName, option);
+            }}
+            variant={isSelected ? "solid" : "outline"}
+            {...props}
+          >
+            {option}
+          </Button>
+        );
+      })}
+    </>
+  );
+};

--- a/apps/web/src/components/RadioButtons/RadioButtons.tsx
+++ b/apps/web/src/components/RadioButtons/RadioButtons.tsx
@@ -19,7 +19,7 @@ export const RadioButtons = <T extends FieldValues, U extends Path<T>, V extends
   return (
     <>
       {options.map(option => {
-        const isSelected = form.getValues(inputName) === option;
+        const isSelected = form.watch(inputName) === option;
 
         return (
           <Button
@@ -27,6 +27,7 @@ export const RadioButtons = <T extends FieldValues, U extends Path<T>, V extends
             width="full"
             borderColor={color("100")}
             borderRadius="4px"
+            data-testid={isSelected ? "radio-button-selected" : undefined}
             onClick={() => {
               onSelect?.(option);
               form.setValue(inputName, option);

--- a/apps/web/src/components/RadioButtons/index.ts
+++ b/apps/web/src/components/RadioButtons/index.ts
@@ -1,0 +1,1 @@
+export * from "./RadioButtons";

--- a/apps/web/src/testUtils.tsx
+++ b/apps/web/src/testUtils.tsx
@@ -8,6 +8,7 @@ import {
   useDynamicDrawerContext,
   useDynamicModal,
   useDynamicModalContext,
+  useMultiForm,
 } from "@umami/components";
 import { type UmamiStore, makeStore } from "@umami/state";
 import { type PropsWithChildren, type ReactElement, type ReactNode, act } from "react";
@@ -129,8 +130,38 @@ export const renderInDrawer = async (component: ReactElement, store?: UmamiStore
   };
 };
 
-export const renderInModal = async (component: ReactElement, store?: UmamiStore) => {
+const DummyForm = ({
+  defaultValues,
+  nextPage,
+}: {
+  defaultValues: Record<string, any>;
+  nextPage: ReactElement;
+}) => {
+  const { openWith } = useDynamicModalContext();
+  const form = useMultiForm({ mode: "onBlur", defaultValues });
+
+  const onSubmit = () => openWith(nextPage);
+
+  return (
+    <form onSubmit={form.handleSubmit(onSubmit)}>
+      <button type="submit" />
+    </form>
+  );
+};
+
+export const renderInModal = async (
+  component: ReactElement,
+  store?: UmamiStore,
+  allFormValues?: Record<string, any>
+) => {
   const { result, store: _store } = customRenderHook(useDynamicModalContext, { store });
+
+  if (allFormValues) {
+    await act(() =>
+      result.current.openWith(<DummyForm defaultValues={allFormValues} nextPage={component} />)
+    );
+    fireEvent.click(screen.getByRole("button"));
+  }
 
   await act(() => result.current.openWith(component));
 

--- a/packages/components/src/DynamicDisclosure/useMultiForm.tsx
+++ b/packages/components/src/DynamicDisclosure/useMultiForm.tsx
@@ -29,10 +29,10 @@ export const useMultiForm = <
     onInvalid: Parameters<typeof form.handleSubmit>[1]
   ) =>
     form.handleSubmit(
-      (async (submittedValues: any) => {
-        await onValid(submittedValues);
+      ((submittedValues: any) => {
         // update current context values
         merge(formDefaultValues, submittedValues);
+        return onValid(submittedValues);
       }) as any,
       onInvalid
     );

--- a/packages/state/jest.config.ts
+++ b/packages/state/jest.config.ts
@@ -3,6 +3,7 @@ import type { Config } from "jest";
 
 const config: Config = {
   ...baseConfig,
+  testTimeout: 15000,
   setupFilesAfterEnv: ["<rootDir>/src/setupTests.ts"],
   rootDir: "./",
 };

--- a/packages/state/src/hooks/backup.ts
+++ b/packages/state/src/hooks/backup.ts
@@ -47,6 +47,7 @@ export const useRestoreV1BackupFile = () => {
         password,
         label: DEFAULT_ACCOUNT_LABEL,
         derivationPathTemplate: derivationPaths[i],
+        curve: "ed25519",
       });
     }
   };

--- a/packages/state/src/hooks/setAccountData.test.ts
+++ b/packages/state/src/hooks/setAccountData.test.ts
@@ -1,3 +1,4 @@
+import { type Curves } from "@taquito/signer";
 import {
   type ImplicitAccount,
   type MnemonicAccount,
@@ -53,395 +54,406 @@ jest.mock("@umami/tezos", () => ({
 const mockedUseRemoveDependenciesAndMultisigs = jest.mocked(useRemoveDependenciesAndMultisigs);
 const mockedRemoveAccountsDependencies = jest.fn();
 
-describe("setAccountDataHooks", () => {
-  beforeEach(() =>
-    mockedUseRemoveDependenciesAndMultisigs.mockReturnValue(mockedRemoveAccountsDependencies)
-  );
+beforeEach(() =>
+  mockedUseRemoveDependenciesAndMultisigs.mockReturnValue(mockedRemoveAccountsDependencies)
+);
 
-  describe("mnemonic accounts", () => {
-    const LABEL_BASE = "Test acc";
-    const PASSWORD = "password";
-    const DERIVATION_PATH_TEMPLATE = AVAILABLE_DERIVATION_PATH_TEMPLATES[2].value;
+describe.each(["ed25519", "secp256k1", "p256"] as const)(
+  "setAccountDataHooks with %s curve",
+  curve => {
+    describe("mnemonic accounts", () => {
+      const LABEL_BASE = "Test acc";
+      const PASSWORD = "password";
+      const DERIVATION_PATH_TEMPLATE = AVAILABLE_DERIVATION_PATH_TEMPLATES[2].value;
 
-    const MOCK_FINGERPRINT = "mockFingerPrint";
-    const MOCK_ENCRYPTED = { mock: "encrypted" } as any;
+      const MOCK_FINGERPRINT = "mockFingerPrint";
+      const MOCK_ENCRYPTED = { mock: "encrypted" } as any;
 
-    const mnemonicAccount = async (index: number, label: string): Promise<MnemonicAccount> => {
-      const pubKeyPair = await derivePublicKeyPair(
-        mnemonic1,
-        makeDerivationPath(DERIVATION_PATH_TEMPLATE, index)
-      );
-      return {
-        curve: "ed25519",
-        derivationPath: makeDerivationPath(DERIVATION_PATH_TEMPLATE, index),
-        type: "mnemonic",
-        pk: pubKeyPair.pk,
-        address: { type: "implicit", pkh: pubKeyPair.pkh },
-        seedFingerPrint: MOCK_FINGERPRINT,
-        label: label,
-        derivationPathTemplate: DERIVATION_PATH_TEMPLATE,
+      const mnemonicAccount = async (
+        index: number,
+        label: string,
+        curve: Curves
+      ): Promise<MnemonicAccount> => {
+        const pubKeyPair = await derivePublicKeyPair(
+          mnemonic1,
+          makeDerivationPath(DERIVATION_PATH_TEMPLATE, index),
+          curve
+        );
+        return {
+          curve,
+          derivationPath: makeDerivationPath(DERIVATION_PATH_TEMPLATE, index),
+          type: "mnemonic",
+          pk: pubKeyPair.pk,
+          address: { type: "implicit", pkh: pubKeyPair.pkh },
+          seedFingerPrint: MOCK_FINGERPRINT,
+          label: label,
+          derivationPathTemplate: DERIVATION_PATH_TEMPLATE,
+        };
       };
-    };
 
-    describe("useRestoreFromMnemonic", () => {
-      beforeEach(() => {
-        jest.mocked(getFingerPrint).mockResolvedValue(MOCK_FINGERPRINT);
-        jest.mocked(encrypt).mockReturnValue(Promise.resolve(MOCK_ENCRYPTED));
-      });
-
-      it("restores only one account if none revealed", async () => {
-        const expected: ImplicitAccount[] = [await mnemonicAccount(0, LABEL_BASE)];
-
-        const {
-          result: { current: restoreFromMnemonic },
-        } = renderHook(() => useRestoreFromMnemonic(), { store });
-        await act(() =>
-          restoreFromMnemonic({
-            mnemonic: mnemonic1,
-            password: PASSWORD,
-            derivationPathTemplate: DERIVATION_PATH_TEMPLATE,
-            label: LABEL_BASE,
-          })
-        );
-
-        expect(store.getState().accounts.items).toEqual(expected);
-        expect(store.getState().accounts.seedPhrases).toEqual({
-          [MOCK_FINGERPRINT]: MOCK_ENCRYPTED,
+      describe("useRestoreFromMnemonic", () => {
+        beforeEach(() => {
+          jest.mocked(getFingerPrint).mockResolvedValue(MOCK_FINGERPRINT);
+          jest.mocked(encrypt).mockReturnValue(Promise.resolve(MOCK_ENCRYPTED));
         });
-        expect(getFingerPrint).toHaveBeenCalledWith(mnemonic1);
-        // Encrypts given mnemonic with the given password.
-        expect(encrypt).toHaveBeenCalledWith(mnemonic1, PASSWORD);
-      });
 
-      it("restores revealed accounts", async () => {
-        const expected = [
-          await mnemonicAccount(0, LABEL_BASE),
-          await mnemonicAccount(1, `${LABEL_BASE} 2`),
-          await mnemonicAccount(2, `${LABEL_BASE} 3`),
-        ];
-        // Reveal mnemonic accounts
-        const revealedAccounts = [
-          ...expected,
-          // Account 3 is not revealed. Restoration stops at first unrevealed account.
-          await mnemonicAccount(4, `${LABEL_BASE} 5`),
-          await mnemonicAccount(5, `${LABEL_BASE} 6`),
-        ];
-        jest
-          .mocked(isAccountRevealed)
-          .mockImplementation(
-            fakeIsAccountRevealed(revealedAccounts.map(account => account.address))
-          );
+        it("restores only one account if none revealed", async () => {
+          const expected: ImplicitAccount[] = [await mnemonicAccount(0, LABEL_BASE, curve)];
 
-        const {
-          result: { current: restoreFromMnemonic },
-        } = renderHook(() => useRestoreFromMnemonic(), { store });
-        await act(() =>
-          restoreFromMnemonic({
-            mnemonic: mnemonic1,
-            password: PASSWORD,
-            derivationPathTemplate: DERIVATION_PATH_TEMPLATE,
-            label: LABEL_BASE,
-          })
-        );
-
-        expect(store.getState().accounts.items).toEqual(expected);
-        expect(store.getState().accounts.seedPhrases).toEqual({
-          [MOCK_FINGERPRINT]: MOCK_ENCRYPTED,
-        });
-        expect(getFingerPrint).toHaveBeenCalledWith(mnemonic1);
-        // Encrypts given mnemonic with the given password.
-        expect(encrypt).toHaveBeenCalledWith(mnemonic1, PASSWORD);
-      });
-
-      it("assigns unique labels to revealed accounts", async () => {
-        // Add existing accounts
-        const existingAccounts = [
-          mockSocialAccount(0, LABEL_BASE),
-          mockSecretKeyAccount(2, `${LABEL_BASE} 3`),
-        ];
-        addTestAccounts(store, existingAccounts);
-        // Labels "labelBase" & "labelBase 3" are taken by other types of accounts.
-        // The next available labels are "labelBase 2" & "labelBase 4".
-        const expected = [
-          await mnemonicAccount(0, `${LABEL_BASE} 2`),
-          await mnemonicAccount(1, `${LABEL_BASE} 4`),
-          await mnemonicAccount(2, `${LABEL_BASE} 5`),
-        ];
-        // Reveal mnemonic accounts
-        jest
-          .mocked(isAccountRevealed)
-          .mockImplementation(fakeIsAccountRevealed(expected.map(account => account.address)));
-
-        const {
-          result: { current: restoreFromMnemonic },
-        } = renderHook(() => useRestoreFromMnemonic(), { store });
-        await act(() =>
-          restoreFromMnemonic({
-            mnemonic: mnemonic1,
-            password: PASSWORD,
-            derivationPathTemplate: DERIVATION_PATH_TEMPLATE,
-            label: LABEL_BASE,
-          })
-        );
-
-        expect(store.getState().accounts.items).toEqual([...existingAccounts, ...expected]);
-        expect(store.getState().accounts.seedPhrases).toEqual({
-          [MOCK_FINGERPRINT]: MOCK_ENCRYPTED,
-        });
-      });
-    });
-
-    describe("useDeriveMnemonicAccount", () => {
-      beforeEach(() => jest.mocked(decrypt).mockResolvedValue(mnemonic1));
-
-      it("throws if we try to derive from an unknown seedphrase", async () => {
-        const UNKNOWN_FINGERPRINT = "unknown fingerprint";
-        store.dispatch(
-          accountsActions.addMnemonicAccounts({
-            seedFingerprint: MOCK_FINGERPRINT,
-            accounts: [],
-            encryptedMnemonic: MOCK_ENCRYPTED,
-          })
-        );
-
-        const {
-          result: { current: deriveMnemonicAccount },
-        } = renderHook(() => useDeriveMnemonicAccount(), { store });
-        await expect(() =>
-          deriveMnemonicAccount({
-            fingerPrint: UNKNOWN_FINGERPRINT,
-            password: PASSWORD,
-            label: LABEL_BASE,
-          })
-        ).rejects.toThrow(`No seedphrase found with fingerprint: ${UNKNOWN_FINGERPRINT}`);
-
-        expect(store.getState().accounts.items).toEqual([]);
-        expect(store.getState().accounts.seedPhrases).toEqual({
-          [MOCK_FINGERPRINT]: MOCK_ENCRYPTED,
-        });
-      });
-
-      it("derives and adds an account after the last index", async () => {
-        const existingAccounts = [
-          (await mnemonicAccount(0, `${LABEL_BASE}`)) as MnemonicAccount,
-          (await mnemonicAccount(1, `${LABEL_BASE} 1`)) as MnemonicAccount,
-        ];
-        const expected = await mnemonicAccount(2, `${LABEL_BASE} 2`);
-        store.dispatch(
-          accountsActions.addMnemonicAccounts({
-            seedFingerprint: MOCK_FINGERPRINT,
-            accounts: existingAccounts,
-            encryptedMnemonic: MOCK_ENCRYPTED,
-          })
-        );
-
-        const {
-          result: { current: deriveMnemonicAccount },
-        } = renderHook(() => useDeriveMnemonicAccount(), { store });
-        await act(() =>
-          deriveMnemonicAccount({
-            fingerPrint: MOCK_FINGERPRINT,
-            password: PASSWORD,
-            label: LABEL_BASE,
-          })
-        );
-
-        expect(store.getState().accounts.items).toEqual([...existingAccounts, expected]);
-        expect(store.getState().accounts.seedPhrases).toEqual({
-          [MOCK_FINGERPRINT]: MOCK_ENCRYPTED,
-        });
-        expect(jest.mocked(decrypt)).toHaveBeenCalledWith(MOCK_ENCRYPTED, PASSWORD);
-      });
-
-      it("uses decrypt with encrypted mnemonic stored for the group", async () => {
-        const existingAccounts = [
-          (await mnemonicAccount(0, `${LABEL_BASE}`)) as MnemonicAccount,
-          (await mnemonicAccount(1, `${LABEL_BASE} 1`)) as MnemonicAccount,
-        ];
-        store.dispatch(
-          accountsActions.addMnemonicAccounts({
-            seedFingerprint: MOCK_FINGERPRINT,
-            accounts: existingAccounts,
-            encryptedMnemonic: MOCK_ENCRYPTED,
-          })
-        );
-
-        const {
-          result: { current: deriveMnemonicAccount },
-        } = renderHook(() => useDeriveMnemonicAccount(), { store });
-        await act(() =>
-          deriveMnemonicAccount({
-            fingerPrint: MOCK_FINGERPRINT,
-            password: PASSWORD,
-            label: LABEL_BASE,
-          })
-        );
-
-        expect(jest.mocked(decrypt)).toHaveBeenCalledWith(MOCK_ENCRYPTED, PASSWORD);
-      });
-
-      it("assigns unique label to derived account", async () => {
-        const otherAccounts = [
-          mockSocialAccount(0, LABEL_BASE),
-          mockSecretKeyAccount(2, `${LABEL_BASE} 5`),
-        ];
-        addTestAccounts(store, otherAccounts);
-        const existingAccounts = [
-          await mnemonicAccount(0, `${LABEL_BASE} 2`),
-          await mnemonicAccount(1, `${LABEL_BASE} 4`),
-        ];
-        // Labels "labelBase" & "labelBase 5" are taken by other types of accounts.
-        // Labels "labelBase 2" & "labelBase 4" are taken by existing mnemonic accounts.
-        // The next available label is "labelBase 3".
-        const expected = await mnemonicAccount(2, `${LABEL_BASE} 3`);
-        store.dispatch(
-          accountsActions.addMnemonicAccounts({
-            seedFingerprint: MOCK_FINGERPRINT,
-            accounts: existingAccounts,
-            encryptedMnemonic: MOCK_ENCRYPTED,
-          })
-        );
-
-        const {
-          result: { current: deriveMnemonicAccount },
-        } = renderHook(() => useDeriveMnemonicAccount(), { store });
-        await act(() =>
-          deriveMnemonicAccount({
-            fingerPrint: MOCK_FINGERPRINT,
-            password: PASSWORD,
-            label: LABEL_BASE,
-          })
-        );
-
-        expect(store.getState().accounts.items).toEqual([
-          ...otherAccounts,
-          ...existingAccounts,
-          expected,
-        ]);
-        expect(store.getState().accounts.seedPhrases).toEqual({
-          [MOCK_FINGERPRINT]: MOCK_ENCRYPTED,
-        });
-      });
-    });
-  });
-
-  describe("useRemoveMnemonic", () => {
-    beforeEach(() => {
-      store.dispatch(
-        accountsActions.addMnemonicAccounts({
-          seedFingerprint: "mockPrint1",
-          accounts: [
-            mockImplicitAccount(1, undefined, "mockPrint1") as MnemonicAccount,
-            mockImplicitAccount(3, undefined, "mockPrint1") as MnemonicAccount,
-          ],
-          encryptedMnemonic: {} as any,
-        })
-      );
-      store.dispatch(
-        accountsActions.addMnemonicAccounts({
-          seedFingerprint: "mockPrint2",
-          accounts: [mockImplicitAccount(2, undefined, "mockPrint2") as MnemonicAccount],
-          encryptedMnemonic: {} as any,
-        })
-      );
-    });
-
-    it("deletes all accounts with given fingerprint", () => {
-      const {
-        result: { current: removeMnemonic },
-      } = renderHook(() => useRemoveMnemonic(), { store });
-
-      act(() => removeMnemonic("mockPrint1"));
-
-      expect(store.getState().accounts.items).toEqual([
-        mockImplicitAccount(2, undefined, "mockPrint2"),
-      ]);
-    });
-
-    it("calls removeAccountsDependencies with all accounts with given fingerprint", () => {
-      const {
-        result: { current: removeMnemonic },
-      } = renderHook(() => useRemoveMnemonic(), { store });
-
-      act(() => removeMnemonic("mockPrint1"));
-
-      expect(mockedRemoveAccountsDependencies).toHaveBeenCalledWith([
-        mockImplicitAccount(1, undefined, "mockPrint1"),
-        mockImplicitAccount(3, undefined, "mockPrint1"),
-      ]);
-    });
-  });
-
-  describe("useRemoveNonMnemonic", () => {
-    const accounts = [
-      mockSocialAccount(1),
-      mockSocialAccount(2),
-      mockLedgerAccount(3),
-      mockLedgerAccount(4),
-      mockSecretKeyAccount(5),
-      mockSecretKeyAccount(6),
-    ];
-
-    beforeEach(() => addTestAccounts(store, accounts));
-
-    describe.each(["social" as const, "ledger" as const, "secret_key" as const])(
-      "for %s type",
-      type => {
-        it("deletes all accounts", () => {
           const {
-            result: { current: removeNonMnemonic },
-          } = renderHook(() => useRemoveNonMnemonic(), { store });
-
-          act(() => removeNonMnemonic(type));
-
-          expect(store.getState().accounts.items).toEqual(
-            accounts.filter(account => account.type !== type)
+            result: { current: restoreFromMnemonic },
+          } = renderHook(() => useRestoreFromMnemonic(), { store });
+          await act(() =>
+            restoreFromMnemonic({
+              mnemonic: mnemonic1,
+              password: PASSWORD,
+              derivationPathTemplate: DERIVATION_PATH_TEMPLATE,
+              label: LABEL_BASE,
+              curve,
+            })
           );
+
+          expect(store.getState().accounts.items).toEqual(expected);
+          expect(store.getState().accounts.seedPhrases).toEqual({
+            [MOCK_FINGERPRINT]: MOCK_ENCRYPTED,
+          });
+          expect(getFingerPrint).toHaveBeenCalledWith(mnemonic1);
+          // Encrypts given mnemonic with the given password.
+          expect(encrypt).toHaveBeenCalledWith(mnemonic1, PASSWORD);
         });
 
-        it("calls removeAccountsDependencies with all accounts", () => {
+        it("restores revealed accounts", async () => {
+          const expected = [
+            await mnemonicAccount(0, LABEL_BASE, curve),
+            await mnemonicAccount(1, `${LABEL_BASE} 2`, curve),
+            await mnemonicAccount(2, `${LABEL_BASE} 3`, curve),
+          ];
+          // Reveal mnemonic accounts
+          const revealedAccounts = [
+            ...expected,
+            // Account 3 is not revealed. Restoration stops at first unrevealed account.
+            await mnemonicAccount(4, `${LABEL_BASE} 5`, curve),
+            await mnemonicAccount(5, `${LABEL_BASE} 6`, curve),
+          ];
+          jest
+            .mocked(isAccountRevealed)
+            .mockImplementation(
+              fakeIsAccountRevealed(revealedAccounts.map(account => account.address))
+            );
+
           const {
-            result: { current: removeNonMnemonic },
-          } = renderHook(() => useRemoveNonMnemonic(), { store });
-
-          act(() => removeNonMnemonic(type));
-
-          expect(mockedRemoveAccountsDependencies).toHaveBeenCalledWith(
-            accounts.filter(account => account.type === type)
+            result: { current: restoreFromMnemonic },
+          } = renderHook(() => useRestoreFromMnemonic(), { store });
+          await act(() =>
+            restoreFromMnemonic({
+              mnemonic: mnemonic1,
+              password: PASSWORD,
+              derivationPathTemplate: DERIVATION_PATH_TEMPLATE,
+              label: LABEL_BASE,
+              curve,
+            })
           );
+
+          expect(store.getState().accounts.items).toEqual(expected);
+          expect(store.getState().accounts.seedPhrases).toEqual({
+            [MOCK_FINGERPRINT]: MOCK_ENCRYPTED,
+          });
+          expect(getFingerPrint).toHaveBeenCalledWith(mnemonic1);
+          // Encrypts given mnemonic with the given password.
+          expect(encrypt).toHaveBeenCalledWith(mnemonic1, PASSWORD);
         });
-      }
+
+        it("assigns unique labels to revealed accounts", async () => {
+          // Add existing accounts
+          const existingAccounts = [
+            mockSocialAccount(0, LABEL_BASE),
+            mockSecretKeyAccount(2, `${LABEL_BASE} 3`),
+          ];
+          addTestAccounts(store, existingAccounts);
+          // Labels "labelBase" & "labelBase 3" are taken by other types of accounts.
+          // The next available labels are "labelBase 2" & "labelBase 4".
+          const expected = [
+            await mnemonicAccount(0, `${LABEL_BASE} 2`, curve),
+            await mnemonicAccount(1, `${LABEL_BASE} 4`, curve),
+            await mnemonicAccount(2, `${LABEL_BASE} 5`, curve),
+          ];
+          // Reveal mnemonic accounts
+          jest
+            .mocked(isAccountRevealed)
+            .mockImplementation(fakeIsAccountRevealed(expected.map(account => account.address)));
+
+          const {
+            result: { current: restoreFromMnemonic },
+          } = renderHook(() => useRestoreFromMnemonic(), { store });
+          await act(() =>
+            restoreFromMnemonic({
+              mnemonic: mnemonic1,
+              password: PASSWORD,
+              derivationPathTemplate: DERIVATION_PATH_TEMPLATE,
+              label: LABEL_BASE,
+              curve,
+            })
+          );
+
+          expect(store.getState().accounts.items).toEqual([...existingAccounts, ...expected]);
+          expect(store.getState().accounts.seedPhrases).toEqual({
+            [MOCK_FINGERPRINT]: MOCK_ENCRYPTED,
+          });
+        });
+      });
+
+      describe("useDeriveMnemonicAccount", () => {
+        beforeEach(() => jest.mocked(decrypt).mockResolvedValue(mnemonic1));
+
+        it("throws if we try to derive from an unknown seedphrase", async () => {
+          const UNKNOWN_FINGERPRINT = "unknown fingerprint";
+          store.dispatch(
+            accountsActions.addMnemonicAccounts({
+              seedFingerprint: MOCK_FINGERPRINT,
+              accounts: [],
+              encryptedMnemonic: MOCK_ENCRYPTED,
+            })
+          );
+
+          const {
+            result: { current: deriveMnemonicAccount },
+          } = renderHook(() => useDeriveMnemonicAccount(), { store });
+          await expect(() =>
+            deriveMnemonicAccount({
+              fingerPrint: UNKNOWN_FINGERPRINT,
+              password: PASSWORD,
+              label: LABEL_BASE,
+            })
+          ).rejects.toThrow(`No seedphrase found with fingerprint: ${UNKNOWN_FINGERPRINT}`);
+
+          expect(store.getState().accounts.items).toEqual([]);
+          expect(store.getState().accounts.seedPhrases).toEqual({
+            [MOCK_FINGERPRINT]: MOCK_ENCRYPTED,
+          });
+        });
+
+        it("derives and adds an account after the last index", async () => {
+          const existingAccounts = [
+            (await mnemonicAccount(0, `${LABEL_BASE}`, curve)) as MnemonicAccount,
+            (await mnemonicAccount(1, `${LABEL_BASE} 1`, curve)) as MnemonicAccount,
+          ];
+          const expected = await mnemonicAccount(2, `${LABEL_BASE} 2`, curve);
+          store.dispatch(
+            accountsActions.addMnemonicAccounts({
+              seedFingerprint: MOCK_FINGERPRINT,
+              accounts: existingAccounts,
+              encryptedMnemonic: MOCK_ENCRYPTED,
+            })
+          );
+
+          const {
+            result: { current: deriveMnemonicAccount },
+          } = renderHook(() => useDeriveMnemonicAccount(), { store });
+          await act(() =>
+            deriveMnemonicAccount({
+              fingerPrint: MOCK_FINGERPRINT,
+              password: PASSWORD,
+              label: LABEL_BASE,
+            })
+          );
+
+          expect(store.getState().accounts.items).toEqual([...existingAccounts, expected]);
+          expect(store.getState().accounts.seedPhrases).toEqual({
+            [MOCK_FINGERPRINT]: MOCK_ENCRYPTED,
+          });
+          expect(jest.mocked(decrypt)).toHaveBeenCalledWith(MOCK_ENCRYPTED, PASSWORD);
+        });
+
+        it("uses decrypt with encrypted mnemonic stored for the group", async () => {
+          const existingAccounts = [
+            (await mnemonicAccount(0, `${LABEL_BASE}`, curve)) as MnemonicAccount,
+            (await mnemonicAccount(1, `${LABEL_BASE} 1`, curve)) as MnemonicAccount,
+          ];
+          store.dispatch(
+            accountsActions.addMnemonicAccounts({
+              seedFingerprint: MOCK_FINGERPRINT,
+              accounts: existingAccounts,
+              encryptedMnemonic: MOCK_ENCRYPTED,
+            })
+          );
+
+          const {
+            result: { current: deriveMnemonicAccount },
+          } = renderHook(() => useDeriveMnemonicAccount(), { store });
+          await act(() =>
+            deriveMnemonicAccount({
+              fingerPrint: MOCK_FINGERPRINT,
+              password: PASSWORD,
+              label: LABEL_BASE,
+            })
+          );
+
+          expect(jest.mocked(decrypt)).toHaveBeenCalledWith(MOCK_ENCRYPTED, PASSWORD);
+        });
+
+        it("assigns unique label to derived account", async () => {
+          const otherAccounts = [
+            mockSocialAccount(0, LABEL_BASE),
+            mockSecretKeyAccount(2, `${LABEL_BASE} 5`),
+          ];
+          addTestAccounts(store, otherAccounts);
+          const existingAccounts = [
+            await mnemonicAccount(0, `${LABEL_BASE} 2`, curve),
+            await mnemonicAccount(1, `${LABEL_BASE} 4`, curve),
+          ];
+          // Labels "labelBase" & "labelBase 5" are taken by other types of accounts.
+          // Labels "labelBase 2" & "labelBase 4" are taken by existing mnemonic accounts.
+          // The next available label is "labelBase 3".
+          const expected = await mnemonicAccount(2, `${LABEL_BASE} 3`, curve);
+          store.dispatch(
+            accountsActions.addMnemonicAccounts({
+              seedFingerprint: MOCK_FINGERPRINT,
+              accounts: existingAccounts,
+              encryptedMnemonic: MOCK_ENCRYPTED,
+            })
+          );
+
+          const {
+            result: { current: deriveMnemonicAccount },
+          } = renderHook(() => useDeriveMnemonicAccount(), { store });
+          await act(() =>
+            deriveMnemonicAccount({
+              fingerPrint: MOCK_FINGERPRINT,
+              password: PASSWORD,
+              label: LABEL_BASE,
+            })
+          );
+
+          expect(store.getState().accounts.items).toEqual([
+            ...otherAccounts,
+            ...existingAccounts,
+            expected,
+          ]);
+          expect(store.getState().accounts.seedPhrases).toEqual({
+            [MOCK_FINGERPRINT]: MOCK_ENCRYPTED,
+          });
+        });
+      });
+    });
+  }
+);
+
+describe("useRemoveMnemonic", () => {
+  beforeEach(() => {
+    store.dispatch(
+      accountsActions.addMnemonicAccounts({
+        seedFingerprint: "mockPrint1",
+        accounts: [
+          mockImplicitAccount(1, undefined, "mockPrint1") as MnemonicAccount,
+          mockImplicitAccount(3, undefined, "mockPrint1") as MnemonicAccount,
+        ],
+        encryptedMnemonic: {} as any,
+      })
+    );
+    store.dispatch(
+      accountsActions.addMnemonicAccounts({
+        seedFingerprint: "mockPrint2",
+        accounts: [mockImplicitAccount(2, undefined, "mockPrint2") as MnemonicAccount],
+        encryptedMnemonic: {} as any,
+      })
     );
   });
 
-  describe("useRemoveAccount", () => {
-    it("deletes secret key on deleting secret key account", () => {
-      const account = mockSecretKeyAccount(0);
-      addTestAccount(store, account);
-      store.dispatch(
-        accountsActions.addSecretKey({
-          pkh: account.address.pkh,
-          encryptedSecretKey: "encryptedSecretKey" as any,
-        })
-      );
+  it("deletes all accounts with given fingerprint", () => {
+    const {
+      result: { current: removeMnemonic },
+    } = renderHook(() => useRemoveMnemonic(), { store });
 
-      const {
-        result: { current: removeAccount },
-      } = renderHook(() => useRemoveAccount(), { store });
-      act(() => removeAccount(account));
+    act(() => removeMnemonic("mockPrint1"));
 
-      expect(store.getState().accounts.items).toEqual([]);
-      expect(store.getState().accounts.secretKeys).toEqual({});
-    });
+    expect(store.getState().accounts.items).toEqual([
+      mockImplicitAccount(2, undefined, "mockPrint2"),
+    ]);
+  });
 
-    it("calls removeAccountsDependencies with the account", () => {
-      const {
-        result: { current: removeAccount },
-      } = renderHook(() => useRemoveAccount(), { store });
+  it("calls removeAccountsDependencies with all accounts with given fingerprint", () => {
+    const {
+      result: { current: removeMnemonic },
+    } = renderHook(() => useRemoveMnemonic(), { store });
 
-      act(() => removeAccount(mockSocialAccount(5)));
+    act(() => removeMnemonic("mockPrint1"));
 
-      expect(mockedRemoveAccountsDependencies).toHaveBeenCalledWith([mockSocialAccount(5)]);
-    });
+    expect(mockedRemoveAccountsDependencies).toHaveBeenCalledWith([
+      mockImplicitAccount(1, undefined, "mockPrint1"),
+      mockImplicitAccount(3, undefined, "mockPrint1"),
+    ]);
+  });
+});
+
+describe("useRemoveNonMnemonic", () => {
+  const accounts = [
+    mockSocialAccount(1),
+    mockSocialAccount(2),
+    mockLedgerAccount(3),
+    mockLedgerAccount(4),
+    mockSecretKeyAccount(5),
+    mockSecretKeyAccount(6),
+  ];
+
+  beforeEach(() => addTestAccounts(store, accounts));
+
+  describe.each(["social" as const, "ledger" as const, "secret_key" as const])(
+    "for %s type",
+    type => {
+      it("deletes all accounts", () => {
+        const {
+          result: { current: removeNonMnemonic },
+        } = renderHook(() => useRemoveNonMnemonic(), { store });
+
+        act(() => removeNonMnemonic(type));
+
+        expect(store.getState().accounts.items).toEqual(
+          accounts.filter(account => account.type !== type)
+        );
+      });
+
+      it("calls removeAccountsDependencies with all accounts", () => {
+        const {
+          result: { current: removeNonMnemonic },
+        } = renderHook(() => useRemoveNonMnemonic(), { store });
+
+        act(() => removeNonMnemonic(type));
+
+        expect(mockedRemoveAccountsDependencies).toHaveBeenCalledWith(
+          accounts.filter(account => account.type === type)
+        );
+      });
+    }
+  );
+});
+
+describe("useRemoveAccount", () => {
+  it("deletes secret key on deleting secret key account", () => {
+    const account = mockSecretKeyAccount(0);
+    addTestAccount(store, account);
+    store.dispatch(
+      accountsActions.addSecretKey({
+        pkh: account.address.pkh,
+        encryptedSecretKey: "encryptedSecretKey" as any,
+      })
+    );
+
+    const {
+      result: { current: removeAccount },
+    } = renderHook(() => useRemoveAccount(), { store });
+    act(() => removeAccount(account));
+
+    expect(store.getState().accounts.items).toEqual([]);
+    expect(store.getState().accounts.secretKeys).toEqual({});
+  });
+
+  it("calls removeAccountsDependencies with the account", () => {
+    const {
+      result: { current: removeAccount },
+    } = renderHook(() => useRemoveAccount(), { store });
+
+    act(() => removeAccount(mockSocialAccount(5)));
+
+    expect(mockedRemoveAccountsDependencies).toHaveBeenCalledWith([mockSocialAccount(5)]);
   });
 });

--- a/packages/state/src/hooks/setAccountData.ts
+++ b/packages/state/src/hooks/setAccountData.ts
@@ -1,3 +1,4 @@
+import { type Curves } from "@taquito/signer";
 import {
   type ImplicitAccount,
   type LedgerAccount,
@@ -45,23 +46,27 @@ export const useRestoreFromMnemonic = () => {
   const network = useSelectedNetwork();
   const restoreRevealedMnemonicAccounts = useRestoreRevealedMnemonicAccounts();
   const dispatch = useDispatch();
+
   return async ({
     mnemonic,
     password,
     derivationPathTemplate,
     label,
+    curve,
   }: {
     mnemonic: string;
     password: string;
     derivationPathTemplate: string;
     label: string;
+    curve: Curves;
   }) => {
     const seedFingerprint = await getFingerPrint(mnemonic);
     const accounts = await restoreRevealedMnemonicAccounts(
       mnemonic,
       network,
       derivationPathTemplate,
-      label
+      label,
+      curve
     );
     const encryptedMnemonic = await encrypt(mnemonic, password);
 
@@ -116,20 +121,20 @@ export const useDeriveMnemonicAccount = () => {
     const nextIndex = existingGroupAccounts.length;
 
     // Newly derived accounts use a derivation path in the same pattern as the first account
-    const pattern = existingGroupAccounts[0].derivationPathTemplate;
+    const { derivationPathTemplate, curve } = existingGroupAccounts[0];
 
-    const nextDerivationPath = makeDerivationPath(pattern, nextIndex);
-    const { pk, pkh } = await derivePublicKeyPair(seedphrase, nextDerivationPath);
+    const nextDerivationPath = makeDerivationPath(derivationPathTemplate, nextIndex);
+    const { pk, pkh } = await derivePublicKeyPair(seedphrase, nextDerivationPath, curve);
 
     const uniqueLabel = getNextAvailableAccountLabels(label, 1)[0];
     const account: MnemonicAccount = {
       type: "mnemonic",
-      curve: "ed25519",
+      curve,
       pk,
       address: { type: "implicit", pkh },
       derivationPath: nextDerivationPath,
       seedFingerPrint: fingerPrint,
-      derivationPathTemplate: pattern,
+      derivationPathTemplate,
       label: uniqueLabel,
     };
 

--- a/packages/tezos/src/helpers.ts
+++ b/packages/tezos/src/helpers.ts
@@ -74,7 +74,7 @@ export const getPublicKeyPairFromSk = async (sk: string): Promise<PublicKeyPair>
 export const derivePublicKeyPair = async (
   mnemonic: string,
   derivationPath: string,
-  curve: Curves = "ed25519"
+  curve: Curves
 ): Promise<PublicKeyPair> =>
   deriveSecretKey(mnemonic, derivationPath, curve).then(getPublicKeyPairFromSk);
 


### PR DESCRIPTION
## Proposed changes

[Task link](https://app.asana.com/0/1207041888417083/1207985676541269/f)

This PR also adds logic for deriving mnemonic accounts with curves different to ed25519

## Types of changes

- [ ] Bugfix
- [x] New feature
- [x] Refactor
- [ ] Breaking change
- [ ] UI fix

## Steps to reproduce

## Screenshots

https://github.com/user-attachments/assets/c3f3d4d0-8010-407f-9d8b-f8e46f27037a

<img width="405" alt="Screenshot 2024-08-22 at 11 57 20" src="https://github.com/user-attachments/assets/098a9715-85c2-4f9c-a20d-4aa86912eac7">
<img width="415" alt="Screenshot 2024-08-22 at 11 57 25" src="https://github.com/user-attachments/assets/c1036a40-cefd-4c23-ac9f-434f4388bea2">
<img width="405" alt="Screenshot 2024-08-22 at 11 57 31" src="https://github.com/user-attachments/assets/3ef1cdb0-5a86-49d3-85d4-f9f80c487b68">
<img width="397" alt="Screenshot 2024-08-22 at 11 57 42" src="https://github.com/user-attachments/assets/27b95301-82be-4266-8cee-e9500e0e522d">


## Checklist

- [x] Tests that prove my fix is effective or that my feature works have been added
- [ ] Documentation has been added (if appropriate)
- [x] Screenshots are added (if any UI changes have been made)
- [ ] All TODOs have a corresponding task created (and the link is attached to it)
