### PR TITLE
[embed] Block mainnet requests on ghostnet deployment

### DIFF
--- a/apps/embed-iframe/src/env.ts
+++ b/apps/embed-iframe/src/env.ts
@@ -1,0 +1,1 @@
+export const ENVIRONMENT = import.meta.env.VITE_EMBED_ENVIRONMENT || "ghostnet";


### PR DESCRIPTION
## Proposed changes

[Security review issue](https://github.com/trilitech/umami-security-review/issues/9)

This PR ands environment variables and blocks mainnet requests from execution on ghostnet deployment.

This is preparation for splitting ghostnet & mainnet environments on Vercel:
- Mainnet will have frame-ancestors for allowlisted dApps only. 
- Ghostnet will work for any url, but for ghostnet requests only.

Once everything is set up and tested, I'll add frame-ancestors to `vercel.mainnet.json`


## Types of changes

- [ ] Bugfix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] UI fix

## Steps to reproduce

## Screenshots

Add the screenshots of how the app used to look like and how it looks now

| Before | Now |
| ------ | --- |
|        |     |

## Checklist

- [ ] Tests that prove my fix is effective or that my feature works have been added
- [ ] Documentation has been added (if appropriate)
- [ ] Screenshots are added (if any UI changes have been made)
- [ ] All TODOs have a corresponding task created (and the link is attached to it)
