### PR TITLE
fix: WalletConnect: operationHash and hash for tezos_send

### DIFF
--- a/apps/web/src/components/SendFlow/WalletConnect/useSignWithWalletConnect.tsx
+++ b/apps/web/src/components/SendFlow/WalletConnect/useSignWithWalletConnect.tsx
@@ -35,7 +35,7 @@ export const useSignWithWalletConnect = ({
           tezosToolkit
         );
 
-        const response = formatJsonRpcResult(requestId.id, { hash: opHash });
+        const response = formatJsonRpcResult(requestId.id, { hash: opHash, operationHash: opHash });
         await walletKit.respondSessionRequest({ topic: requestId.topic, response });
         return openWith(<SuccessStep hash={opHash} />);
       },


### PR DESCRIPTION
## Proposed changes

Adding a backwards compatible change to result for `tezos_send` operation to become compatible with TrustWallet and WalletConnect spec at the same time.

The result of `tezos_send` operation in WalletConnect should look like this according to the spec:
https://docs.reown.com/advanced/multichain/rpc-reference/tezos-rpc
```
"result":  {
        "operationHash": "op..."
    }
```
But the actual implementation in 3 places returns this:
```
"result":  {
        "hash": "op..."
    }
```
A `hash` field is returned instead of the `operationHash`.
The implementation returns hash in
 * TrustWallet
 * Reown's wallet example,, [code](https://github.com/reown-com/web-examples/blob/main/advanced/wallets/react-wallet-v2/src/utils/TezosRequestHandlerUtil.ts#L30)
However, Taquito test dapp follows the spec: https://taquito-test-dapp.pages.dev/

A backward compatible change is implemented to return both fields:
```
"result":  {
        "hash": "op..."
        "operationHash": "op..."
    }
```
Later, TrustWallet will be able to make a smooth switch to become compatible with the spec.

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] UI fix

## Steps to reproduce

With Taquito test dapp:
1. go to https://taquito-test-dapp.pages.dev/
2. connect to umami via WalletConnect
3. send test
 - before the change: the test will fail as hash is not found in the response
 - after the change: the test will pass

With TezosProvider dapp:
1. install Reown example TezosProvider dapp: [PR#697](https://github.com/WalletConnect/web-examples/pull/697)
2. connect to umami via WalletConnect
3. send test
 - before the change: dapp will receive "hash" field
 - after the change: the test will receive both fields. Example:
 
## Screenshots

<img width="683" alt="image" src="https://github.com/user-attachments/assets/54940319-c940-4e38-9972-08ab33a34b2f" />

## Checklist

- [ ] Tests that prove my fix is effective or that my feature works have been added
- [ ] Documentation has been added (if appropriate)
- [x] Screenshots are added (if any UI changes have been made)
- [ ] All TODOs have a corresponding task created (and the link is attached to it)
