### PR TITLE
Add embed ghostnet url to oauth redirect page

### DIFF
--- a/apps/oauth/public/redirect.html
+++ b/apps/oauth/public/redirect.html
@@ -220,7 +220,7 @@
               return null;
             }
 
-            const regex = /https:\/\/(umami-v2-web|umami-embed-iframe)(-git-.*)?\.vercel\.app\/?/;
+            const regex = /https:\/\/(umami-v2-web|umami-embed-iframe|umami-embed-iframe-ghostnet)(-git-.*)?\.vercel\.app\/?/;
             if (instanceParams.redirectToOpener.match(regex)) {
               return instanceParams.redirectToOpener;
             }


### PR DESCRIPTION
## Proposed changes

[Security review issue](https://github.com/trilitech/umami-security-review/issues/9)

This PR adds ghostnet deployment url to oauth redirect.

This is preparation for splitting ghostnet & mainnet environments on Vercel:
- Mainnet will have frame-ancestors for allowlisted dApps only. 
- Ghostnet will work for any url, but for ghostnet requests only.

Once everything is set up and tested, I'll add frame-ancestors to `vercel.mainnet.json`

## Types of changes

- [ ] Bugfix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] UI fix

## Checklist

- [ ] Tests that prove my fix is effective or that my feature works have been added
- [ ] Documentation has been added (if appropriate)
- [ ] Screenshots are added (if any UI changes have been made)
- [ ] All TODOs have a corresponding task created (and the link is attached to it)
