### PR TITLE
Send message to Embed Component when fee estimation completed

### DIFF
--- a/apps/embed-iframe/src/OperationModalContent.tsx
+++ b/apps/embed-iframe/src/OperationModalContent.tsx
@@ -29,7 +29,7 @@ import { getDAppByOrigin } from "./ClientsPermissions";
 const SIGN_TIMEOUT = 5 * 60 * 1000; // 5 minutes
 
 export const OperationModalContent = () => {
-  const { onClose, isLoading, setIsLoading, estimatedOperations } = useOperationModalContext();
+  const { onClose, setIsLoading, estimatedOperations } = useOperationModalContext();
   const { getNetwork, getUserData, getDAppOrigin } = useEmbedApp();
 
   const color = useColor();
@@ -113,7 +113,7 @@ export const OperationModalContent = () => {
                   Fee:
                 </Text>
                 <Text color={color("900")} data-testid="fee" size="xs">
-                  {isLoading ? "..." : prettyTezAmount(totalFee(estimatedOperations!.estimates))}
+                  {prettyTezAmount(totalFee(estimatedOperations!.estimates))}
                 </Text>
               </Flex>
             </Flex>

--- a/apps/embed-iframe/src/operationModalHooks.tsx
+++ b/apps/embed-iframe/src/operationModalHooks.tsx
@@ -2,7 +2,13 @@ import type { PartialTezosOperation } from "@airgap/beacon-types";
 import { Center, Modal, ModalCloseButton, ModalContent } from "@chakra-ui/react";
 
 import { OperationModalContent } from "./OperationModalContent";
-import { sendOperationErrorResponse, toSocialAccount, toTezosNetwork } from "./utils";
+import {
+  sendComputationErrorResponse,
+  sendOperationErrorResponse,
+  sendResponse,
+  toSocialAccount,
+  toTezosNetwork,
+} from "./utils";
 import { useOperationModalContext } from "./OperationModalContext";
 import { ModalLoadingOverlay } from "./ModalLoadingOverlay";
 import { estimate, getErrorContext, toAccountOperations } from "@umami/core";
@@ -42,11 +48,11 @@ export const useOperationModal = () => {
           accountOperations,
           toTezosNetwork(getNetwork()!)
         );
-
         setEstimatedOperations(estimatedOperations);
         onOpen();
+        sendResponse({ type: "computation_completed_response" });
       } catch (error) {
-        sendOperationErrorResponse(getErrorContext(error).description);
+        sendComputationErrorResponse(getErrorContext(error).description);
         onClose();
       }
     },

--- a/apps/embed-iframe/src/utils.ts
+++ b/apps/embed-iframe/src/utils.ts
@@ -13,6 +13,14 @@ export const sendLoginErrorResponse = (errorMessage: string) => {
   });
 };
 
+export const sendComputationErrorResponse = (errorMessage: string) => {
+  sendResponse({
+    type: "computation_completed_response",
+    error: "operation_failed",
+    errorMessage,
+  });
+};
+
 export const sendOperationErrorResponse = (errorMessage: string) => {
   sendResponse({
     type: "operation_response",


### PR DESCRIPTION
## Proposed changes

- This change makes it possible to only show iframe when fee computation is completed 
- If there is an error during computation, dApp will get it, but the user won't see the iframe

[Task link](https://app.asana.com/0/1207646563234653/1208056016062017/f)

## Types of changes

- [ ] Bugfix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] UI fix

## Screenshots


https://github.com/user-attachments/assets/5685ac6e-3c0d-49d7-b369-e95149bb2ad5

https://github.com/user-attachments/assets/a7ecdccf-55e9-4343-904a-b2c09f3c7276




## Checklist

- [x] Tests that prove my fix is effective or that my feature works have been added
- [x] Documentation has been added (if appropriate)
- [x] Screenshots are added (if any UI changes have been made)
- [x] All TODOs have a corresponding task created (and the link is attached to it)
