### PR TITLE
feat: WalletConnect integration, part 3, Beacon modals generalised for any SDK

### DIFF
--- a/apps/web/src/components/SendFlow/Beacon/BatchSignPage.tsx
+++ b/apps/web/src/components/SendFlow/Beacon/BatchSignPage.tsx
@@ -1,3 +1,4 @@
+import { type PartialTezosOperation } from "@airgap/beacon-wallet";
 import {
   Accordion,
   AccordionButton,
@@ -12,28 +13,36 @@ import {
   ModalFooter,
   Text,
 } from "@chakra-ui/react";
-import { FormProvider } from "react-hook-form";
+import { FormProvider, useForm } from "react-hook-form";
 
-import { type BeaconSignPageProps } from "./BeaconSignPageProps";
 import { Header } from "./Header";
-import { useSignWithBeacon } from "./useSignWithBeacon";
 import { useColor } from "../../../styles/useColor";
 import { AddressTile } from "../../AddressTile/AddressTile";
 import { JsValueWrap } from "../../JsValueWrap";
+import { useSignWithBeacon } from "../Beacon/useSignWithBeacon";
 import { SignButton } from "../SignButton";
 import { SignPageFee } from "../SignPageFee";
+import { type SdkSignPageProps } from "../utils";
 
-export const BatchSignPage = ({ operation, message }: BeaconSignPageProps) => {
-  const { isSigning, onSign, network, fee, form } = useSignWithBeacon(operation, message);
+export const BatchSignPage = (
+  signProps: SdkSignPageProps,
+  operationDetails: PartialTezosOperation[]
+) => {
   const color = useColor();
-  const { signer } = operation;
-  const transactionCount = operation.operations.length;
+
+  const beaconCalculatedProps = useSignWithBeacon({ ...signProps });
+  const calculatedProps = beaconCalculatedProps;
+
+  const { isSigning, onSign, network, fee } = calculatedProps;
+  const { signer, operations } = signProps.operation;
+  const transactionCount = operations.length;
+  const form = useForm({ defaultValues: { executeParams: signProps.operation.estimates } });
 
   return (
     <FormProvider {...form}>
       <ModalContent>
         <form>
-          <Header message={message} />
+          <Header headerProps={signProps.headerProps} />
 
           <ModalBody>
             <Accordion allowToggle>
@@ -45,11 +54,7 @@ export const BatchSignPage = ({ operation, message }: BeaconSignPageProps) => {
                   <AccordionIcon />
                 </AccordionButton>
                 <AccordionPanel>
-                  <JsValueWrap
-                    overflowY="auto"
-                    maxHeight="200px"
-                    value={message.operationDetails}
-                  />
+                  <JsValueWrap overflowY="auto" maxHeight="200px" value={operationDetails} />
                 </AccordionPanel>
               </AccordionItem>
             </Accordion>

--- a/apps/web/src/components/SendFlow/Beacon/BeaconSignPage.tsx
+++ b/apps/web/src/components/SendFlow/Beacon/BeaconSignPage.tsx
@@ -1,39 +1,43 @@
 import { CustomError } from "@umami/utils";
 
-import { type BeaconSignPageProps } from "./BeaconSignPageProps";
+import { type SdkSignPageProps } from "../utils";
 import { ContractCallSignPage } from "./ContractCallSignPage";
 import { DelegationSignPage } from "./DelegationSignPage";
 import { FinalizeUnstakeSignPage } from "./FinalizeUnstakeSignPage";
 import { OriginationOperationSignPage } from "./OriginationOperationSignPage";
 import { StakeSignPage } from "./StakeSignPage";
-import { TezSignPage as BeaconTezSignPage } from "./TezSignPage";
+import { TezSignPage } from "./TezSignPage";
 import { UndelegationSignPage } from "./UndelegationSignPage";
 import { UnstakeSignPage } from "./UnstakeSignPage";
+import { useSignWithBeacon } from "../Beacon/useSignWithBeacon";
 
-export const BeaconSignPage = ({ operation, message }: BeaconSignPageProps) => {
-  const operationType = operation.operations[0].type;
+export const SingleSignPage = (signProps: SdkSignPageProps) => {
+  const operationType = signProps.operation.operations[0].type;
+
+  const beaconCalculatedProps = useSignWithBeacon({ ...signProps });
+  const calculatedProps = beaconCalculatedProps;
 
   switch (operationType) {
     case "tez": {
-      return <BeaconTezSignPage message={message} operation={operation} />;
+      return <TezSignPage {...signProps} {...calculatedProps} />;
     }
     case "contract_call": {
-      return <ContractCallSignPage message={message} operation={operation} />;
+      return <ContractCallSignPage {...signProps} {...calculatedProps} />;
     }
     case "delegation": {
-      return <DelegationSignPage message={message} operation={operation} />;
+      return <DelegationSignPage {...signProps} {...calculatedProps} />;
     }
     case "undelegation": {
-      return <UndelegationSignPage message={message} operation={operation} />;
+      return <UndelegationSignPage {...signProps} {...calculatedProps} />;
     }
     case "contract_origination":
-      return <OriginationOperationSignPage message={message} operation={operation} />;
+      return <OriginationOperationSignPage {...signProps} {...calculatedProps} />;
     case "stake":
-      return <StakeSignPage message={message} operation={operation} />;
+      return <StakeSignPage {...signProps} {...calculatedProps} />;
     case "unstake":
-      return <UnstakeSignPage message={message} operation={operation} />;
+      return <UnstakeSignPage {...signProps} {...calculatedProps} />;
     case "finalize_unstake":
-      return <FinalizeUnstakeSignPage message={message} operation={operation} />;
+      return <FinalizeUnstakeSignPage {...signProps} {...calculatedProps} />;
     /**
      * FA1/2 are impossible to get here because we don't parse them
      * instead we get a generic contract call

--- a/apps/web/src/components/SendFlow/Beacon/BeaconSignPageProps.ts
+++ b/apps/web/src/components/SendFlow/Beacon/BeaconSignPageProps.ts
@@ -1,7 +1,0 @@
-import { type OperationRequestOutput } from "@airgap/beacon-wallet";
-import { type EstimatedAccountOperations } from "@umami/core";
-
-export type BeaconSignPageProps = {
-  operation: EstimatedAccountOperations;
-  message: OperationRequestOutput;
-};

--- a/apps/web/src/components/SendFlow/Beacon/ContractCallSignPage.tsx
+++ b/apps/web/src/components/SendFlow/Beacon/ContractCallSignPage.tsx
@@ -12,11 +12,9 @@ import {
   ModalFooter,
 } from "@chakra-ui/react";
 import { type ContractCall } from "@umami/core";
-import { FormProvider } from "react-hook-form";
+import { FormProvider, useForm } from "react-hook-form";
 
-import { type BeaconSignPageProps } from "./BeaconSignPageProps";
 import { Header } from "./Header";
-import { useSignWithBeacon } from "./useSignWithBeacon";
 import { useColor } from "../../../styles/useColor";
 import { AddressTile } from "../../AddressTile/AddressTile";
 import { AdvancedSettingsAccordion } from "../../AdvancedSettingsAccordion";
@@ -24,22 +22,30 @@ import { TezTile } from "../../AssetTiles/TezTile";
 import { JsValueWrap } from "../../JsValueWrap";
 import { SignButton } from "../SignButton";
 import { SignPageFee } from "../SignPageFee";
+import { type CalculatedSignProps, type SdkSignPageProps } from "../utils";
 
-export const ContractCallSignPage = ({ operation, message }: BeaconSignPageProps) => {
+export const ContractCallSignPage = ({
+  operation,
+  headerProps,
+  isSigning,
+  onSign,
+  network,
+  fee,
+}: SdkSignPageProps & CalculatedSignProps) => {
   const {
     amount: mutezAmount,
     contract,
     entrypoint,
     args,
   } = operation.operations[0] as ContractCall;
-  const { isSigning, onSign, network, fee, form } = useSignWithBeacon(operation, message);
   const color = useColor();
+  const form = useForm({ defaultValues: { executeParams: operation.estimates } });
 
   return (
     <FormProvider {...form}>
       <ModalContent>
         <form>
-          <Header message={message} />
+          <Header headerProps={headerProps} />
           <ModalBody>
             <TezTile mutezAmount={mutezAmount} />
 

--- a/apps/web/src/components/SendFlow/Beacon/DelegationSignPage.tsx
+++ b/apps/web/src/components/SendFlow/Beacon/DelegationSignPage.tsx
@@ -1,25 +1,31 @@
 import { Flex, FormLabel, ModalBody, ModalContent, ModalFooter } from "@chakra-ui/react";
 import { type Delegation } from "@umami/core";
-import { FormProvider } from "react-hook-form";
+import { FormProvider, useForm } from "react-hook-form";
 
-import { type BeaconSignPageProps } from "./BeaconSignPageProps";
 import { Header } from "./Header";
-import { useSignWithBeacon } from "./useSignWithBeacon";
 import { AddressTile } from "../../AddressTile/AddressTile";
 import { AdvancedSettingsAccordion } from "../../AdvancedSettingsAccordion";
 import { SignButton } from "../SignButton";
 import { SignPageFee } from "../SignPageFee";
+import { type CalculatedSignProps, type SdkSignPageProps } from "../utils";
 
-export const DelegationSignPage = ({ operation, message }: BeaconSignPageProps) => {
+export const DelegationSignPage = ({
+  operation,
+  headerProps,
+  isSigning,
+  onSign,
+  network,
+  fee,
+}: SdkSignPageProps & CalculatedSignProps) => {
   const { recipient } = operation.operations[0] as Delegation;
 
-  const { isSigning, onSign, network, fee, form } = useSignWithBeacon(operation, message);
+  const form = useForm({ defaultValues: { executeParams: operation.estimates } });
 
   return (
     <FormProvider {...form}>
       <ModalContent>
         <form>
-          <Header message={message} />
+          <Header headerProps={headerProps} />
           <ModalBody>
             <FormLabel>From</FormLabel>
             <AddressTile address={operation.signer.address} />

--- a/apps/web/src/components/SendFlow/Beacon/FinalizeUnstakeSignPage.tsx
+++ b/apps/web/src/components/SendFlow/Beacon/FinalizeUnstakeSignPage.tsx
@@ -1,17 +1,23 @@
 import { Flex, FormLabel, ModalBody, ModalContent, ModalFooter } from "@chakra-ui/react";
 import { useAccountTotalFinalizableUnstakeAmount } from "@umami/state";
-import { FormProvider } from "react-hook-form";
+import { FormProvider, useForm } from "react-hook-form";
 
-import { type BeaconSignPageProps } from "./BeaconSignPageProps";
 import { Header } from "./Header";
-import { useSignWithBeacon } from "./useSignWithBeacon";
 import { AddressTile } from "../../AddressTile/AddressTile";
 import { TezTile } from "../../AssetTiles/TezTile";
 import { SignButton } from "../SignButton";
 import { SignPageFee } from "../SignPageFee";
+import { type CalculatedSignProps, type SdkSignPageProps } from "../utils";
 
-export const FinalizeUnstakeSignPage = ({ operation, message }: BeaconSignPageProps) => {
-  const { isSigning, onSign, network, fee, form } = useSignWithBeacon(operation, message);
+export const FinalizeUnstakeSignPage = ({
+  operation,
+  headerProps,
+  isSigning,
+  onSign,
+  network,
+  fee,
+}: SdkSignPageProps & CalculatedSignProps) => {
+  const form = useForm({ defaultValues: { executeParams: operation.estimates } });
   const totalFinalizableAmount = useAccountTotalFinalizableUnstakeAmount(
     operation.signer.address.pkh
   );
@@ -19,7 +25,7 @@ export const FinalizeUnstakeSignPage = ({ operation, message }: BeaconSignPagePr
     <FormProvider {...form}>
       <ModalContent>
         <form>
-          <Header message={message} />
+          <Header headerProps={headerProps} />
           <ModalBody>
             <Flex alignItems="center" justifyContent="end" marginTop="12px">
               <SignPageFee fee={fee} />

--- a/apps/web/src/components/SendFlow/Beacon/Header.tsx
+++ b/apps/web/src/components/SendFlow/Beacon/Header.tsx
@@ -1,12 +1,12 @@
-import { type OperationRequestOutput } from "@airgap/beacon-wallet";
 import { AspectRatio, Flex, Heading, Image, Text } from "@chakra-ui/react";
 import { capitalize } from "lodash";
 
 import { CodeSandboxIcon } from "../../../assets/icons";
 import { useColor } from "../../../styles/useColor";
 import { SignPageHeader } from "../SignPageHeader";
+import { type SignHeaderProps } from "../utils";
 
-export const Header = ({ message }: { message: OperationRequestOutput }) => {
+export const Header = ({ headerProps }: { headerProps: SignHeaderProps }) => {
   const color = useColor();
 
   return (
@@ -16,7 +16,7 @@ export const Header = ({ message }: { message: OperationRequestOutput }) => {
           Network:
         </Heading>
         <Text color={color("700")} fontWeight="400" size="sm">
-          {capitalize(message.network.type)}
+          {capitalize(headerProps.network.name)}
         </Text>
       </Flex>
 
@@ -32,10 +32,10 @@ export const Header = ({ message }: { message: OperationRequestOutput }) => {
             borderRadius="4px"
             objectFit="cover"
             fallback={<CodeSandboxIcon width="36px" height="36px" />}
-            src={message.appMetadata.icon}
+            src={headerProps.appIcon}
           />
         </AspectRatio>
-        <Heading size="sm">{message.appMetadata.name}</Heading>
+        <Heading size="sm">{headerProps.appName}</Heading>
       </Flex>
     </SignPageHeader>
   );

--- a/apps/web/src/components/SendFlow/Beacon/OriginationOperationSignPage.test.tsx
+++ b/apps/web/src/components/SendFlow/Beacon/OriginationOperationSignPage.test.tsx
@@ -6,7 +6,6 @@ import { WalletClient, useGetSecretKey } from "@umami/state";
 import { executeParams } from "@umami/test-utils";
 import { GHOSTNET, makeToolkit, prettyTezAmount } from "@umami/tezos";
 
-import { OriginationOperationSignPage } from "./OriginationOperationSignPage";
 import {
   act,
   dynamicModalContextMock,
@@ -16,6 +15,8 @@ import {
   waitFor,
 } from "../../../testUtils";
 import { SuccessStep } from "../SuccessStep";
+import { type SdkSignPageProps, type SignHeaderProps } from "../utils";
+import { SingleSignPage } from "./BeaconSignPage";
 
 const message = {
   id: "messageid",
@@ -29,6 +30,16 @@ const operation = {
   signer: mockImplicitAccount(0),
   operations: [mockContractOrigination(0)],
   estimates: [executeParams({ fee: 123 })],
+};
+const headerProps: SignHeaderProps = {
+  network: GHOSTNET,
+  appName: message.appMetadata.name,
+  appIcon: message.appMetadata.icon,
+};
+const signProps: SdkSignPageProps = {
+  headerProps: headerProps,
+  operation: operation,
+  requestId: { sdkType: "beacon", id: message.id },
 };
 
 jest.mock("@umami/core", () => ({
@@ -48,7 +59,7 @@ jest.mock("@umami/state", () => ({
 
 describe("<OriginationOperationSignPage />", () => {
   it("renders fee", async () => {
-    await renderInModal(<OriginationOperationSignPage message={message} operation={operation} />);
+    await renderInModal(<SingleSignPage {...signProps} />);
 
     await waitFor(() => expect(screen.getByText(prettyTezAmount(123))).toBeVisible());
   });
@@ -62,13 +73,15 @@ describe("<OriginationOperationSignPage />", () => {
     jest.mocked(executeOperations).mockResolvedValue({ opHash: "ophash" } as BatchWalletOperation);
     jest.spyOn(WalletClient, "respond").mockResolvedValue();
 
-    await renderInModal(<OriginationOperationSignPage message={message} operation={operation} />);
-
-    await act(() => user.type(screen.getByLabelText("Password"), "Password"));
+    await renderInModal(<SingleSignPage {...signProps} />);
 
     const signButton = screen.getByRole("button", {
       name: "Confirm Transaction",
     });
+    await waitFor(() => expect(signButton).toBeDisabled());
+
+    await act(() => user.type(screen.getByLabelText("Password"), "ThisIsAPassword"));
+
     await waitFor(() => expect(signButton).toBeEnabled());
     await act(() => user.click(signButton));
 

--- a/apps/web/src/components/SendFlow/Beacon/OriginationOperationSignPage.tsx
+++ b/apps/web/src/components/SendFlow/Beacon/OriginationOperationSignPage.tsx
@@ -17,21 +17,28 @@ import {
 } from "@chakra-ui/react";
 import { type ContractOrigination } from "@umami/core";
 import { capitalize } from "lodash";
-import { FormProvider } from "react-hook-form";
+import { FormProvider, useForm } from "react-hook-form";
 
-import { type BeaconSignPageProps } from "./BeaconSignPageProps";
-import { useSignWithBeacon } from "./useSignWithBeacon";
 import { CodeSandboxIcon } from "../../../assets/icons";
 import { useColor } from "../../../styles/useColor";
 import { AdvancedSettingsAccordion } from "../../AdvancedSettingsAccordion";
 import { JsValueWrap } from "../../JsValueWrap";
 import { SignButton } from "../SignButton";
 import { SignPageFee } from "../SignPageFee";
+import { type CalculatedSignProps, type SdkSignPageProps } from "../utils";
 
-export const OriginationOperationSignPage = ({ operation, message }: BeaconSignPageProps) => {
-  const { isSigning, onSign, network, form, fee } = useSignWithBeacon(operation, message);
+export const OriginationOperationSignPage = ({
+  operation,
+  headerProps,
+  isSigning,
+  onSign,
+  network,
+  fee,
+}: SdkSignPageProps & CalculatedSignProps) => {
   const color = useColor();
   const { code, storage } = operation.operations[0] as ContractOrigination;
+
+  const form = useForm({ defaultValues: { executeParams: operation.estimates } });
 
   return (
     <FormProvider {...form}>
@@ -46,7 +53,7 @@ export const OriginationOperationSignPage = ({ operation, message }: BeaconSignP
                 Network:
               </Heading>
               <Text color={color("700")} fontWeight="400" size="sm">
-                {capitalize(message.network.type)}
+                {capitalize(headerProps.network.name)}
               </Text>
             </Flex>
           </ModalHeader>
@@ -64,10 +71,10 @@ export const OriginationOperationSignPage = ({ operation, message }: BeaconSignP
                   borderRadius="4px"
                   objectFit="cover"
                   fallback={<CodeSandboxIcon width="36px" height="36px" />}
-                  src={message.appMetadata.icon}
+                  src={headerProps.appIcon}
                 />
               </AspectRatio>
-              <Heading size="sm">{message.appMetadata.name}</Heading>
+              <Heading size="sm">{headerProps.appName}</Heading>
             </Flex>
 
             <Flex alignItems="center" justifyContent="end" marginTop="12px">

--- a/apps/web/src/components/SendFlow/Beacon/StakeSignPage.tsx
+++ b/apps/web/src/components/SendFlow/Beacon/StakeSignPage.tsx
@@ -1,25 +1,31 @@
 import { Flex, FormLabel, ModalBody, ModalContent, ModalFooter } from "@chakra-ui/react";
 import { type Stake } from "@umami/core";
-import { FormProvider } from "react-hook-form";
+import { FormProvider, useForm } from "react-hook-form";
 
-import { type BeaconSignPageProps } from "./BeaconSignPageProps";
 import { Header } from "./Header";
-import { useSignWithBeacon } from "./useSignWithBeacon";
 import { AddressTile } from "../../AddressTile/AddressTile";
 import { TezTile } from "../../AssetTiles/TezTile";
 import { SignButton } from "../SignButton";
 import { SignPageFee } from "../SignPageFee";
+import { type CalculatedSignProps, type SdkSignPageProps } from "../utils";
 
-export const StakeSignPage = ({ operation, message }: BeaconSignPageProps) => {
+export const StakeSignPage = ({
+  operation,
+  headerProps,
+  isSigning,
+  onSign,
+  network,
+  fee,
+}: SdkSignPageProps & CalculatedSignProps) => {
   const { amount: mutezAmount } = operation.operations[0] as Stake;
 
-  const { isSigning, onSign, network, fee, form } = useSignWithBeacon(operation, message);
+  const form = useForm({ defaultValues: { executeParams: operation.estimates } });
 
   return (
     <FormProvider {...form}>
       <ModalContent>
         <form>
-          <Header message={message} />
+          <Header headerProps={headerProps} />
           <ModalBody>
             <Flex alignItems="center" justifyContent="end" marginTop="12px">
               <SignPageFee fee={fee} />

--- a/apps/web/src/components/SendFlow/Beacon/TezSignPage.test.tsx
+++ b/apps/web/src/components/SendFlow/Beacon/TezSignPage.test.tsx
@@ -3,9 +3,8 @@ import type { BatchWalletOperation } from "@taquito/taquito/dist/types/wallet/ba
 import { executeOperations, mockImplicitAccount, mockTezOperation } from "@umami/core";
 import { WalletClient, makeStore, networksActions, useGetSecretKey } from "@umami/state";
 import { executeParams } from "@umami/test-utils";
-import { GHOSTNET, MAINNET, makeToolkit } from "@umami/tezos";
+import { GHOSTNET, makeToolkit } from "@umami/tezos";
 
-import { TezSignPage } from "./TezSignPage";
 import {
   act,
   dynamicModalContextMock,
@@ -15,6 +14,8 @@ import {
   waitFor,
 } from "../../../testUtils";
 import { SuccessStep } from "../SuccessStep";
+import { type SdkSignPageProps, type SignHeaderProps } from "../utils";
+import { SingleSignPage } from "./BeaconSignPage";
 
 jest.mock("@umami/core", () => ({
   ...jest.requireActual("@umami/core"),
@@ -50,22 +51,35 @@ describe("<TezSignPage />", () => {
       operations: [mockTezOperation(0)],
       estimates: [executeParams({ fee: 123 })],
     };
-    store.dispatch(networksActions.setCurrent(MAINNET));
+    const headerProps: SignHeaderProps = {
+      network: GHOSTNET,
+      appName: message.appMetadata.name,
+      appIcon: message.appMetadata.icon,
+    };
+    const signProps: SdkSignPageProps = {
+      headerProps: headerProps,
+      operation: operation,
+      requestId: { sdkType: "beacon", id: message.id },
+    };
+
+    store.dispatch(networksActions.setCurrent(GHOSTNET));
     jest.mocked(useGetSecretKey).mockImplementation(() => () => Promise.resolve("secretKey"));
 
     jest.mocked(executeOperations).mockResolvedValue({ opHash: "ophash" } as BatchWalletOperation);
     jest.spyOn(WalletClient, "respond").mockResolvedValue();
 
-    await renderInModal(<TezSignPage message={message} operation={operation} />, store);
+    await renderInModal(<SingleSignPage {...signProps} />, store);
 
     expect(screen.getByText("Ghostnet")).toBeInTheDocument();
     expect(screen.queryByText("Mainnet")).not.toBeInTheDocument();
 
-    await act(() => user.type(screen.getByLabelText("Password"), "Password"));
-
     const signButton = screen.getByRole("button", {
       name: "Confirm Transaction",
     });
+    await waitFor(() => expect(signButton).toBeDisabled());
+
+    await act(() => user.type(screen.getByLabelText("Password"), "ThisIsAPassword"));
+
     await waitFor(() => expect(signButton).toBeEnabled());
     await act(() => user.click(signButton));
 

--- a/apps/web/src/components/SendFlow/Beacon/TezSignPage.tsx
+++ b/apps/web/src/components/SendFlow/Beacon/TezSignPage.tsx
@@ -1,26 +1,31 @@
 import { Flex, FormLabel, ModalBody, ModalContent, ModalFooter } from "@chakra-ui/react";
 import { type TezTransfer } from "@umami/core";
-import { FormProvider } from "react-hook-form";
+import { FormProvider, useForm } from "react-hook-form";
 
-import { type BeaconSignPageProps } from "./BeaconSignPageProps";
 import { Header } from "./Header";
-import { useSignWithBeacon } from "./useSignWithBeacon";
 import { AddressTile } from "../../AddressTile/AddressTile";
 import { AdvancedSettingsAccordion } from "../../AdvancedSettingsAccordion";
 import { TezTile } from "../../AssetTiles/TezTile";
 import { SignButton } from "../SignButton";
 import { SignPageFee } from "../SignPageFee";
+import { type CalculatedSignProps, type SdkSignPageProps } from "../utils";
 
-export const TezSignPage = ({ operation, message }: BeaconSignPageProps) => {
+export const TezSignPage = ({
+  operation,
+  headerProps,
+  isSigning,
+  onSign,
+  network,
+  fee,
+}: SdkSignPageProps & CalculatedSignProps) => {
   const { amount: mutezAmount, recipient } = operation.operations[0] as TezTransfer;
-
-  const { isSigning, onSign, network, fee, form } = useSignWithBeacon(operation, message);
+  const form = useForm({ defaultValues: { executeParams: operation.estimates } });
 
   return (
     <FormProvider {...form}>
-      <ModalContent>
+      <ModalContent data-testid="TezSignPage">
         <form>
-          <Header message={message} />
+          <Header headerProps={headerProps} />
           <ModalBody>
             <TezTile mutezAmount={mutezAmount} />
 

--- a/apps/web/src/components/SendFlow/Beacon/UndelegationSignPage.tsx
+++ b/apps/web/src/components/SendFlow/Beacon/UndelegationSignPage.tsx
@@ -1,22 +1,28 @@
 import { Flex, FormLabel, ModalBody, ModalContent, ModalFooter } from "@chakra-ui/react";
-import { FormProvider } from "react-hook-form";
+import { FormProvider, useForm } from "react-hook-form";
 
-import { type BeaconSignPageProps } from "./BeaconSignPageProps";
 import { Header } from "./Header";
-import { useSignWithBeacon } from "./useSignWithBeacon";
 import { AddressTile } from "../../AddressTile/AddressTile";
 import { AdvancedSettingsAccordion } from "../../AdvancedSettingsAccordion";
 import { SignButton } from "../SignButton";
 import { SignPageFee } from "../SignPageFee";
+import { type CalculatedSignProps, type SdkSignPageProps } from "../utils";
 
-export const UndelegationSignPage = ({ operation, message }: BeaconSignPageProps) => {
-  const { isSigning, onSign, network, form, fee } = useSignWithBeacon(operation, message);
+export const UndelegationSignPage = ({
+  operation,
+  headerProps,
+  isSigning,
+  onSign,
+  network,
+  fee,
+}: SdkSignPageProps & CalculatedSignProps) => {
+  const form = useForm({ defaultValues: { executeParams: operation.estimates } });
 
   return (
     <FormProvider {...form}>
       <ModalContent>
         <form>
-          <Header message={message} />
+          <Header headerProps={headerProps} />
           <ModalBody>
             <FormLabel>From</FormLabel>
             <AddressTile address={operation.signer.address} />

--- a/apps/web/src/components/SendFlow/Beacon/UnstakeSignPage.tsx
+++ b/apps/web/src/components/SendFlow/Beacon/UnstakeSignPage.tsx
@@ -1,25 +1,31 @@
 import { Flex, FormLabel, ModalBody, ModalContent, ModalFooter } from "@chakra-ui/react";
 import { type Unstake } from "@umami/core";
-import { FormProvider } from "react-hook-form";
+import { FormProvider, useForm } from "react-hook-form";
 
-import { type BeaconSignPageProps } from "./BeaconSignPageProps";
 import { Header } from "./Header";
-import { useSignWithBeacon } from "./useSignWithBeacon";
 import { AddressTile } from "../../AddressTile/AddressTile";
 import { TezTile } from "../../AssetTiles/TezTile";
 import { SignButton } from "../SignButton";
 import { SignPageFee } from "../SignPageFee";
+import { type CalculatedSignProps, type SdkSignPageProps } from "../utils";
 
-export const UnstakeSignPage = ({ operation, message }: BeaconSignPageProps) => {
+export const UnstakeSignPage = ({
+  operation,
+  headerProps,
+  isSigning,
+  onSign,
+  network,
+  fee,
+}: SdkSignPageProps & CalculatedSignProps) => {
   const { amount: mutezAmount } = operation.operations[0] as Unstake;
 
-  const { isSigning, onSign, network, fee, form } = useSignWithBeacon(operation, message);
+  const form = useForm({ defaultValues: { executeParams: operation.estimates } });
 
   return (
     <FormProvider {...form}>
       <ModalContent>
         <form>
-          <Header message={message} />
+          <Header headerProps={headerProps} />
           <ModalBody>
             <Flex alignItems="center" justifyContent="end" marginTop="12px">
               <SignPageFee fee={fee} />

--- a/apps/web/src/components/SendFlow/Beacon/useSignWithBeacon.tsx
+++ b/apps/web/src/components/SendFlow/Beacon/useSignWithBeacon.tsx
@@ -1,23 +1,20 @@
-import {
-  BeaconMessageType,
-  type OperationRequestOutput,
-  type OperationResponseInput,
-} from "@airgap/beacon-wallet";
+import { BeaconMessageType, type OperationResponseInput } from "@airgap/beacon-wallet";
 import { type TezosToolkit } from "@taquito/taquito";
 import { useDynamicModalContext } from "@umami/components";
-import { type EstimatedAccountOperations, executeOperations, totalFee } from "@umami/core";
-import { WalletClient, useAsyncActionHandler, useFindNetwork } from "@umami/state";
+import { executeOperations, totalFee } from "@umami/core";
+import { WalletClient, useAsyncActionHandler } from "@umami/state";
 import { useForm } from "react-hook-form";
 
 import { SuccessStep } from "../SuccessStep";
+import { type CalculatedSignProps, type SdkSignPageProps } from "../utils";
 
-export const useSignWithBeacon = (
-  operation: EstimatedAccountOperations,
-  message: OperationRequestOutput
-) => {
+export const useSignWithBeacon = ({
+  operation,
+  headerProps,
+  requestId,
+}: SdkSignPageProps): CalculatedSignProps => {
   const { isLoading: isSigning, handleAsyncAction } = useAsyncActionHandler();
   const { openWith } = useDynamicModalContext();
-  const findNetwork = useFindNetwork();
 
   const form = useForm({ defaultValues: { executeParams: operation.estimates } });
 
@@ -31,7 +28,7 @@ export const useSignWithBeacon = (
 
         const response: OperationResponseInput = {
           type: BeaconMessageType.OperationResponse,
-          id: message.id,
+          id: requestId.id.toString(),
           transactionHash: opHash,
         };
         await WalletClient.respond(response);
@@ -47,7 +44,6 @@ export const useSignWithBeacon = (
     fee: totalFee(form.watch("executeParams")),
     isSigning,
     onSign,
-    network: findNetwork(message.network.type),
-    form,
+    network: headerProps.network,
   };
 };

--- a/apps/web/src/components/SendFlow/utils.tsx
+++ b/apps/web/src/components/SendFlow/utils.tsx
@@ -18,7 +18,7 @@ import {
   useGetOwnedAccount,
   useSelectedNetwork,
 } from "@umami/state";
-import { type ExecuteParams, type RawPkh } from "@umami/tezos";
+import { type ExecuteParams, type Network, type RawPkh } from "@umami/tezos";
 import { repeat } from "lodash";
 import { useState } from "react";
 import { useForm, useFormContext } from "react-hook-form";
@@ -48,6 +48,38 @@ export type SignPageProps<T = undefined> = {
   operations: EstimatedAccountOperations;
   mode: SignPageMode;
   data: T;
+};
+
+export type CalculatedSignProps = {
+  fee: number;
+  isSigning: boolean;
+  onSign: (tezosToolkit: TezosToolkit) => Promise<void>;
+  network: any;
+};
+
+export type sdkType = "beacon" | "walletconnect";
+
+export type SignRequestId =
+  | {
+      sdkType: "beacon";
+      id: string;
+    }
+  | {
+      sdkType: "walletconnect";
+      id: number;
+      topic: string;
+    };
+
+export type SignHeaderProps = {
+  network: Network;
+  appName: string;
+  appIcon?: string;
+};
+
+export type SdkSignPageProps = {
+  requestId: SignRequestId;
+  operation: EstimatedAccountOperations;
+  headerProps: SignHeaderProps;
 };
 
 export const FormSubmitButton = ({ title = "Preview", ...props }: ButtonProps) => {


### PR DESCRIPTION
## Proposed changes

Preparing Umami web for handling WalletConnect requests.
The modals and tests are prepared to be used for both Beacon and WalletConnect.

There are no visible or functional changes.

## Types of changes

- [ ] Bugfix
- [ ] New feature
- [x] Refactor
- [ ] Breaking change
- [ ] UI fix

## Steps to reproduce

## Screenshots

Add the screenshots of how the app used to look like and how it looks now

| Before | Now |
| ------ | --- |
|        |     |

## Checklist

- [x] Tests that prove my fix is effective or that my feature works have been added
- [ ] Documentation has been added (if appropriate)
- [ ] Screenshots are added (if any UI changes have been made)
- [ ] All TODOs have a corresponding task created (and the link is attached to it)
