### PR TITLE
Adjust mac entitlements for desktop

### DIFF
--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -27,6 +27,8 @@ mac:
       arch:
         - arm64
         - x64
+  entitlements: entitlements.mac.plist
+  entitlementsInherit: entitlements.mac.plist
 win:
   icon: icons/512x512.png
   target: appx

--- a/apps/desktop/entitlements.mac.plist
+++ b/apps/desktop/entitlements.mac.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <false/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <false/>
+  </dict>
+</plist>


### PR DESCRIPTION
## Proposed changes

This PR `disables` these entitlements for MacOS desktop app
```
com.apple.security.cs.allow-unsigned-executable-memory
com.apple.security.cs.disable-library-validation
```
