### PR TITLE
[Web][UMA-1034] hints in modals for Beacon and WC

### DIFF
--- a/apps/web/src/components/HintsAccordion/HintsAccordion.tsx
+++ b/apps/web/src/components/HintsAccordion/HintsAccordion.tsx
@@ -1,0 +1,45 @@
+import {
+  Accordion,
+  AccordionButton,
+  AccordionIcon,
+  AccordionItem,
+  AccordionPanel,
+  Heading,
+} from "@chakra-ui/react";
+import { Hints, type SignPage } from "@umami/core";
+
+import { useColor } from "../../styles/useColor";
+
+type HintsProps = {
+  signPage: SignPage;
+};
+
+export const HintsAccordion = ({ signPage }: HintsProps) => {
+  const color = useColor();
+
+  if (!(signPage in Hints) || !Hints[signPage].header || !Hints[signPage].description) {
+    return null;
+  }
+
+  return (
+    <Accordion
+      width="full"
+      marginTop="16px"
+      marginBottom="16px"
+      allowToggle
+      data-testid="hints-accordion"
+    >
+      <AccordionItem border="none" borderRadius="8px" backgroundColor={color("100")}>
+        <Heading>
+          <AccordionButton padding="12px" borderRadius="8px">
+            <Heading flex="1" textAlign="left" size="md">
+              {Hints[signPage].header}
+            </Heading>
+            <AccordionIcon />
+          </AccordionButton>
+        </Heading>
+        <AccordionPanel padding="16px">{Hints[signPage].description}</AccordionPanel>
+      </AccordionItem>
+    </Accordion>
+  );
+};

--- a/apps/web/src/components/HintsAccordion/index.tsx
+++ b/apps/web/src/components/HintsAccordion/index.tsx
@@ -1,0 +1,1 @@
+export * from "./HintsAccordion";

