### PR TITLE
feat: detect payload signing type for WalletConnect

### DIFF
--- a/apps/web/src/components/WalletConnect/useHandleWcRequest.tsx
+++ b/apps/web/src/components/WalletConnect/useHandleWcRequest.tsx
@@ -1,7 +1,12 @@
-import { SigningType } from "@airgap/beacon-wallet";
+import { type SigningType } from "@airgap/beacon-wallet";
 import { useToast } from "@chakra-ui/react";
 import { useDynamicModalContext } from "@umami/components";
-import { type ImplicitAccount, estimate, toAccountOperations } from "@umami/core";
+import {
+  type ImplicitAccount,
+  estimate,
+  getSigningTypeFromPayload,
+  toAccountOperations,
+} from "@umami/core";
 import {
   useAsyncActionHandler,
   useFindNetwork,
@@ -95,14 +100,16 @@ export const useHandleWcRequest = () => {
               session
             );
           }
+
+          const signingType: SigningType = getSigningTypeFromPayload(request.params.payload);
           const signPayloadProps: SignPayloadProps = {
             appName: session.peer.metadata.name,
             appIcon: session.peer.metadata.icons[0],
             payload: request.params.payload,
             isScam: event.verifyContext.verified.isScam,
             validationStatus: event.verifyContext.verified.validation,
-            signer: signer,
-            signingType: SigningType.RAW,
+            signer,
+            signingType,
             requestId: { sdkType: "walletconnect", id: id, topic },
           };
 

--- a/packages/core/src/decodeBeaconPayload.test.ts
+++ b/packages/core/src/decodeBeaconPayload.test.ts
@@ -1,12 +1,15 @@
 import { SigningType } from "@airgap/beacon-wallet";
 
