### PR TITLE
feat: Adding WalletConnect data to peer list and slices

### DIFF
--- a/apps/desktop/src/Router.tsx
+++ b/apps/desktop/src/Router.tsx
@@ -1,7 +1,7 @@
 /* istanbul ignore file */
 import { DynamicModalContext, useDynamicModal } from "@umami/components";
 import { useDataPolling } from "@umami/data-polling";
-import { WalletClient, useImplicitAccounts, useResetConnections } from "@umami/state";
+import { WalletClient, useImplicitAccounts, useResetBeaconConnections } from "@umami/state";
 import { noop } from "lodash";
 import { useEffect } from "react";
 import { HashRouter, Navigate, Route, Routes } from "react-router-dom";
@@ -59,7 +59,7 @@ const LoggedInRouterWithPolling = () => {
 };
 
 const LoggedOutRouter = () => {
-  const resetBeaconConnections = useResetConnections();
+  const resetBeaconConnections = useResetBeaconConnections();
 
   useEffect(() => {
     WalletClient.destroy().then(resetBeaconConnections).catch(noop);

--- a/apps/desktop/src/utils/beacon/BeaconPeers.tsx
+++ b/apps/desktop/src/utils/beacon/BeaconPeers.tsx
@@ -10,7 +10,7 @@ import {
   Image,
   Text,
 } from "@chakra-ui/react";
-import { useGetConnectionInfo, usePeers, useRemovePeer } from "@umami/state";
+import { useBeaconPeers, useGetBeaconConnectionInfo, useRemoveBeaconPeer } from "@umami/state";
 import { parsePkh } from "@umami/tezos";
 import capitalize from "lodash/capitalize";
 import { Fragment } from "react";
@@ -22,10 +22,10 @@ import colors from "../../style/colors";
 /**
  * Component displaying a list of connected dApps.
  *
- * Loads dApps data from {@link usePeers} hook & zips it with generated dAppIds.
+ * Loads dApps data from {@link useBeaconPeers} hook & zips it with generated dAppIds.
  */
 export const BeaconPeers = () => {
-  const { peers } = usePeers();
+  const { peers } = useBeaconPeers();
 
   if (peers.length === 0) {
     return (
@@ -57,7 +57,7 @@ export const BeaconPeers = () => {
  * @param onRemove - action for deleting dApp connection.
  */
 const PeerRow = ({ peerInfo }: { peerInfo: ExtendedPeerInfo }) => {
-  const removePeer = useRemovePeer();
+  const removeBeaconPeer = useRemoveBeaconPeer();
 
   return (
     <Flex justifyContent="space-between" height="106px" data-testid="peer-row" paddingY="30px">
@@ -76,7 +76,7 @@ const PeerRow = ({ peerInfo }: { peerInfo: ExtendedPeerInfo }) => {
         <IconButton
           aria-label="Remove Peer"
           icon={<TrashIcon />}
-          onClick={() => removePeer(peerInfo)}
+          onClick={() => removeBeaconPeer(peerInfo)}
           size="xs"
           variant="circle"
         />
@@ -94,7 +94,7 @@ const PeerRow = ({ peerInfo }: { peerInfo: ExtendedPeerInfo }) => {
  * @param peerInfo - peerInfo provided by beacon Api + computed dAppId.
  */
 const StoredPeerInfo = ({ peerInfo }: { peerInfo: ExtendedPeerInfo }) => {
-  const connectionInfo = useGetConnectionInfo(peerInfo.senderId);
+  const connectionInfo = useGetBeaconConnectionInfo(peerInfo.senderId);
 
   if (!connectionInfo) {
     return null;

--- a/apps/desktop/src/utils/beacon/PermissionRequestModal.tsx
+++ b/apps/desktop/src/utils/beacon/PermissionRequestModal.tsx
@@ -27,7 +27,7 @@ import {
 import { useDynamicModalContext } from "@umami/components";
 import {
   WalletClient,
-  useAddConnection,
+  useAddBeaconConnection,
   useAsyncActionHandler,
   useGetImplicitAccount,
 } from "@umami/state";
@@ -39,7 +39,7 @@ import { OwnedImplicitAccountsAutocomplete } from "../../components/AddressAutoc
 import colors from "../../style/colors";
 
 export const PermissionRequestModal = ({ request }: { request: PermissionRequestOutput }) => {
-  const addConnectionToBeaconSlice = useAddConnection();
+  const addConnectionToBeaconSlice = useAddBeaconConnection();
   const getAccount = useGetImplicitAccount();
   const { onClose } = useDynamicModalContext();
   const { handleAsyncAction } = useAsyncActionHandler();

--- a/apps/desktop/src/utils/beacon/useHandleBeaconMessage.tsx
+++ b/apps/desktop/src/utils/beacon/useHandleBeaconMessage.tsx
@@ -11,7 +11,7 @@ import {
   useAsyncActionHandler,
   useFindNetwork,
   useGetOwnedAccountSafe,
-  useRemovePeerBySenderId,
+  useRemoveBeaconPeerBySenderId,
 } from "@umami/state";
 import { type Network } from "@umami/tezos";
 
@@ -23,7 +23,7 @@ import { BeaconSignPage } from "../../components/SendFlow/Beacon/BeaconSignPage"
 /**
  * @returns a function that handles a beacon message and opens a modal with the appropriate content
  *
- * For operation requests it will also try to convert the operation(s) to our {@link Operation} format,
+ * For operation requests it will also try to convert the operation(s)n to our {@link Operation} format,
  * estimate the fee and open the BeaconSignPage only if it succeeds
  */
 export const useHandleBeaconMessage = () => {
@@ -31,7 +31,7 @@ export const useHandleBeaconMessage = () => {
   const { handleAsyncAction } = useAsyncActionHandler();
   const getAccount = useGetOwnedAccountSafe();
   const findNetwork = useFindNetwork();
-  const removePeer = useRemovePeerBySenderId();
+  const removePeer = useRemoveBeaconPeerBySenderId();
 
   // we should confirm that we support the network that the beacon request is coming from
   const checkNetwork = ({

--- a/apps/web/src/components/Menu/AppsMenu/AppsMenu.test.tsx
+++ b/apps/web/src/components/Menu/AppsMenu/AppsMenu.test.tsx
@@ -1,15 +1,40 @@
-import { WalletClient } from "@umami/state";
+jest.mock("@umami/state", () => ({
+  ...jest.requireActual("@umami/state"),
+  walletKit: {
+    core: {},
+    metadata: {
+      name: "AppMenu test",
+      description: "Umami Wallet with WalletConnect",
+      url: "https://umamiwallet.com",
+      icons: ["https://umamiwallet.com/assets/favicon-32-45gq0g6M.png"],
+    },
+    getActiveSessions: jest.fn(),
+    pair: jest.fn(),
+  },
+  createWalletKit: jest.fn(),
+}));
+
+import { WalletClient, walletKit } from "@umami/state";
 
 import { AppsMenu } from "./AppsMenu";
 import { act, renderInDrawer, screen, userEvent } from "../../../testUtils";
 
 describe("<AppsMenu />", () => {
-  it("calls addPeer on button click with the copied text", async () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+  it("calls addPeer for Beacon on button click with the copied text", async () => {
     const user = userEvent.setup();
     const payload =
       "btunoo2sZmmMB6k9Bef8tgYs7PsS6g6DFdUiDzVuwMxv7nGJN71eFCtGxGfq321pFy4eT2ckDWWzTdBhvje7VUzy2ZciQSe9rGMCF6Fpx5MCM3q2CWyUt4nhqSFigPhcUHaLAzAwcSTXbSRn9YZ8QJwwaWzdsNF6UW4PrWeCbABvHArBDpeLRNxJRjMpAVndoCCf9Vbu7YRXF2FcxWxUrcqfj1i3hr34M8zRTtP5QuVqita8MW5A6Ub3tB3bDvykqa8aYFvxbWr47USytTQjVqnnFUdBo8rm3cJyUq39hJwUdbvZEyoGUWnfuhFHYcbyZP86CPef1p7Eh1KUEwVKxLxQwNX84Eg1eBkZowRtNKcqqShMhKT7ZEELyfh1ji7NckRF8RJuwuco4dqBg6msuZjZqta4CsJvQw4A66RbePC8LxwKEb3Nhha8cygtbQVC4Scb7PaLY9qwQJjYL7n";
     jest.spyOn(navigator.clipboard, "readText").mockResolvedValue(payload);
-    const mockAddPeer = jest.spyOn(WalletClient, "addPeer");
+    jest.spyOn(walletKit, "getActiveSessions").mockImplementation(() => ({}));
+
+    // make sure the mocks are correct
+    expect(walletKit.metadata.name).toEqual("AppMenu test");
+    expect(walletKit.getActiveSessions()).toEqual({});
+
+    const mockAddPeer = jest.spyOn(WalletClient, "addPeer").mockResolvedValue(undefined);
 
     await renderInDrawer(<AppsMenu />);
 
@@ -24,5 +49,26 @@ describe("<AppsMenu />", () => {
       type: "p2p-pairing-request",
       version: "3",
     });
+  });
+
+  it("handles WalletConenct request on button click with the copied text", async () => {
+    const user = userEvent.setup();
+    const payload =
+      "wc:c02d87d6f8c46a9192e1fd4627b5104d326ee6ec4dd9040482a277bdc53e2f10@2?expiryTimestamp=1733241891&relay-protocol=irn&symKey=d8b5f7b8a35b7e73126bfe4af89568811a87c4cfd49e3946c44026d55267ebd7";
+    jest.spyOn(navigator.clipboard, "readText").mockResolvedValue(payload);
+    jest.spyOn(walletKit, "getActiveSessions").mockImplementation(() => ({}));
+
+    // make sure the mocks are correct
+    expect(walletKit.metadata.name).toEqual("AppMenu test");
+    expect(walletKit.getActiveSessions()).toEqual({});
+
+    const mockAddPeer = jest.spyOn(WalletClient, "addPeer").mockResolvedValue(undefined);
+
+    await renderInDrawer(<AppsMenu />);
+
+    await act(() => user.click(screen.getByText("Connect")));
+
+    expect(mockAddPeer).not.toHaveBeenCalled();
+    expect(walletKit.pair).toHaveBeenCalledWith({ uri: payload });
   });
 });

--- a/apps/web/src/components/Menu/AppsMenu/AppsMenu.tsx
+++ b/apps/web/src/components/Menu/AppsMenu/AppsMenu.tsx
@@ -2,7 +2,7 @@ import { Button, Text } from "@chakra-ui/react";
 import { useAddPeer } from "@umami/state";
 
 import { BeaconPeers } from "../../beacon";
-import { useOnWalletConnect } from "../../WalletConnect";
+import { WcPeers, useOnWalletConnect } from "../../WalletConnect";
 import { DrawerContentWrapper } from "../DrawerContentWrapper";
 
 export const AppsMenu = () => {
@@ -36,6 +36,7 @@ export const AppsMenu = () => {
       title="Apps"
     >
       <BeaconPeers />
+      <WcPeers />
     </DrawerContentWrapper>
   );
 };

--- a/apps/web/src/components/Menu/Menu.test.tsx
+++ b/apps/web/src/components/Menu/Menu.test.tsx
@@ -6,6 +6,7 @@ import {
   addTestAccount,
   makeStore,
   useDownloadBackupFile,
+  walletKit,
 } from "@umami/state";
 
 import { AddressBookMenu } from "./AddressBookMenu/AddressBookMenu";
@@ -30,6 +31,17 @@ jest.mock("@chakra-ui/system", () => ({
 jest.mock("@umami/state", () => ({
   ...jest.requireActual("@umami/state"),
   useDownloadBackupFile: jest.fn(),
+  walletKit: {
+    core: {},
+    metadata: {
+      name: "AppMenu test",
+      description: "Umami Wallet with WalletConnect",
+      url: "https://umamiwallet.com",
+      icons: ["https://umamiwallet.com/assets/favicon-32-45gq0g6M.png"],
+    },
+    getActiveSessions: jest.fn(),
+  },
+  createWalletKit: jest.fn(),
 }));
 
 let store: UmamiStore;
@@ -71,6 +83,7 @@ describe("<Menu />", () => {
     ])("opens %label menu correctly", async (label, Component) => {
       const user = userEvent.setup();
       const { openWith } = dynamicDrawerContextMock;
+      jest.spyOn(walletKit, "getActiveSessions").mockImplementation(() => ({}));
 
       await renderInDrawer(<Menu />, store);
 

--- a/apps/web/src/components/WalletConnect/SessionProposalModal.tsx
+++ b/apps/web/src/components/WalletConnect/SessionProposalModal.tsx
@@ -16,7 +16,12 @@ import {
 } from "@chakra-ui/react";
 import { type WalletKitTypes } from "@reown/walletkit";
 import { useDynamicModalContext } from "@umami/components";
-import { useAsyncActionHandler, useGetImplicitAccount, walletKit } from "@umami/state";
+import {
+  useAsyncActionHandler,
+  useGetImplicitAccount,
+  useToggleWcPeerListUpdated,
+  walletKit,
+} from "@umami/state";
 import { type SessionTypes } from "@walletconnect/types";
 import { buildApprovedNamespaces, getSdkError } from "@walletconnect/utils";
 import { FormProvider, useForm } from "react-hook-form";
@@ -35,6 +40,7 @@ export const SessionProposalModal = ({
   network: NetworkType;
 }) => {
   const getAccount = useGetImplicitAccount();
+  const toggleWcPeerListUpdated = useToggleWcPeerListUpdated();
   const color = useColor();
 
   const { onClose } = useDynamicModalContext();
@@ -71,6 +77,7 @@ export const SessionProposalModal = ({
         sessionProperties: {},
       });
       console.log("WC session approved", session);
+      toggleWcPeerListUpdated();
       onClose();
     });
 

--- a/apps/web/src/components/WalletConnect/WalletConnectPeers.tsx
+++ b/apps/web/src/components/WalletConnect/WalletConnectPeers.tsx
@@ -1,0 +1,131 @@
+import { Center, Divider, Flex, IconButton, Image, Text, VStack } from "@chakra-ui/react";
+import { useDisconnectWalletConnectPeer, useGetWcPeerListToggle, walletKit } from "@umami/state";
+import { parsePkh } from "@umami/tezos";
+import { type SessionTypes } from "@walletconnect/types";
+import { getSdkError } from "@walletconnect/utils";
+import capitalize from "lodash/capitalize";
+import { useEffect, useState } from "react";
+
+import { CodeSandboxIcon, StubIcon as TrashIcon } from "../../assets/icons";
+import { useColor } from "../../styles/useColor";
+import { AddressPill } from "../AddressPill";
+import { EmptyMessage } from "../EmptyMessage";
+
+/**
+ * Component displaying a list of connected dApps.
+ *
+ * Loads dApps data from WalletConnect API and displays it in a list.
+ */
+export const WcPeers = () => {
+  const [sessions, setSessions] = useState<Record<string, SessionTypes.Struct>>({});
+  const isUpdated = useGetWcPeerListToggle();
+
+  useEffect(() => {
+    const sessions: Record<string, SessionTypes.Struct> = walletKit.getActiveSessions();
+    setSessions(sessions);
+  }, [isUpdated]);
+
+  if (!Object.keys(sessions).length) {
+    return (
+      <EmptyMessage
+        alignItems="flex-start"
+        marginTop="40px"
+        data-testid="wc-peers-empty"
+        subtitle="No WalletConnect Apps to show"
+        title="Your WalletConnect Apps will appear here..."
+      />
+    );
+  }
+
+  return (
+    <VStack
+      alignItems="flex-start"
+      gap="24px"
+      marginTop="24px"
+      data-testid="wc-peers"
+      divider={<Divider />}
+      spacing="0"
+    >
+      {
+        // loop peers and print PeerRow
+        Object.entries(sessions).map(([topic, sessionInfo]) => (
+          <PeerRow key={topic} sessionInfo={sessionInfo} />
+        ))
+      }
+    </VStack>
+  );
+};
+
+/**
+ * Component for displaying info about single connected dApp.
+ *
+ * @param sessionInfo - sessionInfo provided by wc Api + computed dAppId.
+ * @param onRemove - action for deleting dApp connection.
+ */
+const PeerRow = ({ sessionInfo }: { sessionInfo: SessionTypes.Struct }) => {
+  const color = useColor();
+  const disconnectWalletConnectPeer = useDisconnectWalletConnectPeer();
+
+  return (
+    <Center
+      alignItems="center"
+      justifyContent="space-between"
+      width="full"
+      height="60px"
+      data-testid="peer-row"
+    >
+      <Flex height="100%">
+        <Center width="60px" marginRight="12px">
+          <Image
+            objectFit="cover"
+            fallback={<CodeSandboxIcon width="36px" height="36px" />}
+            src={sessionInfo.peer.metadata.icons[0]}
+          />
+        </Center>
+        <Center alignItems="flex-start" flexDirection="column" gap="6px">
+          <Text color={color("900")} size="lg">
+            {sessionInfo.peer.metadata.name}
+          </Text>
+          <StoredSessionInfo sessionInfo={sessionInfo} />
+        </Center>
+      </Flex>
+      <IconButton
+        color={color("500")}
+        aria-label="Remove Peer"
+        icon={<TrashIcon />}
+        onClick={() =>
+          disconnectWalletConnectPeer({
+            topic: sessionInfo.topic,
+            reason: getSdkError("USER_DISCONNECTED"),
+          })
+        }
+        variant="iconButtonSolid"
+      />
+    </Center>
+  );
+};
+
+/**
+ * Component for displaying additional info about connection with a dApp.
+ *
+ * Displays {@link AddressPill} with a connected account and network type.
+ *
+ * @param sessionInfo - sessionInfo provided by WalletConnect Api.
+ * Account is stored in format: tezos:ghostnet:tz1...
+ * Network is stored in format: tezos:mainnet
+ */
+const StoredSessionInfo = ({ sessionInfo }: { sessionInfo: SessionTypes.Struct }) => (
+  <Flex>
+    <AddressPill
+      marginRight="10px"
+      address={parsePkh(sessionInfo.namespaces.tezos.accounts[0].split(":")[2])}
+    />
+    <Divider marginRight="10px" orientation="vertical" />
+    <Text marginTop="2px" marginRight="4px" fontWeight={600} size="sm">
+      Network:
+    </Text>
+    <Text marginTop="2px" data-testid="dapp-connection-network" size="sm">
+      {capitalize(sessionInfo.namespaces.tezos.chains?.[0].split(":")[1] ?? "")}
+    </Text>
+  </Flex>
+);

--- a/apps/web/src/components/WalletConnect/index.tsx
+++ b/apps/web/src/components/WalletConnect/index.tsx
@@ -1,1 +1,2 @@
 export * from "./WalletConnectProvider";
+export * from "./WalletConnectPeers";

--- a/apps/web/src/components/beacon/BeaconPeers.tsx
+++ b/apps/web/src/components/beacon/BeaconPeers.tsx
@@ -1,6 +1,6 @@
 import { type ExtendedPeerInfo } from "@airgap/beacon-wallet";
 import { Center, Divider, Flex, Heading, IconButton, Image, Text, VStack } from "@chakra-ui/react";
-import { useGetConnectionInfo, usePeers, useRemovePeer } from "@umami/state";
+import { useBeaconPeers, useGetBeaconConnectionInfo, useRemoveBeaconPeer } from "@umami/state";
 import { parsePkh } from "@umami/tezos";
 import capitalize from "lodash/capitalize";
 
@@ -12,10 +12,10 @@ import { EmptyMessage } from "../EmptyMessage";
 /**
  * Component displaying a list of connected dApps.
  *
- * Loads dApps data from {@link usePeers} hook & zips it with generated dAppIds.
+ * Loads dApps data from {@link useBeaconPeers} hook & zips it with generated dAppIds.
  */
 export const BeaconPeers = () => {
-  const { peers } = usePeers();
+  const { peers } = useBeaconPeers();
 
   if (peers.length === 0) {
     return (
@@ -53,7 +53,7 @@ export const BeaconPeers = () => {
  */
 const PeerRow = ({ peerInfo }: { peerInfo: ExtendedPeerInfo }) => {
   const color = useColor();
-  const removePeer = useRemovePeer();
+  const removePeer = useRemoveBeaconPeer();
 
   return (
     <Center
@@ -98,7 +98,7 @@ const PeerRow = ({ peerInfo }: { peerInfo: ExtendedPeerInfo }) => {
  * @param peerInfo - peerInfo provided by beacon Api + computed dAppId.
  */
 const StoredPeerInfo = ({ peerInfo }: { peerInfo: ExtendedPeerInfo }) => {
-  const connectionInfo = useGetConnectionInfo(peerInfo.senderId);
+  const connectionInfo = useGetBeaconConnectionInfo(peerInfo.senderId);
 
   if (!connectionInfo) {
     return null;

--- a/apps/web/src/components/beacon/PermissionRequestModal.tsx
+++ b/apps/web/src/components/beacon/PermissionRequestModal.tsx
@@ -26,7 +26,7 @@ import {
 import { useDynamicModalContext } from "@umami/components";
 import {
   WalletClient,
-  useAddConnection,
+  useAddBeaconConnection,
   useAsyncActionHandler,
   useGetImplicitAccount,
 } from "@umami/state";
@@ -41,7 +41,7 @@ import { JsValueWrap } from "../JsValueWrap";
 
 export const PermissionRequestModal = ({ request }: { request: PermissionRequestOutput }) => {
   const color = useColor();
-  const addConnectionToBeaconSlice = useAddConnection();
+  const addConnectionToBeaconSlice = useAddBeaconConnection();
   const getAccount = useGetImplicitAccount();
   const { onClose } = useDynamicModalContext();
   const { handleAsyncAction } = useAsyncActionHandler();

--- a/apps/web/src/components/beacon/useHandleBeaconMessage.tsx
+++ b/apps/web/src/components/beacon/useHandleBeaconMessage.tsx
@@ -11,7 +11,7 @@ import {
   useAsyncActionHandler,
   useFindNetwork,
   useGetOwnedAccountSafe,
-  useRemovePeerBySenderId,
+  useRemoveBeaconPeerBySenderId,
 } from "@umami/state";
 import { type Network } from "@umami/tezos";
 
@@ -31,7 +31,7 @@ export const useHandleBeaconMessage = () => {
   const { handleAsyncAction } = useAsyncActionHandler();
   const getAccount = useGetOwnedAccountSafe();
   const findNetwork = useFindNetwork();
-  const removePeer = useRemovePeerBySenderId();
+  const removePeer = useRemoveBeaconPeerBySenderId();
 
   // we should confirm that we support the network that the beacon request is coming from
   const checkNetwork = ({

--- a/packages/state/package.json
+++ b/packages/state/package.json
@@ -83,6 +83,7 @@
     "@umami/tzkt": "workspace:^",
     "@walletconnect/core": "^2.16.2",
     "@walletconnect/jsonrpc-utils": "^1.0.8",
+    "@walletconnect/types": "^2.16.2",
     "@walletconnect/utils": "^2.16.2",
     "bip39": "^3.1.0",
     "framer-motion": "^11.12.0",

--- a/packages/state/src/hooks/WalletConnect.ts
+++ b/packages/state/src/hooks/WalletConnect.ts
@@ -1,0 +1,27 @@
+import { type ErrorResponse } from "@walletconnect/jsonrpc-utils";
+import { useDispatch } from "react-redux";
+
+import { useAppSelector } from "./useAppSelector";
+import { wcActions } from "../slices";
+import { walletKit } from "../walletConnect";
+
+// get a toggle to monitor updates in peer list
+export const useGetWcPeerListToggle = () => {
+  const wcData = useAppSelector(s => s.walletconnect);
+  return wcData.peerListUpdatedToggle;
+};
+
+// report that the peer list is updated
+export const useToggleWcPeerListUpdated = () => {
+  const dispatch = useDispatch();
+  return () => dispatch(wcActions.togglePeerListUpdated());
+};
+
+// remove dApp connection from WalletConnect SDK
+export const useDisconnectWalletConnectPeer = () => {
+  const togglePeerListUpdated = useToggleWcPeerListUpdated();
+  return async (params: { topic: string; reason: ErrorResponse }) => {
+    await walletKit.disconnectSession(params).then(() => togglePeerListUpdated());
+    console.log("WC session deleted on user request", params);
+  };
+};

--- a/packages/state/src/hooks/beacon.test.ts
+++ b/packages/state/src/hooks/beacon.test.ts
@@ -3,10 +3,10 @@ import { mockMnemonicAccount, mockSocialAccount } from "@umami/core";
 import { type RawPkh } from "@umami/tezos";
 
 import {
-  useAddConnection,
-  useGetConnectionInfo,
-  useRemoveConnection,
-  useResetConnections,
+  useAddBeaconConnection,
+  useGetBeaconConnectionInfo,
+  useRemoveBeaconConnection,
+  useResetBeaconConnections,
 } from "./beacon";
 import { beaconActions } from "../slices";
 import { type UmamiStore, makeStore } from "../store";
@@ -33,7 +33,7 @@ const connectionInfo = (accountPkh: RawPkh, networkType: NetworkType) => ({
 
 describe("useGetConnectedAccount", () => {
   it("returns undefined when no connection for dAppId is stored", () => {
-    const view = renderHook(() => useGetConnectionInfo(dAppId1), { store });
+    const view = renderHook(() => useGetBeaconConnectionInfo(dAppId1), { store });
 
     expect(view.result.current).toBeUndefined();
   });
@@ -42,7 +42,7 @@ describe("useGetConnectedAccount", () => {
     addConnection(dAppId1, pkh1, NetworkType.MAINNET);
     addConnection(dAppId2, pkh2, NetworkType.GHOSTNET);
 
-    const view = renderHook(() => useGetConnectionInfo(dAppId2), { store });
+    const view = renderHook(() => useGetBeaconConnectionInfo(dAppId2), { store });
 
     expect(view.result.current).toEqual(connectionInfo(pkh2, NetworkType.GHOSTNET));
   });
@@ -55,7 +55,7 @@ describe("useResetConnections", () => {
 
     const {
       result: { current: resetBeaconSlice },
-    } = renderHook(() => useResetConnections(), { store });
+    } = renderHook(() => useResetBeaconConnections(), { store });
     resetBeaconSlice();
 
     expect(store.getState().beacon).toEqual({});
@@ -68,7 +68,7 @@ describe("useAddConnection", () => {
 
     const {
       result: { current: addConnectionHook },
-    } = renderHook(() => useAddConnection(), { store });
+    } = renderHook(() => useAddBeaconConnection(), { store });
     addConnectionHook(dAppId2, pkh2, NetworkType.MAINNET);
 
     expect(store.getState().beacon).toEqual({
@@ -82,7 +82,7 @@ describe("useAddConnection", () => {
 
     const {
       result: { current: addConnectionHook },
-    } = renderHook(() => useAddConnection(), { store });
+    } = renderHook(() => useAddBeaconConnection(), { store });
     addConnectionHook(dAppId1, pkh2, NetworkType.MAINNET);
 
     expect(store.getState().beacon).toEqual({
@@ -98,7 +98,7 @@ describe("useRemoveConnection", () => {
 
     const {
       result: { current: removeConnection },
-    } = renderHook(() => useRemoveConnection(), { store });
+    } = renderHook(() => useRemoveBeaconConnection(), { store });
     removeConnection(dAppId2);
 
     expect(store.getState().beacon).toEqual({

--- a/packages/state/src/hooks/index.ts
+++ b/packages/state/src/hooks/index.ts
@@ -18,3 +18,4 @@ export * from "./removeAccountDependencies";
 export * from "./setAccountData";
 export * from "./staking";
 export * from "./tokens";
+export * from "./WalletConnect";

--- a/packages/state/src/hooks/removeAccountDependencies.ts
+++ b/packages/state/src/hooks/removeAccountDependencies.ts
@@ -1,6 +1,6 @@
 import { type Account, type ImplicitAccount } from "@umami/core";
 
-import { useRemovePeersByAccounts } from "./beacon";
+import { useRemoveBeaconPeersByAccounts } from "./beacon";
 import { useCurrentAccount, useImplicitAccounts } from "./getAccountData";
 import { useMultisigAccounts } from "./multisig";
 import { useAppDispatch } from "./useAppDispatch";
@@ -45,7 +45,7 @@ export const useRemoveDependenciesAndMultisigs = () => {
  */
 const useRemoveAccountsDependencies = () => {
   const dispatch = useAppDispatch();
-  const removePeersByAccounts = useRemovePeersByAccounts();
+  const removePeersByAccounts = useRemoveBeaconPeersByAccounts();
   const currentAccount = useCurrentAccount();
   const implicitAccounts = useImplicitAccounts();
 

--- a/packages/state/src/reducer.ts
+++ b/packages/state/src/reducer.ts
@@ -4,6 +4,7 @@ import createWebStorage from "redux-persist/lib/storage/createWebStorage";
 
 import { createAsyncMigrate } from "./createAsyncMigrate";
 import { VERSION, accountsMigrations, mainStoreMigrations } from "./migrations";
+import { wcSlice } from "./slices";
 import { accountsSlice } from "./slices/accounts/accounts";
 import { announcementSlice } from "./slices/announcement";
 import { assetsSlice } from "./slices/assets";
@@ -56,6 +57,7 @@ export const makeReducer = (storage_: Storage | undefined) => {
     assets: assetsSlice.reducer,
     batches: batchesSlice.reducer,
     beacon: beaconSlice.reducer,
+    walletconnect: wcSlice.reducer,
     contacts: contactsSlice.reducer,
     errors: errorsSlice.reducer,
     multisigs: multisigsSlice.reducer,

--- a/packages/state/src/slices/WalletConnect.ts
+++ b/packages/state/src/slices/WalletConnect.ts
@@ -1,0 +1,29 @@
+import { createSlice } from "@reduxjs/toolkit";
+
+export type WalletConnectInfo = {
+  peerListUpdatedToggle: boolean;
+};
+
+// mapping topic -> connection info
+export type State = WalletConnectInfo;
+
+export const wcInitialState: State = { peerListUpdatedToggle: false };
+
+/**
+ * Stores connection info between dApps and accounts.
+ *
+ * dApps are identified by topic (a unique string id generated from dApp public key).
+ */
+export const wcSlice = createSlice({
+  name: "walletconnect",
+  initialState: wcInitialState,
+  reducers: {
+    reset: () => wcInitialState,
+
+    togglePeerListUpdated: state => {
+      state.peerListUpdatedToggle = !state.peerListUpdatedToggle;
+    },
+  },
+});
+
+export const wcActions = wcSlice.actions;

--- a/packages/state/src/slices/beacon.ts
+++ b/packages/state/src/slices/beacon.ts
@@ -3,12 +3,12 @@ import { createSlice } from "@reduxjs/toolkit";
 import { type RawPkh } from "@umami/tezos";
 import { fromPairs } from "lodash";
 
-export type DAppConnectionInfo = {
+export type DAppBeaconConnectionInfo = {
   accountPkh: RawPkh;
   networkType: NetworkType;
 };
 
-type State = Record<string, DAppConnectionInfo>;
+type State = Record<string, DAppBeaconConnectionInfo>;
 
 export const beaconInitialState: State = {};
 

--- a/packages/state/src/slices/index.ts
+++ b/packages/state/src/slices/index.ts
@@ -9,3 +9,4 @@ export * from "./multisigs";
 export * from "./networks";
 export * from "./tokens";
 export * from "./protocolSettings";
+export * from "./WalletConnect";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1800,9 +1800,12 @@ importers:
       '@walletconnect/jsonrpc-utils':
         specifier: ^1.0.8
         version: 1.0.8
-      '@walletconnect/utils':
+      '@walletconnect/types':
         specifier: ^2.16.2
         version: 2.17.2
+      '@walletconnect/utils':
+        specifier: ^2.16.2
+        version: 2.16.2
       bip39:
         specifier: ^3.1.0
         version: 3.1.0


### PR DESCRIPTION
## Proposed changes

Adding peers for WalletConnect
 - adding walletconnect to slices
 - updating peer list on connect and disconnect

## Types of changes

- [ ] Bugfix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] UI fix

## Steps to reproduce

1. Rejecting
actions: on dApp - connect, copy link. on Wallet: Connect, reject
result: on Wallet - Approve button is inactive. On reject - modal is closed immediately. on dApp: modal is closed

2. Approving
actions: on dApp - connect, copy link. on Wallet: on Wallet: Connect, select Account, Approve
result: on dApp - connected, the list of actions is shown. on Wallet: the modal is closed, the list of peers contains the dApp (name, account, network, button to disconnect)
actions: on dApp - request transaction
result: on dApp - transaction is immediately rejected with USER rejected error

3. Disconnecting from Wallet
actions: connect with approve; click Disconnect on Wallet
result: on Wallet: dapp is removed from the list. on Dapp - state changes to disconnected

4. Disconnecting from dApp
actions: connect with approve; click Disconnect on dApp
result: on Wallet: dapp is removed from the list; toast shows which dApp disconnected. on dApp - state changes to disconnected

## Screenshots

<img width="398" alt="image" src="https://github.com/user-attachments/assets/86af1ef9-dd4e-4749-92c8-b9de22da1efd">

<img width="397" alt="image" src="https://github.com/user-attachments/assets/a0b3bbcc-8f94-492e-8816-7c94ac394d0e">

<img width="205" alt="image" src="https://github.com/user-attachments/assets/8087e8b0-87d4-4305-a91b-195275e1cced">


## Checklist

- [ ] Tests that prove my fix is effective or that my feature works have been added
- [ ] Documentation has been added (if appropriate)
- [ ] Screenshots are added (if any UI changes have been made)
- [ ] All TODOs have a corresponding task created (and the link is attached to it)
