### PR TITLE
Fix custom error handling

### DIFF
--- a/apps/desktop/src/components/Onboarding/restoreBackupFile/RestoreBackupFile.test.tsx
+++ b/apps/desktop/src/components/Onboarding/restoreBackupFile/RestoreBackupFile.test.tsx
@@ -1,5 +1,6 @@
 import { mockToast, useRestoreBackup } from "@umami/state";
 import { fileUploadMock, umamiBackup } from "@umami/test-utils";
+import { CustomError } from "@umami/utils";
 
 import { RestoreBackupFile } from "./RestoreBackupFile";
 import {
@@ -41,7 +42,9 @@ describe("<RestoreBackupFile />", () => {
   it("shows error for wrong backup file format", async () => {
     jest
       .mocked(useRestoreBackup)
-      .mockImplementation(() => jest.fn(() => Promise.reject("Invalid backup file.")));
+      .mockImplementation(() =>
+        jest.fn(() => Promise.reject(new CustomError("Invalid backup file.")))
+      );
     const user = userEvent.setup();
 
     render(<RestoreBackupFile />);

--- a/apps/desktop/src/components/SendFlow/Delegation/FormPage.test.tsx
+++ b/apps/desktop/src/components/SendFlow/Delegation/FormPage.test.tsx
@@ -8,6 +8,7 @@ import {
 } from "@umami/core";
 import { type UmamiStore, addTestAccount, assetsActions, makeStore, mockToast } from "@umami/state";
 import { executeParams } from "@umami/test-utils";
+import { CustomError } from "@umami/utils";
 
 import { FormPage, type FormValues } from "./FormPage";
 import { SignPage } from "./SignPage";
@@ -158,7 +159,7 @@ describe("<Form />", () => {
       });
 
       const estimateMock = jest.mocked(estimate);
-      estimateMock.mockRejectedValue(new Error("Some error occurred"));
+      estimateMock.mockRejectedValue(new CustomError("Some error occurred"));
 
       await act(() => user.click(submitButton));
 

--- a/apps/desktop/src/components/SendFlow/Tez/FormPage.test.tsx
+++ b/apps/desktop/src/components/SendFlow/Tez/FormPage.test.tsx
@@ -8,6 +8,7 @@ import {
 } from "@umami/core";
 import { type UmamiStore, addTestAccount, makeStore, mockToast } from "@umami/state";
 import { executeParams } from "@umami/test-utils";
+import { CustomError } from "@umami/utils";
 
 import { FormPage, type FormValues } from "./FormPage";
 import { SignPage } from "./SignPage";
@@ -241,7 +242,7 @@ describe("<Form />", () => {
       const submitButton = screen.getByText("Preview");
       await waitFor(() => expect(submitButton).toBeEnabled());
       const estimateMock = jest.mocked(estimate);
-      estimateMock.mockRejectedValue(new Error("Some error occurred"));
+      estimateMock.mockRejectedValue(new CustomError("Some error occurred"));
 
       await act(() => user.click(submitButton));
 

--- a/apps/desktop/src/components/SendFlow/Undelegation/FormPage.test.tsx
+++ b/apps/desktop/src/components/SendFlow/Undelegation/FormPage.test.tsx
@@ -15,6 +15,7 @@ import {
 } from "@umami/state";
 import { executeParams } from "@umami/test-utils";
 import { mockImplicitAddress } from "@umami/tezos";
+import { CustomError } from "@umami/utils";
 
 import { FormPage, type FormValues } from "./FormPage";
 import { SignPage } from "./SignPage";
@@ -98,7 +99,7 @@ describe("<Form />", () => {
       );
 
       const estimateMock = jest.mocked(estimate);
-      estimateMock.mockRejectedValue(new Error("Some error occurred"));
+      estimateMock.mockRejectedValue(new CustomError("Some error occurred"));
 
       const submitButton = screen.getByText("Preview");
       await waitFor(() => expect(submitButton).toBeEnabled());

--- a/apps/desktop/src/utils/beacon/useHandleBeaconMessage.test.tsx
+++ b/apps/desktop/src/utils/beacon/useHandleBeaconMessage.test.tsx
@@ -12,6 +12,7 @@ import { estimate, makeAccountOperations, mockImplicitAccount } from "@umami/cor
 import { type UmamiStore, WalletClient, addTestAccount, makeStore, mockToast } from "@umami/state";
 import { executeParams } from "@umami/test-utils";
 import { mockImplicitAddress } from "@umami/tezos";
+import { CustomError } from "@umami/utils";
 
 import { useHandleBeaconMessage } from "./useHandleBeaconMessage";
 import { BatchSignPage } from "../../components/SendFlow/Beacon/BatchSignPage";
@@ -251,7 +252,7 @@ describe("<useHandleBeaconMessage />", () => {
     });
 
     it("doesn't open a modal on an error while estimating the fee", async () => {
-      jest.mocked(estimate).mockRejectedValueOnce(new Error("Something went very wrong!"));
+      jest.mocked(estimate).mockRejectedValueOnce(new CustomError("Something went very wrong!"));
 
       const message: BeaconRequestOutputMessage = {
         type: BeaconMessageType.OperationRequest,

--- a/apps/desktop/src/views/batch/BatchView.test.tsx
+++ b/apps/desktop/src/views/batch/BatchView.test.tsx
@@ -9,6 +9,7 @@ import {
 } from "@umami/core";
 import { type UmamiStore, addTestAccount, makeStore, mockToast } from "@umami/state";
 import { executeParams } from "@umami/test-utils";
+import { CustomError } from "@umami/utils";
 
 import { BatchView } from "./BatchView";
 import { act, render, screen, userEvent, within } from "../../mocks/testUtils";
@@ -85,7 +86,7 @@ describe("<BatchView />", () => {
 
     it("doesn't show up if the estimation fails with an unknown error", async () => {
       const user = userEvent.setup();
-      jest.mocked(estimate).mockRejectedValue(new Error("something went wrong"));
+      jest.mocked(estimate).mockRejectedValue(new CustomError("something went wrong"));
 
       render(<BatchView operations={operations} />, { store });
 

--- a/apps/web/src/components/SendFlow/Delegation/FormPage.test.tsx
+++ b/apps/web/src/components/SendFlow/Delegation/FormPage.test.tsx
@@ -8,6 +8,7 @@ import {
   mockToast,
 } from "@umami/state";
 import { executeParams } from "@umami/test-utils";
+import { CustomError } from "@umami/utils";
 
 import { FormPage, type FormValues } from "./FormPage";
 import { SignPage } from "./SignPage";
@@ -112,14 +113,13 @@ describe("<Form />", () => {
     });
 
     const estimateMock = jest.mocked(estimate);
-    estimateMock.mockRejectedValue(new Error("Some error occurred"));
+    estimateMock.mockRejectedValue(new CustomError("Some error occurred"));
 
     await act(() => user.click(submitButton));
 
     expect(estimateMock).toHaveBeenCalledTimes(1);
     expect(mockToast).toHaveBeenCalledWith({
-      description:
-        "Something went wrong. Please try again or contact support if the issue persists.",
+      description: "Some error occurred",
       status: "error",
       isClosable: true,
     });

--- a/apps/web/src/components/SendFlow/Tez/FormPage.test.tsx
+++ b/apps/web/src/components/SendFlow/Tez/FormPage.test.tsx
@@ -7,6 +7,7 @@ import {
 } from "@umami/core";
 import { type UmamiStore, addTestAccount, makeStore, mockToast } from "@umami/state";
 import { executeParams } from "@umami/test-utils";
+import { CustomError } from "@umami/utils";
 
 import { FormPage } from "./FormPage";
 import { SignPage } from "./SignPage";
@@ -167,19 +168,13 @@ describe("<Form />", () => {
       const submitButton = screen.getByText("Preview");
       await waitFor(() => expect(submitButton).toBeEnabled());
       const estimateMock = jest.mocked(estimate);
-      expect(mockToast).toHaveBeenCalledWith({
-        description:
-          "Something went wrong. Please try again or contact support if the issue persists.",
-        status: "error",
-        isClosable: true,
-      });
+      estimateMock.mockRejectedValue(new CustomError("Some error occurred"));
 
       await act(() => user.click(submitButton));
 
       expect(estimateMock).toHaveBeenCalledTimes(1);
       expect(mockToast).toHaveBeenCalledWith({
-        description:
-          "Something went wrong. Please try again or contact support if the issue persists.",
+        description: "Some error occurred",
         status: "error",
         isClosable: true,
       });

--- a/apps/web/src/components/SendFlow/Tez/FormPage.test.tsx
+++ b/apps/web/src/components/SendFlow/Tez/FormPage.test.tsx
@@ -167,7 +167,12 @@ describe("<Form />", () => {
       const submitButton = screen.getByText("Preview");
       await waitFor(() => expect(submitButton).toBeEnabled());
       const estimateMock = jest.mocked(estimate);
-      estimateMock.mockRejectedValue(new Error("Some error occurred"));
+      expect(mockToast).toHaveBeenCalledWith({
+        description:
+          "Something went wrong. Please try again or contact support if the issue persists.",
+        status: "error",
+        isClosable: true,
+      });
 
       await act(() => user.click(submitButton));
 

--- a/apps/web/src/components/SendFlow/Undelegation/FormPage.test.tsx
+++ b/apps/web/src/components/SendFlow/Undelegation/FormPage.test.tsx
@@ -93,7 +93,12 @@ describe("<Form />", () => {
       );
 
       const estimateMock = jest.mocked(estimate);
-      estimateMock.mockRejectedValue(new Error("Some error occurred"));
+      expect(mockToast).toHaveBeenCalledWith({
+        description:
+          "Something went wrong. Please try again or contact support if the issue persists.",
+        status: "error",
+        isClosable: true,
+      });
 
       const submitButton = screen.getByText("Preview");
       await waitFor(() => expect(submitButton).toBeEnabled());
@@ -101,7 +106,8 @@ describe("<Form />", () => {
 
       expect(estimateMock).toHaveBeenCalledTimes(1);
       expect(mockToast).toHaveBeenCalledWith({
-        description: "Some error occurred",
+        description:
+          "Something went wrong. Please try again or contact support if the issue persists.",
         status: "error",
         isClosable: true,
       });

--- a/apps/web/src/components/SendFlow/Undelegation/FormPage.test.tsx
+++ b/apps/web/src/components/SendFlow/Undelegation/FormPage.test.tsx
@@ -14,6 +14,7 @@ import {
 } from "@umami/state";
 import { executeParams } from "@umami/test-utils";
 import { mockImplicitAddress } from "@umami/tezos";
+import { CustomError } from "@umami/utils";
 
 import { FormPage, type FormValues } from "./FormPage";
 import { SignPage } from "./SignPage";
@@ -93,12 +94,7 @@ describe("<Form />", () => {
       );
 
       const estimateMock = jest.mocked(estimate);
-      expect(mockToast).toHaveBeenCalledWith({
-        description:
-          "Something went wrong. Please try again or contact support if the issue persists.",
-        status: "error",
-        isClosable: true,
-      });
+      estimateMock.mockRejectedValue(new CustomError("Some error occurred"));
 
       const submitButton = screen.getByText("Preview");
       await waitFor(() => expect(submitButton).toBeEnabled());
@@ -106,8 +102,7 @@ describe("<Form />", () => {
 
       expect(estimateMock).toHaveBeenCalledTimes(1);
       expect(mockToast).toHaveBeenCalledWith({
-        description:
-          "Something went wrong. Please try again or contact support if the issue persists.",
+        description: "Some error occurred",
         status: "error",
         isClosable: true,
       });

--- a/apps/web/src/components/beacon/useHandleBeaconMessage.test.tsx
+++ b/apps/web/src/components/beacon/useHandleBeaconMessage.test.tsx
@@ -12,6 +12,7 @@ import { estimate, makeAccountOperations, mockImplicitAccount } from "@umami/cor
 import { type UmamiStore, WalletClient, addTestAccount, makeStore, mockToast } from "@umami/state";
 import { executeParams } from "@umami/test-utils";
 import { mockImplicitAddress } from "@umami/tezos";
+import { CustomError } from "@umami/utils";
 
 import { useHandleBeaconMessage } from "./useHandleBeaconMessage";
 import { BatchSignPage } from "../../components/SendFlow/Beacon/BatchSignPage";
@@ -251,7 +252,7 @@ describe("<useHandleBeaconMessage />", () => {
     });
 
     it("doesn't open a modal on an error while estimating the fee", async () => {
-      jest.mocked(estimate).mockRejectedValueOnce(new Error("Something went very wrong!"));
+      jest.mocked(estimate).mockRejectedValueOnce(new CustomError("Something went very wrong!"));
 
       const message: BeaconRequestOutputMessage = {
         type: BeaconMessageType.OperationRequest,

--- a/packages/tezos/src/helpers.ts
+++ b/packages/tezos/src/helpers.ts
@@ -130,6 +130,6 @@ export const decryptSecretKey = async (secretKey: string, password: string) => {
       throw new CustomError("Invalid secret key: checksum doesn't match");
     }
 
-    throw error;
+    throw new CustomError(error.message);
   }
 };


### PR DESCRIPTION
## Proposed changes

Fixing this test which fails on `main`
```
  ● <Form /> › single transaction › shows a toast if estimation fails

    expect(jest.fn()).toHaveBeenCalledWith(...expected)

    - Expected
    + Received

      Object {
    -   "description": "Some error occurred",
    +   "description": "Something went wrong. Please try again or contact support if the issue persists.",
        "isClosable": true,
        "status": "error",
      },

    Number of calls: 1

      101 |
      102 |       expect(estimateMock).toHaveBeenCalledTimes(1);
    > 103 |       expect(mockToast).toHaveBeenCalledWith({
          |                         ^
      104 |         description: "Some error occurred",
      105 |         status: "error",
      106 |         isClosable: true,
```

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] UI fix

## Steps to reproduce

## Screenshots
