### PR TITLE
feat: dependabot to run monthly on weekends

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,9 @@ updates:
     directory: "/"
     open-pull-requests-limit: 20
     schedule:
-      interval: "daily"
+      interval: "monthly"
+      day: "saturday"   # Runs the update on the first Saturday of the month
+      time: "08:00"     # at 08:00 UTC
     groups:
       taquito:
         patterns:


### PR DESCRIPTION
## Proposed changes

Depndabot spends too many resources.
Will run it monthly on weekends. 

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] UI fix

## Steps to reproduce

## Screenshots


## Checklist

- [ ] Tests that prove my fix is effective or that my feature works have been added
- [ ] Documentation has been added (if appropriate)
- [ ] Screenshots are added (if any UI changes have been made)
- [ ] All TODOs have a corresponding task created (and the link is attached to it)
