### PR TITLE
fix: Beacon responds to dApp in case of error

### DIFF
--- a/apps/web/src/components/SendFlow/Beacon/useSignWithBeacon.tsx
+++ b/apps/web/src/components/SendFlow/Beacon/useSignWithBeacon.tsx
@@ -1,8 +1,13 @@
-import { BeaconMessageType, type OperationResponseInput } from "@airgap/beacon-wallet";
+import {
+  BeaconErrorType,
+  BeaconMessageType,
+  type OperationResponseInput,
+} from "@airgap/beacon-wallet";
 import { type TezosToolkit } from "@taquito/taquito";
 import { useDynamicModalContext } from "@umami/components";
 import { executeOperations, totalFee } from "@umami/core";
 import { WalletClient, useAsyncActionHandler } from "@umami/state";
+import { getErrorContext } from "@umami/utils";
 import { useForm } from "react-hook-form";
 
 import { SuccessStep } from "../SuccessStep";
@@ -34,9 +39,15 @@ export const useSignWithBeacon = ({
 
         return openWith(<SuccessStep hash={opHash} />);
       },
-      (error: { message: any }) => ({
-        description: `Failed to confirm Beacon operation: ${error.message}`,
-      })
+      (error: any) => {
+        const context = getErrorContext(error);
+        void WalletClient.respond({
+          id: headerProps.requestId.id.toString(),
+          type: BeaconMessageType.Error,
+          errorType: BeaconErrorType.UNKNOWN_ERROR,
+        });
+        return { description: `Failed to confirm Beacon operation: ${context.description}` };
+      }
     );
 
   return {

--- a/apps/web/src/components/beacon/useHandleBeaconMessage.test.tsx
+++ b/apps/web/src/components/beacon/useHandleBeaconMessage.test.tsx
@@ -91,6 +91,7 @@ describe("<useHandleBeaconMessage />", () => {
         id: "mockMessageId",
         type: "error",
       });
+      expect(WalletClient.respond).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -143,12 +144,14 @@ describe("<useHandleBeaconMessage />", () => {
         id: "mockMessageId",
         type: "error",
       });
+      expect(WalletClient.respond).toHaveBeenCalledTimes(1);
     });
   });
 
   it("displays an error on an unknown Beacon request", async () => {
     const message = {
       type: BeaconMessageType.BlockchainRequest,
+      id: "mockMessageId",
     } as unknown as BeaconRequestOutputMessage;
 
     const {
@@ -165,6 +168,12 @@ describe("<useHandleBeaconMessage />", () => {
         isClosable: true,
       })
     );
+    expect(WalletClient.respond).toHaveBeenCalledWith({
+      errorType: "UNKNOWN_ERROR",
+      id: "mockMessageId",
+      type: "error",
+    });
+    expect(WalletClient.respond).toHaveBeenCalledTimes(1);
     expect(dynamicModalContextMock.openWith).not.toHaveBeenCalled();
   });
 
@@ -173,6 +182,7 @@ describe("<useHandleBeaconMessage />", () => {
       const message = {
         type: BeaconMessageType.OperationRequest,
         operationDetails: [],
+        id: "mockMessageId",
         sourceAddress: account.address.pkh,
         network: { type: NetworkType.MAINNET },
       } as unknown as BeaconRequestOutputMessage;
@@ -190,6 +200,12 @@ describe("<useHandleBeaconMessage />", () => {
           isClosable: true,
         })
       );
+      expect(WalletClient.respond).toHaveBeenCalledWith({
+        errorType: "UNKNOWN_ERROR",
+        id: "mockMessageId",
+        type: "error",
+      });
+      expect(WalletClient.respond).toHaveBeenCalledTimes(1);
       expect(dynamicModalContextMock.openWith).not.toHaveBeenCalled();
     });
 
@@ -197,6 +213,7 @@ describe("<useHandleBeaconMessage />", () => {
       const message = {
         type: BeaconMessageType.OperationRequest,
         operationDetails: [{ kind: TezosOperationType.ACTIVATE_ACCOUNT }],
+        id: "mockMessageId",
         sourceAddress: account.address.pkh,
         network: { type: NetworkType.MAINNET },
       } as unknown as BeaconRequestOutputMessage;
@@ -215,6 +232,12 @@ describe("<useHandleBeaconMessage />", () => {
           isClosable: true,
         })
       );
+      expect(WalletClient.respond).toHaveBeenCalledWith({
+        errorType: "UNKNOWN_ERROR",
+        id: "mockMessageId",
+        type: "error",
+      });
+      expect(WalletClient.respond).toHaveBeenCalledTimes(1);
       expect(dynamicModalContextMock.openWith).not.toHaveBeenCalled();
     });
 