-import { decodeBeaconPayload } from "./decodeBeaconPayload";
+import { decodeBeaconPayload, getSigningTypeFromPayload } from "./decodeBeaconPayload";
 
 describe("decodeBeaconPayload", () => {
+  const emptyPayload = "";
+
   it("returns an error message if the payload is not a valid utf8", () => {
     const payload =
       "05010000004354657a6f73205369676e6564204d6573736167653a20496e76616c696420555446383a20c380c2afc3bfc3bec3bd3b204e6f6e7072696e7461626c653a20000115073b";
 
+    expect(getSigningTypeFromPayload(payload)).toEqual(SigningType.MICHELINE);
     expect(decodeBeaconPayload(payload, SigningType.MICHELINE)).toEqual({
       result: payload,
       error: "Cannot parse Beacon payload",
@@ -18,6 +21,7 @@ describe("decodeBeaconPayload", () => {
       "05010000004254657a6f73205369676e6564204d6573736167653a206d79646170702e636f6d20323032312d30312d31345431353a31363a30345a2048656c6c6f20776f726c6421";
     const expected = "Tezos Signed Message: mydapp.com 2021-01-14T15:16:04Z Hello world!";
 
+    expect(getSigningTypeFromPayload(payload)).toEqual(SigningType.MICHELINE);
     expect(decodeBeaconPayload(payload, SigningType.MICHELINE)).toEqual({ result: expected });
   });
 
@@ -41,6 +45,7 @@ describe("decodeBeaconPayload", () => {
     const expected = {
       result: "Tezos Signed Message: mydapp.com 2021-01-14T15:16:04Z Hello world!",
     };
+    expect(getSigningTypeFromPayload(payload)).toEqual(SigningType.RAW);
     expect(decodeBeaconPayload(payload, SigningType.RAW)).toEqual(expected);
   });
 
@@ -63,6 +68,7 @@ describe("decodeBeaconPayload", () => {
       ],
     });
 
+    expect(getSigningTypeFromPayload(raw)).toEqual(SigningType.RAW);
     expect(decodeBeaconPayload(raw, SigningType.RAW)).toEqual({ result });
   });
 
@@ -82,17 +88,25 @@ describe("decodeBeaconPayload", () => {
   });
 
   it("handles an empty payload", () => {
-    const emptyPayload = "";
+    expect(getSigningTypeFromPayload(emptyPayload)).toEqual(SigningType.RAW);
     expect(decodeBeaconPayload(emptyPayload, SigningType.RAW)).toEqual({
-      result: "",
+      result: emptyPayload,
     });
   });
 
   it("handles a payload with non-hex characters", () => {
-    const nonHexPayload = "0501ZZZZ";
-    expect(decodeBeaconPayload(nonHexPayload, SigningType.RAW)).toEqual({
+    const nonHexPayload = "0301ZZZZ";
+    expect(getSigningTypeFromPayload(nonHexPayload)).toEqual(SigningType.OPERATION);
+    expect(decodeBeaconPayload(nonHexPayload, SigningType.OPERATION)).toEqual({
       error: "Cannot parse Beacon payload",
-      result: "0501ZZZZ",
+      result: nonHexPayload,
+    });
+  });
+
+  it("handles OPERATION payload", () => {
+    expect(getSigningTypeFromPayload(emptyPayload)).toEqual(SigningType.RAW);
+    expect(decodeBeaconPayload(emptyPayload, SigningType.RAW)).toEqual({
+      result: emptyPayload,
     });
   });
 });

--- a/packages/core/src/decodeBeaconPayload.ts
+++ b/packages/core/src/decodeBeaconPayload.ts
@@ -1,7 +1,7 @@
 import { SigningType } from "@airgap/beacon-wallet";
 import { CODEC, type ProtocolsHash, Uint8ArrayConsumer, getCodec } from "@taquito/local-forging";
-import { DefaultProtocol, unpackData } from "@taquito/michel-codec";
-import { hex2buf } from "@taquito/utils";
+import { DefaultProtocol, type MichelsonData, unpackData } from "@taquito/michel-codec";
+import { bytesToString, hex2buf } from "@taquito/utils";
 
 import { CustomError } from "../../utils/src/ErrorContext";
 
@@ -25,14 +25,27 @@ export const decodeBeaconPayload = (
     switch (signingType) {
       case SigningType.MICHELINE:
       case SigningType.OPERATION: {
-        const consumer = Uint8ArrayConsumer.fromHexString(payload);
-        const uint8array = consumer.consume(consumer.length());
-        const parsed = unpackData(uint8array);
+        if (getSigningTypeFromPayload(payload) !== signingType) {
+          throw new CustomError("Invalid prefix for signing type");
+        }
 
-        if ("string" in parsed && Object.keys(parsed).length === 1) {
-          result = parsed.string;
-        } else {
-          result = JSON.stringify(parsed);
+        try {
+          const consumer = Uint8ArrayConsumer.fromHexString(payload);
+          const uint8array = consumer.consume(consumer.length());
+          const parsed: MichelsonData = unpackData(uint8array);
+          if ("string" in parsed && Object.keys(parsed).length === 1) {
+            result = parsed.string;
+          } else {
+            result = JSON.stringify(parsed);
+          }
+        } catch {
+          // "03" for operation
+          // "05" + "01" + 8-padded-length for micheline
+          const prefixLen = signingType === SigningType.MICHELINE ? 12 : 2;
+          result = bytesToString(payload.slice(prefixLen));
+          if (result.length === 0) {
+            throw new CustomError("Invalid payload. Failed to decode.");
+          }
         }
         break;
       }
@@ -54,7 +67,8 @@ export const decodeBeaconPayload = (
     }
 
     return { result };
-  } catch {
+  } catch (error) {
+    console.error(error);
     return { result: payload, error: "Cannot parse Beacon payload" };
   }
 };
@@ -63,3 +77,10 @@ const isValidASCII = (str: string) => str.split("").every(char => char.charCodeA
 
 const parseOperationMicheline = (payload: string) =>
   getCodec(CODEC.MANAGER, DefaultProtocol as string as ProtocolsHash).decoder(payload);
+
+export const getSigningTypeFromPayload = (payload: string): SigningType =>
+  payload.startsWith("05")
+    ? SigningType.MICHELINE
+    : payload.startsWith("03")
+      ? SigningType.OPERATION
+      : SigningType.RAW;


### PR DESCRIPTION
## Proposed changes

Improved payload representation if the `unpackData` fails

## Types of changes

- [ ] Bugfix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] UI fix

## Steps to reproduce

## Screenshots

Add the screenshots of how the app used to look like and how it looks now

Before:

Taquito:
<img width="456" alt="image" src="https://github.com/user-attachments/assets/12c58e2a-b6e0-49bb-bdcd-3a0cdec83fb1" />


Now:

Test dApp with Tezos Provider
<img width="450" alt="image" src="https://github.com/user-attachments/assets/2f8036a3-b6bd-4a10-adad-7f36a4792b40" />

Taquito test dApp
<img width="459" alt="image" src="https://github.com/user-attachments/assets/13a2c7e5-62e1-427b-9614-91eb35d5570f" />

fxhash
<img width="460" alt="image" src="https://github.com/user-attachments/assets/34c8baba-bc1f-4ff4-ae93-5240eebec319" />

objkt
<img width="453" alt="image" src="https://github.com/user-attachments/assets/1c0fe387-ca16-4856-8ba8-4eea782e65ee" />



## Checklist

- [x] Tests that prove my fix is effective or that my feature works have been added
- [ ] Documentation has been added (if appropriate)
- [x] Screenshots are added (if any UI changes have been made)
- [ ] All TODOs have a corresponding task created (and the link is attached to it)
