### PR TITLE
fix: Error: No matching request found (on Beacon sign)

### DIFF
--- a/apps/desktop/src/utils/beacon/SignPayloadRequestModal.tsx
+++ b/apps/desktop/src/utils/beacon/SignPayloadRequestModal.tsx
@@ -28,7 +28,7 @@ import { SignButton } from "../../components/SendFlow/SignButton";
 import colors from "../../style/colors";
 
 export const SignPayloadRequestModal = ({ request }: { request: SignPayloadRequestOutput }) => {
-  const { onClose } = useDynamicModalContext();
+  const { goBack } = useDynamicModalContext();
   const getAccount = useGetImplicitAccount();
   const signerAccount = getAccount(request.sourceAddress);
   const toast = useToast();
@@ -56,7 +56,7 @@ export const SignPayloadRequestModal = ({ request }: { request: SignPayloadReque
       description: "Successfully submitted Beacon operation",
       status: "success",
     });
-    onClose();
+    goBack();
   };
 
   return (

--- a/apps/web/src/components/beacon/SignPayloadRequestModal.tsx
+++ b/apps/web/src/components/beacon/SignPayloadRequestModal.tsx
@@ -28,7 +28,7 @@ import { useColor } from "../../styles/useColor";
 import { SignButton } from "../SendFlow/SignButton";
 
 export const SignPayloadRequestModal = ({ request }: { request: SignPayloadRequestOutput }) => {
-  const { onClose } = useDynamicModalContext();
+  const { goBack } = useDynamicModalContext();
   const getAccount = useGetImplicitAccount();
   const signerAccount = getAccount(request.sourceAddress);
   const toast = useToast();
@@ -57,7 +57,7 @@ export const SignPayloadRequestModal = ({ request }: { request: SignPayloadReque
       description: "Successfully submitted Beacon operation",
       status: "success",
     });
-    onClose();
+    goBack();
   };
 
   return (


### PR DESCRIPTION
## Proposed changes

Fixed error on successful sign request:

`Uncaught (in promise) Error: No matching request found!`

The problem is that on successful sign, `SignPayloadRequestModal` calls `onClose()` which is intended to handle the situation when a user closes the modal window effectively rejecting the request. Since the sign is already approved, an attempt to reject the request results in this error. The logic is the same in web and desktop:

* web: https://github.com/trilitech/umami-v2/blob/main/apps/web/src/components/beacon/useHandleBeaconMessage.tsx#L91
* desktop: https://github.com/trilitech/umami-v2/blob/main/apps/desktop/src/utils/beacon/useHandleBeaconMessage.tsx#L90

The error is not shown after the change.

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] UI fix

## Steps to reproduce

1. connect wallet with https://taquito-test-dapp.pages.dev/
2. sign payload
3. check the log for the error `Error: No matching request found!`

## Screenshots

Add the screenshots of how the app used to look like and how it looks now

Before:
<img width="426" alt="image" src="https://github.com/user-attachments/assets/f48bf9c2-4099-4cc2-a518-ecec8cf5d2d6" />


## Checklist

- [ ] Tests that prove my fix is effective or that my feature works have been added
- [ ] Documentation has been added (if appropriate)
- [x] Screenshots are added (if any UI changes have been made)
- [ ] All TODOs have a corresponding task created (and the link is attached to it)