--- a/apps/web/src/components/SendFlow/common/BatchSignPage.test.tsx
+++ b/apps/web/src/components/SendFlow/common/BatchSignPage.test.tsx
@@ -3,6 +3,7 @@ import type { BatchWalletOperation } from "@taquito/taquito/dist/types/wallet/ba
 import {
   type EstimatedAccountOperations,
   type Operation,
+  Titles,
   executeOperations,
   mockContractCall,
   mockImplicitAccount,
@@ -23,7 +24,6 @@ import {
 import { SuccessStep } from "../SuccessStep";
 import { type SdkSignPageProps, type SignHeaderProps } from "../utils";
 import { BatchSignPage } from "./BatchSignPage";
-import { Titles } from "../../Titles";
 
 jest.mock("@umami/core", () => ({
   ...jest.requireActual("@umami/core"),

--- a/apps/web/src/components/SendFlow/common/BatchSignPage.tsx
+++ b/apps/web/src/components/SendFlow/common/BatchSignPage.tsx
@@ -12,13 +12,13 @@ import {
   ModalFooter,
   Text,
 } from "@chakra-ui/react";
+import { Titles } from "@umami/core";
 import { FormProvider, useForm } from "react-hook-form";
 
 import { Header } from "./Header";
 import { useColor } from "../../../styles/useColor";
 import { AddressTile } from "../../AddressTile/AddressTile";
 import { JsValueWrap } from "../../JsValueWrap";
-import { Titles } from "../../Titles";
 import { useSignWithBeacon } from "../Beacon/useSignWithBeacon";
 import { SignButton } from "../SignButton";
 import { SignPageFee } from "../SignPageFee";
@@ -42,7 +42,7 @@ export const BatchSignPage = (signProps: SdkSignPageProps) => {
 
   return (
     <FormProvider {...form}>
-      <ModalContent data-testId="BatchSignPage">
+      <ModalContent data-testid="BatchSignPage">
         <form>
           <Header headerProps={signProps.headerProps} title={Titles.BatchSignPage} />
 

--- a/apps/web/src/components/SendFlow/common/ContractCallSignPage.tsx
+++ b/apps/web/src/components/SendFlow/common/ContractCallSignPage.tsx
@@ -11,7 +11,7 @@ import {
   ModalContent,
   ModalFooter,
 } from "@chakra-ui/react";
-import { type ContractCall } from "@umami/core";
+import { type ContractCall, Titles } from "@umami/core";
 import { FormProvider, useForm } from "react-hook-form";
 
 import { Header } from "./Header";
@@ -19,8 +19,8 @@ import { useColor } from "../../../styles/useColor";
 import { AddressTile } from "../../AddressTile/AddressTile";
 import { AdvancedSettingsAccordion } from "../../AdvancedSettingsAccordion";
 import { TezTile } from "../../AssetTiles/TezTile";
+import { HintsAccordion } from "../../HintsAccordion";
 import { JsValueWrap } from "../../JsValueWrap";
-import { Titles } from "../../Titles";
 import { SignButton } from "../SignButton";
 import { SignPageFee } from "../SignPageFee";
 import { type CalculatedSignProps, type SdkSignPageProps } from "../utils";
@@ -47,6 +47,7 @@ export const ContractCallSignPage = ({
       <ModalContent data-testid="ContractCallSignPage">
         <form>
           <Header headerProps={headerProps} title={Titles.ContractCallSignPage} />
+          <HintsAccordion signPage="ContractCallSignPage" />
           <ModalBody>
             <TezTile mutezAmount={mutezAmount} />
 

--- a/apps/web/src/components/SendFlow/common/DelegationSignPage.tsx
+++ b/apps/web/src/components/SendFlow/common/DelegationSignPage.tsx
@@ -1,11 +1,11 @@
 import { Flex, FormLabel, ModalBody, ModalContent, ModalFooter } from "@chakra-ui/react";
-import { type Delegation } from "@umami/core";
+import { type Delegation, Titles } from "@umami/core";
 import { FormProvider, useForm } from "react-hook-form";
 
 import { Header } from "./Header";
 import { AddressTile } from "../../AddressTile/AddressTile";
 import { AdvancedSettingsAccordion } from "../../AdvancedSettingsAccordion";
-import { Titles } from "../../Titles";
+import { HintsAccordion } from "../../HintsAccordion";
 import { SignButton } from "../SignButton";
 import { SignPageFee } from "../SignPageFee";
 import { type CalculatedSignProps, type SdkSignPageProps } from "../utils";
@@ -27,6 +27,7 @@ export const DelegationSignPage = ({
       <ModalContent data-testid="DelegationSignPage">
         <form>
           <Header headerProps={headerProps} title={Titles.DelegationSignPage} />
+          <HintsAccordion signPage="DelegationSignPage" />
           <ModalBody>
             <FormLabel>From</FormLabel>
             <AddressTile address={operation.signer.address} />

--- a/apps/web/src/components/SendFlow/common/FinalizeUnstakeSignPage.tsx
+++ b/apps/web/src/components/SendFlow/common/FinalizeUnstakeSignPage.tsx
@@ -1,11 +1,12 @@
 import { Flex, FormLabel, ModalBody, ModalContent, ModalFooter } from "@chakra-ui/react";
+import { Titles } from "@umami/core";
 import { useAccountTotalFinalizableUnstakeAmount } from "@umami/state";
 import { FormProvider, useForm } from "react-hook-form";
 
 import { Header } from "./Header";
 import { AddressTile } from "../../AddressTile/AddressTile";
 import { TezTile } from "../../AssetTiles/TezTile";
-import { Titles } from "../../Titles";
+import { HintsAccordion } from "../../HintsAccordion";
 import { SignButton } from "../SignButton";
 import { SignPageFee } from "../SignPageFee";
 import { type CalculatedSignProps, type SdkSignPageProps } from "../utils";
@@ -27,6 +28,7 @@ export const FinalizeUnstakeSignPage = ({
       <ModalContent data-testid="FinalizeUnstakeSignPage">
         <form>
           <Header headerProps={headerProps} title={Titles.FinalizeUnstakeSignPage} />
+          <HintsAccordion signPage="FinalizeUnstakeSignPage" />
           <ModalBody>
             <Flex alignItems="center" justifyContent="end" marginTop="12px">
               <SignPageFee fee={fee} />

--- a/apps/web/src/components/SendFlow/common/OriginationOperationSignPage.test.tsx
+++ b/apps/web/src/components/SendFlow/common/OriginationOperationSignPage.test.tsx
@@ -65,6 +65,7 @@ describe("<OriginationOperationSignPage />", () => {
 
     expect(screen.getByTestId("sign-page-header")).toHaveTextContent("Origination request");
     expect(screen.getByTestId("app-name")).toHaveTextContent("mockDappName");
+    expect(screen.queryByTestId("hints-accordion")).not.toBeInTheDocument();
   });
 
   it("passes correct payload to sign handler", async () => {

--- a/apps/web/src/components/SendFlow/common/OriginationOperationSignPage.tsx
+++ b/apps/web/src/components/SendFlow/common/OriginationOperationSignPage.tsx
@@ -10,17 +10,17 @@ import {
   ModalContent,
   ModalFooter,
 } from "@chakra-ui/react";
-import { type ContractOrigination } from "@umami/core";
+import { type ContractOrigination, Titles } from "@umami/core";
 import { FormProvider, useForm } from "react-hook-form";
 
 import { useColor } from "../../../styles/useColor";
 import { AdvancedSettingsAccordion } from "../../AdvancedSettingsAccordion";
+import { HintsAccordion } from "../../HintsAccordion";
 import { JsValueWrap } from "../../JsValueWrap";
 import { SignButton } from "../SignButton";
 import { SignPageFee } from "../SignPageFee";
 import { type CalculatedSignProps, type SdkSignPageProps } from "../utils";
 import { Header } from "./Header";
-import { Titles } from "../../Titles";
 
 export const OriginationOperationSignPage = ({
   operation,
@@ -40,6 +40,7 @@ export const OriginationOperationSignPage = ({
         <form>
           <Header headerProps={headerProps} title={Titles.OriginationOperationSignPage} />
 
+          <HintsAccordion signPage="OriginationOperationSignPage" />
           <ModalBody data-testid="beacon-request-body">
             <Flex alignItems="center" justifyContent="end" marginTop="12px">
               <SignPageFee fee={fee} />

--- a/apps/web/src/components/SendFlow/common/SingleSignPage.test.tsx
+++ b/apps/web/src/components/SendFlow/common/SingleSignPage.test.tsx
@@ -2,7 +2,10 @@ import { BeaconMessageType, NetworkType, type OperationRequestOutput } from "@ai
 import type { BatchWalletOperation } from "@taquito/taquito/dist/types/wallet/batch-operation";
 import {
   type EstimatedAccountOperations,
+  Hints,
   type Operation,
+  type SignPage,
+  Titles,
   executeOperations,
   mockContractCall,
   mockContractOrigination,
@@ -29,7 +32,6 @@ import {
 import { SuccessStep } from "../SuccessStep";
 import { type SdkSignPageProps, type SignHeaderProps } from "../utils";
 import { SingleSignPage } from "./SingleSignPage";
-import { Titles } from "../../Titles/Titles";
 
 jest.mock("@umami/core", () => ({
   ...jest.requireActual("@umami/core"),
@@ -60,7 +62,7 @@ describe("<SingleSignPage />", () => {
     } as OperationRequestOutput;
 
     // check all types of Modals called by SingleSignOperation
-    const mockedOperations: Record<string, Operation> = {
+    const mockedOperations: Record<SignPage, Operation> = {
       TezSignPage: mockTezOperation(0),
       ContractCallSignPage: mockContractCall(0),
       DelegationSignPage: mockDelegationOperation(0),
@@ -69,17 +71,6 @@ describe("<SingleSignPage />", () => {
       StakeSignPage: mockStakeOperation(0),
       UnstakeSignPage: mockUnstakeOperation(0),
       FinalizeUnstakeSignPage: mockFinalizeUnstakeOperation(0),
-    };
-
-    const titles: Record<string, string> = {
-      TezSignPage: Titles.TezSignPage,
-      ContractCallSignPage: Titles.ContractCallSignPage,
-      DelegationSignPage: Titles.DelegationSignPage,
-      UndelegationSignPage: Titles.UndelegationSignPage,
-      OriginationOperationSignPage: Titles.OriginationOperationSignPage,
-      StakeSignPage: Titles.StakeSignPage,
-      UnstakeSignPage: Titles.UnstakeSignPage,
-      FinalizeUnstakeSignPage: Titles.FinalizeUnstakeSignPage,
     };
 
     const operation: EstimatedAccountOperations = {
@@ -117,8 +108,14 @@ describe("<SingleSignPage />", () => {
       expect(screen.queryByText("Mainnet")).not.toBeInTheDocument();
       expect(screen.getByTestId(key)).toBeInTheDocument(); // e.g. TezSignPage
 
-      expect(screen.getByTestId("sign-page-header")).toHaveTextContent(titles[key]);
+      expect(screen.getByTestId("sign-page-header")).toHaveTextContent(Titles[key]);
       expect(screen.getByTestId("app-name")).toHaveTextContent("mockDappName");
+      if (key in Hints && Hints[key].header && Hints[key].description) {
+        expect(screen.getByTestId("hints-accordion")).toHaveTextContent(Hints[key].header);
+        expect(screen.getByTestId("hints-accordion")).toHaveTextContent(Hints[key].description);
+      } else {
+        expect(screen.queryByTestId("hints-accordion")).not.toBeInTheDocument();
+      }
 
       const signButton = screen.getByRole("button", {
         name: "Confirm transaction",
@@ -148,5 +145,5 @@ describe("<SingleSignPage />", () => {
       });
       dynamicModalContextMock.openWith.mockClear();
     }
-  });
+  }, 10000);
 });

--- a/apps/web/src/components/SendFlow/common/StakeSignPage.tsx
+++ b/apps/web/src/components/SendFlow/common/StakeSignPage.tsx
@@ -1,11 +1,11 @@
 import { Flex, FormLabel, ModalBody, ModalContent, ModalFooter } from "@chakra-ui/react";
-import { type Stake } from "@umami/core";
+import { type Stake, Titles } from "@umami/core";
 import { FormProvider, useForm } from "react-hook-form";
 
 import { Header } from "./Header";
 import { AddressTile } from "../../AddressTile/AddressTile";
 import { TezTile } from "../../AssetTiles/TezTile";
-import { Titles } from "../../Titles";
+import { HintsAccordion } from "../../HintsAccordion";
 import { SignButton } from "../SignButton";
 import { SignPageFee } from "../SignPageFee";
 import { type CalculatedSignProps, type SdkSignPageProps } from "../utils";
@@ -27,6 +27,7 @@ export const StakeSignPage = ({
       <ModalContent data-testid="StakeSignPage">
         <form>
           <Header headerProps={headerProps} title={Titles.StakeSignPage} />
+          <HintsAccordion signPage="StakeSignPage" />
           <ModalBody>
             <Flex alignItems="center" justifyContent="end" marginTop="12px">
               <SignPageFee fee={fee} />

--- a/apps/web/src/components/SendFlow/common/TezSignPage.tsx
+++ b/apps/web/src/components/SendFlow/common/TezSignPage.tsx
@@ -1,12 +1,12 @@
 import { Flex, FormLabel, ModalBody, ModalContent, ModalFooter } from "@chakra-ui/react";
-import { type TezTransfer } from "@umami/core";
+import { type TezTransfer, Titles } from "@umami/core";
 import { FormProvider, useForm } from "react-hook-form";
 
 import { Header } from "./Header";
 import { AddressTile } from "../../AddressTile/AddressTile";
 import { AdvancedSettingsAccordion } from "../../AdvancedSettingsAccordion";
 import { TezTile } from "../../AssetTiles/TezTile";
-import { Titles } from "../../Titles";
+import { HintsAccordion } from "../../HintsAccordion";
 import { SignButton } from "../SignButton";
 import { SignPageFee } from "../SignPageFee";
 import { type CalculatedSignProps, type SdkSignPageProps } from "../utils";
@@ -27,6 +27,7 @@ export const TezSignPage = ({
       <ModalContent data-testid="TezSignPage">
         <form>
           <Header headerProps={headerProps} title={Titles.TezSignPage} />
+          <HintsAccordion signPage="TezSignPage" />
           <ModalBody>
             <TezTile mutezAmount={mutezAmount} />
 

--- a/apps/web/src/components/SendFlow/common/UndelegationSignPage.tsx
+++ b/apps/web/src/components/SendFlow/common/UndelegationSignPage.tsx
@@ -1,10 +1,11 @@
 import { Flex, FormLabel, ModalBody, ModalContent, ModalFooter } from "@chakra-ui/react";
+import { Titles } from "@umami/core";
 import { FormProvider, useForm } from "react-hook-form";
 
 import { Header } from "./Header";
 import { AddressTile } from "../../AddressTile/AddressTile";
 import { AdvancedSettingsAccordion } from "../../AdvancedSettingsAccordion";
-import { Titles } from "../../Titles";
+import { HintsAccordion } from "../../HintsAccordion";
 import { SignButton } from "../SignButton";
 import { SignPageFee } from "../SignPageFee";
 import { type CalculatedSignProps, type SdkSignPageProps } from "../utils";
@@ -24,6 +25,7 @@ export const UndelegationSignPage = ({
       <ModalContent data-testid="UndelegationSignPage">
         <form>
           <Header headerProps={headerProps} title={Titles.UndelegationSignPage} />
+          <HintsAccordion signPage="UndelegationSignPage" />
           <ModalBody>
             <FormLabel>From</FormLabel>
             <AddressTile address={operation.signer.address} />

--- a/apps/web/src/components/SendFlow/common/UnstakeSignPage.tsx
+++ b/apps/web/src/components/SendFlow/common/UnstakeSignPage.tsx
@@ -1,11 +1,11 @@
 import { Flex, FormLabel, ModalBody, ModalContent, ModalFooter } from "@chakra-ui/react";
-import { type Unstake } from "@umami/core";
+import { Titles, type Unstake } from "@umami/core";
 import { FormProvider, useForm } from "react-hook-form";
 
 import { Header } from "./Header";
 import { AddressTile } from "../../AddressTile/AddressTile";
 import { TezTile } from "../../AssetTiles/TezTile";
-import { Titles } from "../../Titles";
+import { HintsAccordion } from "../../HintsAccordion";
 import { SignButton } from "../SignButton";
 import { SignPageFee } from "../SignPageFee";
 import { type CalculatedSignProps, type SdkSignPageProps } from "../utils";
@@ -27,6 +27,7 @@ export const UnstakeSignPage = ({
       <ModalContent data-testid="UnstakeSignPage">
         <form>
           <Header headerProps={headerProps} title={Titles.UnstakeSignPage} />
+          <HintsAccordion signPage="UnstakeSignPage" />
           <ModalBody>
             <Flex alignItems="center" justifyContent="end" marginTop="12px">
               <SignPageFee fee={fee} />

--- a/apps/web/src/components/beacon/useHandleBeaconMessage.test.tsx
+++ b/apps/web/src/components/beacon/useHandleBeaconMessage.test.tsx
@@ -407,6 +407,7 @@ describe("<useHandleBeaconMessage />", () => {
         );
         expect(screen.getByTestId("sign-page-header")).toHaveTextContent("Send request");
         expect(screen.getByTestId("app-name")).toHaveTextContent("mockDappName");
+        expect(screen.queryByTestId("hints-accordion")).not.toBeInTheDocument();
 
         expect(mockToast).not.toHaveBeenCalled();
       });

--- a/packages/core/src/constants/Hints.ts
+++ b/packages/core/src/constants/Hints.ts
@@ -1,0 +1,35 @@
+import { type SignPage } from "./Titles";
+
+type HintData = {
+  header?: string;
+  description?: string;
+};
+
+const finalizationConsequences =
+  "Finalizing unstaked funds makes them available on your spendable balance. They can now be spent or staken again to earn more rewards.";
+const unstakingConsequences = `Unstaked tez immediately stop accruing staking rewards, but sill give rights to delegation rewards. Unstaked tez remain locked for up to 4 cycles (~11 days), after which they can be finalized on request. ${finalizationConsequences}`;
+
+export const Hints: Record<SignPage, HintData> = {
+  DelegationSignPage: {
+    header: "It takes at least 3 full cycles (~9 days) to start receiving delegation rewards",
+    description:
+      "The actual delay will depend on your chosen baker payout strategy. Bakers typically distribute delegation rewards every cycle (~3 days). Ensure the delegation fee offered by the baker is less than 100%; otherwise, you may not receive rewards. Delegation means that all your funds are delegated to one baker. The funds remain spendable, and you can cancel or change the delegation at any time.",
+  },
+  UndelegationSignPage: {
+    header: "Stops both delegation and staking. Restoring rewards takes 2 cycles (~6 days).",
+    description: `Undelegation takes effect immediately. However, you will still receive delegation rewards for the current and the next 2 cycles, as baking rights are computed 2 cycles in advance. By undelegating, you also initiate the unstaking process if you have staked. ${unstakingConsequences}`,
+  },
+  StakeSignPage: {
+    header: "You will start receiving rewards immediately (within the current cycle)",
+    description: `Your spendable balance will be reduced by the amount staked. You will start accruing staking rewards immediately (within the current cycle). Staking rewards are compounded on your staked balance. You can cancel staking any time. ${unstakingConsequences}`,
+  },
+  UnstakeSignPage: {
+    header:
+      "Unstake request take effect immediately, but funds remain frozen for up to 4 cycles (~10 days)",
+    description: unstakingConsequences,
+  },
+  FinalizeUnstakeSignPage: {
+    header: "Takes 1 block (8 seconds) to complete.",
+    description: `Finalizing applies to all finalizable funds in your balance. ${finalizationConsequences}`,
+  },
+};

--- a/packages/core/src/constants/Titles.tsx
+++ b/packages/core/src/constants/Titles.tsx
@@ -1,3 +1,4 @@
+export type SignPage = keyof typeof Titles;
 export const Titles: Record<string, string> = {
   TezSignPage: "Send request",
   ContractCallSignPage: "Contract call request",

--- a/packages/core/src/constants/index.tsx
+++ b/packages/core/src/constants/index.tsx
@@ -1,1 +1,2 @@
+export * from "./Hints";
 export * from "./Titles";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,7 @@
 export * from "./Account";
 export * from "./AccountOperations";
 export * from "./Contact";
+export * from "./constants";
 export * from "./decodeBeaconPayload";
 export * from "./Delegate";
 export * from "./estimate";


### PR DESCRIPTION
## Proposed changes

Umami modals for both Beacon and WalletConnect should be more helpful.
A user can easily make a mistake or hesitate confirming a transaction without understanding of the consequences of the operation.

Task: [UMA-1034](https://linear.app/tezos/issue/UMA-1034)

## Types of changes

- [ ] Bugfix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] UI fix

## Steps to reproduce

1. Connect https://taquito-test-dapp.pages.dev/
2. run operations:
 - delegate
 - undelegate
 - stake
 - unstake
 - finalize
3. see the hint and the details description

Other operations are covered in #2340

## Screenshots

Add the screenshots of how the app used to look like and how it looks now

| Operation | Before | Now |
| ------ | ------ | --- |
| DelegationRequest | <img width="500" alt="image" src="https://github.com/user-attachments/assets/7dc5ed0b-713b-4f5c-8746-c2489bbc018c" />  | <img width="500" alt="image" src="https://github.com/user-attachments/assets/3d51ba94-c05a-44fc-9257-cce6f09f51b5" /> |
| accordion opened |        | <img width="500" alt="image" src="https://github.com/user-attachments/assets/b41ab8c5-0586-4fe5-a24e-f798e0539fd8" /> |
| Undelegation Request | <img width="500" alt="image" src="https://github.com/user-attachments/assets/6761ba70-a6d7-418c-a1fb-0d76c9f8cae5" /> | <img width="500" alt="image" src="https://github.com/user-attachments/assets/6290affb-5e5c-443a-af58-cf9389d9acef" /> |
| accordion opened |        | <img width="500" alt="image" src="https://github.com/user-attachments/assets/c4781484-500e-4449-bc85-33f73a0b9ab4" /> |
| Stake | <img width="517" alt="image" src="https://github.com/user-attachments/assets/2dba318e-5ea3-4e96-9cf2-bbe8582e26f8" /> | <img width="500" alt="image" src="https://github.com/user-attachments/assets/94cab80f-a4bd-4824-b900-f54ba304925a" /> |
| accordion opened |        | <img width="500" alt="image" src="https://github.com/user-attachments/assets/0495f9e4-dfd7-487f-a97f-9da02210d2b0" /> |
| Unstake | <img width="517" alt="image" src="https://github.com/user-attachments/assets/13412113-9424-4fde-b182-b521a83a9a0b" /> | <img width="500" alt="image" src="https://github.com/user-attachments/assets/e0a5bf95-e55f-4cf8-840f-a8c2183c1716" /> |
| accordion opened |        | <img width="500" alt="image" src="https://github.com/user-attachments/assets/455b5d20-a62e-4e39-8a47-be7a0c2f57a3" /> |
| Finalize Unstake Request | <img width="500" alt="image" src="https://github.com/user-attachments/assets/03dbff5d-447e-4693-a1fe-ff3bd9043f69" /> | <img width="520" alt="image" src="https://github.com/user-attachments/assets/09149530-68bb-4548-aa2b-80df242dfd54" /> |
| accordion opened |        | <img width="500" alt="image" src="https://github.com/user-attachments/assets/b842fb27-5949-4162-8f91-cd2b3458814e" /> |

## Checklist

- [x] Tests that prove my fix is effective or that my feature works have been added
- [ ] Documentation has been added (if appropriate)
- [x] Screenshots are added (if any UI changes have been made)
- [ ] All TODOs have a corresponding task created (and the link is attached to it)