@@ -254,6 +277,7 @@ describe("<useHandleBeaconMessage />", () => {
         id: "mockMessageId",
         type: "error",
       });
+      expect(WalletClient.respond).toHaveBeenCalledTimes(1);
       expect(dynamicModalContextMock.openWith).not.toHaveBeenCalled();
     });
 
@@ -317,12 +341,12 @@ describe("<useHandleBeaconMessage />", () => {
           isClosable: true,
         });
       });
-
       expect(WalletClient.respond).toHaveBeenCalledWith({
         errorType: "NETWORK_NOT_SUPPORTED",
         id: "mockMessageId",
         type: "error",
       });
+      expect(WalletClient.respond).toHaveBeenCalledTimes(1);
       expect(dynamicModalContextMock.openWith).not.toHaveBeenCalled();
     });
 
@@ -421,6 +445,7 @@ describe("<useHandleBeaconMessage />", () => {
           id: "mockMessageId",
           type: "error",
         });
+        expect(WalletClient.respond).toHaveBeenCalledTimes(1);
       });
     });
 
@@ -527,6 +552,7 @@ describe("<useHandleBeaconMessage />", () => {
         id: "mockMessageId",
         type: "error",
       });
+      expect(WalletClient.respond).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/core/src/AccountOperations.ts
+++ b/packages/core/src/AccountOperations.ts
@@ -1,9 +1,9 @@
 import { type Estimation } from "@umami/tezos";
+import { CustomError } from "@umami/utils";
 import { BigNumber } from "bignumber.js";
 
 import { type Account, type ImplicitAccount, type MultisigAccount } from "./Account";
 import { type Operation } from "./Operation";
-import { CustomError } from "../../utils/src/ErrorContext";
 
 type ProposalOperations = {
   type: "proposal";

--- a/packages/core/src/Operation.ts
+++ b/packages/core/src/Operation.ts
@@ -1,9 +1,8 @@
 import { type MichelsonV1Expression, type TransactionOperationParameter } from "@taquito/rpc";
 import { MANAGER_LAMBDA } from "@taquito/taquito";
 import { type Address, type ContractAddress, type ImplicitAddress } from "@umami/tezos";
+import { CustomError } from "@umami/utils";
 import { isEqual } from "lodash";
-
-import { CustomError } from "../../utils/src/ErrorContext";
 
 export type TezTransfer = {
   type: "tez";

--- a/packages/core/src/beaconUtils.ts
+++ b/packages/core/src/beaconUtils.ts
@@ -1,10 +1,10 @@
 import { type PartialTezosOperation, TezosOperationType } from "@airgap/beacon-wallet";
 import { isValidImplicitPkh, parseImplicitPkh, parsePkh } from "@umami/tezos";
+import { CustomError } from "@umami/utils";
 
 import { type ImplicitAccount } from "./Account";
 import { type ImplicitOperations } from "./AccountOperations";
 import { type ContractOrigination, type Operation } from "./Operation";
-import { CustomError } from "../../utils/src/ErrorContext";
 
 /**
  * takes a list of {@link PartialTezosOperation} which come from Beacon


### PR DESCRIPTION
## Proposed changes

Beacon should handle exceptions and send response to dApp in case of failure.
Asana: [task](https://app.asana.com/0/1205770721172203/1209118741509278)

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] UI fix

## Steps to reproduce

Details:
Case 1:
- Connect https://taquito-test-dapp.pages.dev/
- Set delegate to some address --> success
- Set delegate to the same address --> toast
- observe the toast "The delegate is unchanged. Delegation to this address is already done."
- the dApp hangs waiting for the response

Case 2:

- connect https://taquito-test-dapp.pages.dev/
- Stake <too much> or 0
- Toast about insufficient balance
- no answer to dApp

## Screenshots

Add the screenshots of how the app used to look like and how it looks now

Now dApp receives reject:

<img width="430" alt="image" src="https://github.com/user-attachments/assets/4d621268-67ab-4794-afb3-eca40feef115" />

<img width="430" alt="image" src="https://github.com/user-attachments/assets/b5c7cf98-0334-4550-82f6-d26598c43f1b" />

## Checklist

- [ ] Tests that prove my fix is effective or that my feature works have been added
- [ ] Documentation has been added (if appropriate)
- [x] Screenshots are added (if any UI changes have been made)
- [ ] All TODOs have a corresponding task created (and the link is attached to it)
