### PR TITLE
fix: beacon was deleting peer on sign close

### DIFF
--- a/apps/web/src/components/beacon/useHandleBeaconMessage.tsx
+++ b/apps/web/src/components/beacon/useHandleBeaconMessage.tsx
@@ -90,7 +90,6 @@ export const useHandleBeaconMessage = () => {
                 type: BeaconMessageType.Error,
                 errorType: BeaconErrorType.ABORTED_ERROR,
               });
-              await removePeer(message.senderId);
             };
             break;
           }


### PR DESCRIPTION
## Proposed changes

If a Beacon user closes the modal with Sign Payload request, the conenction is closed and the peer is removed.
This shouldn't happen. It was just a single operation reject.

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] UI fix

## Steps to reproduce

1. connect umami via Beacon from https://taquito-test-dapp.pages.dev/
2. request to sign payload
3. close the modal
4. check the list of peers

## Screenshots

## Checklist

- [ ] Tests that prove my fix is effective or that my feature works have been added
- [ ] Documentation has been added (if appropriate)
- [ ] Screenshots are added (if any UI changes have been made)
- [ ] All TODOs have a corresponding task created (and the link is attached to it)
