### PR TITLE
Add import/no-useless-path-segments rule to eslint-config

### DIFF
--- a/apps/web/src/components/SendFlow/Beacon/BatchSignPage.tsx
+++ b/apps/web/src/components/SendFlow/Beacon/BatchSignPage.tsx
@@ -16,10 +16,10 @@ import {
 import { FormProvider, useForm } from "react-hook-form";
 
 import { Header } from "./Header";
+import { useSignWithBeacon } from "./useSignWithBeacon";
 import { useColor } from "../../../styles/useColor";
 import { AddressTile } from "../../AddressTile/AddressTile";
 import { JsValueWrap } from "../../JsValueWrap";
-import { useSignWithBeacon } from "../Beacon/useSignWithBeacon";
 import { SignButton } from "../SignButton";
 import { SignPageFee } from "../SignPageFee";
 import { type SdkSignPageProps } from "../utils";

--- a/apps/web/src/components/SendFlow/Beacon/BeaconSignPage.tsx
+++ b/apps/web/src/components/SendFlow/Beacon/BeaconSignPage.tsx
@@ -9,7 +9,7 @@ import { StakeSignPage } from "./StakeSignPage";
 import { TezSignPage } from "./TezSignPage";
 import { UndelegationSignPage } from "./UndelegationSignPage";
 import { UnstakeSignPage } from "./UnstakeSignPage";
-import { useSignWithBeacon } from "../Beacon/useSignWithBeacon";
+import { useSignWithBeacon } from "./useSignWithBeacon";
 
 export const SingleSignPage = (signProps: SdkSignPageProps) => {
   const operationType = signProps.operation.operations[0].type;

--- a/apps/web/src/components/beacon/BeaconPeers.tsx
+++ b/apps/web/src/components/beacon/BeaconPeers.tsx
@@ -5,8 +5,8 @@ import { parsePkh } from "@umami/tezos";
 import capitalize from "lodash/capitalize";
 
 import { CodeSandboxIcon, StubIcon as TrashIcon } from "../../assets/icons";
-import { AddressPill } from "../../components/AddressPill/AddressPill";
 import { useColor } from "../../styles/useColor";
+import { AddressPill } from "../AddressPill/AddressPill";
 import { EmptyMessage } from "../EmptyMessage";
 
 /**

--- a/apps/web/src/components/beacon/PermissionRequestModal.tsx
+++ b/apps/web/src/components/beacon/PermissionRequestModal.tsx
@@ -34,8 +34,8 @@ import { capitalize } from "lodash";
 import { FormProvider, useForm } from "react-hook-form";
 
 import { CodeSandboxIcon } from "../../assets/icons";
-import { OwnedImplicitAccountsAutocomplete } from "../../components/AddressAutocomplete";
 import { useColor } from "../../styles/useColor";
+import { OwnedImplicitAccountsAutocomplete } from "../AddressAutocomplete";
 import { ModalCloseButton } from "../CloseButton";
 import { JsValueWrap } from "../JsValueWrap";
 

--- a/apps/web/src/components/beacon/SignPayloadRequestModal.tsx
+++ b/apps/web/src/components/beacon/SignPayloadRequestModal.tsx
@@ -24,8 +24,8 @@ import { WalletClient, useGetImplicitAccount } from "@umami/state";
 import { useState } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 
-import { SignButton } from "../../components/SendFlow/SignButton";
 import { useColor } from "../../styles/useColor";
+import { SignButton } from "../SendFlow/SignButton";
 
 export const SignPayloadRequestModal = ({ request }: { request: SignPayloadRequestOutput }) => {
   const { onClose } = useDynamicModalContext();

--- a/apps/web/src/components/beacon/useHandleBeaconMessage.test.tsx
+++ b/apps/web/src/components/beacon/useHandleBeaconMessage.test.tsx
@@ -20,9 +20,9 @@ import { MAINNET, mockImplicitAddress } from "@umami/tezos";
 import { CustomError } from "@umami/utils";
 
 import { useHandleBeaconMessage } from "./useHandleBeaconMessage";
-import { BatchSignPage } from "../../components/SendFlow/Beacon/BatchSignPage";
-import { SingleSignPage } from "../../components/SendFlow/Beacon/BeaconSignPage";
 import { act, dynamicModalContextMock, renderHook, screen, waitFor } from "../../testUtils";
+import { BatchSignPage } from "../SendFlow/Beacon/BatchSignPage";
+import { SingleSignPage } from "../SendFlow/Beacon/BeaconSignPage";
 import { type SdkSignPageProps, type SignHeaderProps } from "../SendFlow/utils";
 
 jest.mock("@umami/core", () => ({

--- a/apps/web/src/components/beacon/useHandleBeaconMessage.tsx
+++ b/apps/web/src/components/beacon/useHandleBeaconMessage.tsx
@@ -18,8 +18,8 @@ import { CustomError } from "@umami/utils";
 
 import { PermissionRequestModal } from "./PermissionRequestModal";
 import { SignPayloadRequestModal } from "./SignPayloadRequestModal";
-import { BatchSignPage } from "../../components/SendFlow/Beacon/BatchSignPage";
-import { SingleSignPage } from "../../components/SendFlow/Beacon/BeaconSignPage";
+import { BatchSignPage } from "../SendFlow/Beacon/BatchSignPage";
+import { SingleSignPage } from "../SendFlow/Beacon/BeaconSignPage";
 import { type SdkSignPageProps, type SignHeaderProps } from "../SendFlow/utils";
 
 /**

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -78,6 +78,7 @@ module.exports = {
     "import/no-cycle": "warn",
     "import/no-self-import": "warn",
     "import/no-duplicates": ["warn", { "prefer-inline": true }],
+    "import/no-useless-path-segments": ["warn", { noUselessIndex: true, commonjs: true }],
     "import/order": [
       "warn",
       {


### PR DESCRIPTION
## Proposed changes


This rule prevents unnecessary path segments in import and require statements.

This rule is automatically fixable by the `--fix CLI option`.

## Types of changes

- [ ] Bugfix
- [ ] New feature
- [x] Refactor
- [ ] Breaking change
- [ ] UI fix

## Steps to reproduce

## Screenshots

Add the screenshots of how the app used to look like and how it looks now

| Before | Now |
| ------ | --- |
|        |     |

## Checklist

- [ ] Tests that prove my fix is effective or that my feature works have been added
- [ ] Documentation has been added (if appropriate)
- [ ] Screenshots are added (if any UI changes have been made)
- [ ] All TODOs have a corresponding task created (and the link is attached to it)
