### PR TITLE
Fix key extraction during migration

### DIFF
--- a/apps/desktop/public/electron.js
+++ b/apps/desktop/public/electron.js
@@ -116,6 +116,11 @@ async function createBackupFromPrevDB() {
     ];
 
     const extractKeys = json => {
+      // if json is not a string, it's already a valid object
+      if (typeof json !== "string") {
+        return json;
+      }
+
       const regexp = /"([^"]+)":("[^"\\]*(?:\\.[^"\\]*)*"|{[^}]+})/g;
 
       const result = {};


### PR DESCRIPTION
This PR handles the case where the data to be extracted is already a valid object, so there is no need to process it again.