### PR TITLE
feat: detailed balance for web, user view

### DIFF
--- a/apps/desktop/src/components/SideNavbar.tsx
+++ b/apps/desktop/src/components/SideNavbar.tsx
@@ -1,5 +1,5 @@
 import { Box, Divider, Flex, type FlexProps, Text, useMediaQuery } from "@chakra-ui/react";
-import { useTotalBalance } from "@umami/state";
+import { useSpendableBalanceOfAllAccounts } from "@umami/state";
 import { type ReactElement } from "react";
 import { Link, useLocation } from "react-router-dom";
 
@@ -156,7 +156,7 @@ const MenuItem = ({
 };
 
 const TotalBalance = () => {
-  const balance = useTotalBalance();
+  const balance = useSpendableBalanceOfAllAccounts();
   const [isShort] = useMediaQuery("(max-height: 900px)");
 
   return (

--- a/apps/web/src/components/AccountCard/AccountBalance.test.tsx
+++ b/apps/web/src/components/AccountCard/AccountBalance.test.tsx
@@ -5,12 +5,10 @@ import {
   addTestAccount,
   assetsActions,
   makeStore,
-  networksActions,
 } from "@umami/state";
-import { GHOSTNET, MAINNET } from "@umami/tezos";
 
 import { AccountBalance } from "./AccountBalance";
-import { act, render, screen, userEvent, waitFor, within } from "../../testUtils";
+import { render, screen } from "../../testUtils";
 
 let store: UmamiStore;
 const account = mockImplicitAccount(0);
@@ -22,54 +20,6 @@ beforeEach(() => {
 });
 
 describe("<AccountBalance />", () => {
-  it("renders a buy tez link for mainnet", () => {
-    store.dispatch(networksActions.setCurrent(MAINNET));
-
-    render(<AccountBalance />, { store });
-
-    const link = screen.getByRole("link", { name: "Buy" });
-    expect(link).toBeVisible();
-    expect(link).toHaveAttribute(
-      "href",
-      "https://widget.wert.io/default/widget/?commodity=XTZ&address=tz1gUNyn3hmnEWqkusWPzxRaon1cs7ndWh7h&network=tezos&commodity_id=xtz.simple.tezos"
-    );
-  });
-
-  it("renders a buy tez link for ghostnet", () => {
-    store.dispatch(networksActions.setCurrent(GHOSTNET));
-
-    render(<AccountBalance />, { store });
-
-    const link = screen.getByRole("link", { name: "Buy" });
-    expect(link).toBeVisible();
-    expect(link).toHaveAttribute("href", "https://faucet.ghostnet.teztnets.com/");
-  });
-
-  it("renders a receive button", () => {
-    render(<AccountBalance />, { store });
-
-    expect(screen.getByRole("button", { name: "Receive" })).toBeVisible();
-  });
-
-  it("renders a send button", async () => {
-    const user = userEvent.setup();
-    render(<AccountBalance />, { store });
-
-    const button = screen.getByRole("button", { name: "Send" });
-
-    expect(button).toBeVisible();
-
-    await waitFor(async () => {
-      await act(() => user.click(button));
-    });
-
-    await waitFor(() =>
-      expect(
-        within(screen.getByRole("dialog")).getByRole("heading", { name: "Send" })
-      ).toBeVisible()
-    );
-  });
-
   describe("balance", () => {
     it("renders balance", () => {
       store.dispatch(assetsActions.updateConversionRate(2.44));
@@ -85,7 +35,7 @@ describe("<AccountBalance />", () => {
       render(<AccountBalance />, { store });
 
       expect(screen.getByTestId("tez-balance")).toHaveTextContent("1.234567 ꜩ");
-      expect(screen.getByTestId("usd-balance")).toHaveTextContent("$3.02");
+      expect(screen.getByTestId("usd-balance")).toHaveTextContent("$3.02 (US$2.44 / XTZ)");
     });
 
     it("renders only tez balance if conversion rate is not available", () => {
@@ -109,23 +59,6 @@ describe("<AccountBalance />", () => {
 
       expect(screen.getByTestId("tez-balance")).toHaveTextContent("0 ꜩ");
       expect(screen.getByTestId("usd-balance")).toHaveTextContent("$0.00");
-    });
-  });
-
-  describe("if user is unverified", () => {
-    beforeEach(() => {
-      store.dispatch(
-        accountsActions.setIsVerified({ pkh: account.address.pkh, isVerified: false })
-      );
-    });
-
-    it.each(["Buy", "Send", "Receive"])("%s button is disabled", buttonName => {
-      render(<AccountBalance />, { store });
-
-      const button = screen.getByLabelText(buttonName);
-
-      // eslint-disable-next-line jest-dom/prefer-enabled-disabled
-      expect(button).toHaveAttribute("disabled");
     });
   });
 });

--- a/apps/web/src/components/AccountCard/AccountBalanceDetails.test.tsx
+++ b/apps/web/src/components/AccountCard/AccountBalanceDetails.test.tsx
@@ -1,0 +1,284 @@
+import { mockImplicitAccount, rawAccountFixture } from "@umami/core";
+import {
+  type UmamiStore,
+  accountsActions,
+  addTestAccount,
+  assetsActions,
+  makeStore,
+} from "@umami/state";
+import { mockImplicitAddress } from "@umami/tezos";
+
+import { AccountBalanceDetails } from "./AccountBalanceDetails";
+import { render, screen } from "../../testUtils";
+
+let store: UmamiStore;
+const account = mockImplicitAccount(0);
+const stakerAddress = mockImplicitAddress(0).pkh;
+
+beforeEach(() => {
+  store = makeStore();
+  addTestAccount(store, account);
+  store.dispatch(accountsActions.setCurrent(account.address.pkh));
+});
+
+describe("<AccountBalanceDetails />", () => {
+  describe("balance details", () => {
+    it("hids 0 values", () => {
+      store.dispatch(assetsActions.updateConversionRate(2.44));
+      store.dispatch(
+        assetsActions.updateAccountStates([
+          rawAccountFixture({
+            address: account.address.pkh,
+            balance: 1234567,
+          }),
+        ])
+      );
+
+      render(<AccountBalanceDetails />, { store });
+
+      expect(screen.queryByTestId("spendable-balance")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("staked-balance")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("finalizable-unstaked-balance")).not.toBeInTheDocument();
+    });
+
+    it("doesn't render balance if it's not available", () => {
+      render(<AccountBalanceDetails />, { store });
+
+      expect(screen.queryByTestId("spendable-balance")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("staked-balance")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("finalizable-unstaked-balance")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("Delegation and staking", () => {
+    it("renders delegation when delegate exists", () => {
+      store.dispatch(
+        assetsActions.updateAccountStates([
+          rawAccountFixture({
+            address: account.address.pkh,
+          }),
+        ])
+      );
+
+      render(<AccountBalanceDetails />, { store });
+
+      expect(screen.getByText("Delegated to:")).toBeInTheDocument();
+      expect(screen.getByTestId("current-baker")).toHaveTextContent("mega_baker");
+    });
+
+    it("no delegation status if not delegated and no staking-related balances", () => {
+      store.dispatch(
+        assetsActions.updateAccountStates([
+          rawAccountFixture({
+            address: account.address.pkh,
+            delegate: null,
+          }),
+        ])
+      );
+
+      render(<AccountBalanceDetails />, { store });
+
+      expect(screen.queryByText("Delegation:")).not.toBeInTheDocument();
+      expect(screen.queryByText("Inactive")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("current-baker")).not.toBeInTheDocument();
+    });
+
+    it("delegation status Inactive is shown if not delegated and finalizable balance", () => {
+      store.dispatch(
+        assetsActions.updateAccountStates([
+          rawAccountFixture({
+            address: account.address.pkh,
+            delegate: null,
+          }),
+        ])
+      );
+      store.dispatch(
+        assetsActions.updateUnstakeRequests([
+          {
+            cycle: 2,
+            amount: 300000,
+            staker: { address: stakerAddress },
+            status: "finalizable",
+          },
+        ])
+      );
+
+      render(<AccountBalanceDetails />, { store });
+
+      expect(screen.getByText("Delegation:")).toBeInTheDocument();
+      expect(screen.getByText("Inactive")).toBeInTheDocument();
+      expect(screen.queryByTestId("current-baker")).not.toBeInTheDocument();
+    });
+
+    it("delegation status Inactive is shown if not delegated and frozen unstaked balance", () => {
+      store.dispatch(
+        assetsActions.updateAccountStates([
+          rawAccountFixture({
+            address: account.address.pkh,
+            delegate: null,
+          }),
+        ])
+      );
+      store.dispatch(
+        assetsActions.updateUnstakeRequests([
+          {
+            cycle: 2,
+            amount: 300000,
+            staker: { address: stakerAddress },
+            status: "pending",
+          },
+        ])
+      );
+
+      render(<AccountBalanceDetails />, { store });
+
+      expect(screen.getByText("Delegation:")).toBeInTheDocument();
+      expect(screen.getByText("Inactive")).toBeInTheDocument();
+      expect(screen.queryByTestId("current-baker")).not.toBeInTheDocument();
+    });
+
+    it("renders staked and spendable balance", () => {
+      store.dispatch(
+        assetsActions.updateAccountStates([
+          rawAccountFixture({
+            address: account.address.pkh,
+            balance: 1234567,
+            stakedBalance: 1000000,
+          }),
+        ])
+      );
+
+      render(<AccountBalanceDetails />, { store });
+
+      expect(screen.getByTestId("spendable-balance")).toHaveTextContent("0.234567 ꜩ");
+      expect(screen.getByTestId("staked-balance")).toHaveTextContent("Staked:");
+      expect(screen.getByTestId("staked-balance")).toHaveTextContent("1.000000 ꜩ");
+      expect(screen.queryByTestId("frozen-unstaked-balance")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("finalizable-unstaked-balance")).not.toBeInTheDocument();
+    });
+
+    it("renders unstaked (frozen) balance when greater than 0", () => {
+      const stakerAddress = mockImplicitAddress(0).pkh;
+      store.dispatch(
+        assetsActions.updateAccountStates([
+          rawAccountFixture({
+            address: account.address.pkh,
+            balance: 1234567,
+          }),
+        ])
+      );
+
+      store.dispatch(
+        assetsActions.updateUnstakeRequests([
+          {
+            cycle: 1,
+            amount: 100000,
+            staker: { address: stakerAddress },
+            status: "pending",
+          },
+          {
+            cycle: 1,
+            amount: 20000,
+            staker: { address: stakerAddress },
+            status: "pending",
+          },
+        ])
+      );
+
+      render(<AccountBalanceDetails />, { store });
+
+      expect(screen.getByTestId("spendable-balance")).toHaveTextContent("1.234567 ꜩ");
+      expect(screen.queryByTestId("staked-balance")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("finalizable-unstaked-balance")).not.toBeInTheDocument();
+      expect(screen.getByTestId("frozen-unstaked-balance")).toHaveTextContent("Frozen unstaked:");
+      expect(screen.getByTestId("frozen-unstaked-balance")).toHaveTextContent("0.120000 ꜩ");
+    });
+
+    it("renders finalizable balance when greater than 0", () => {
+      store.dispatch(
+        assetsActions.updateAccountStates([
+          rawAccountFixture({
+            address: account.address.pkh,
+            balance: 1234567,
+          }),
+        ])
+      );
+
+      store.dispatch(
+        assetsActions.updateUnstakeRequests([
+          {
+            cycle: 2,
+            amount: 300000,
+            staker: { address: stakerAddress },
+            status: "finalizable",
+          },
+        ])
+      );
+
+      render(<AccountBalanceDetails />, { store });
+
+      expect(screen.getByTestId("spendable-balance")).toHaveTextContent("Spendable:");
+      expect(screen.getByTestId("spendable-balance")).toHaveTextContent("1.234567 ꜩ");
+      expect(screen.queryByTestId("staked-balance")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("frozen-unstaked-balance")).not.toBeInTheDocument();
+      expect(screen.getByTestId("finalizable-unstaked-balance")).toHaveTextContent(
+        "Finalizable unstaked:"
+      );
+      expect(screen.getByTestId("finalizable-unstaked-balance")).toHaveTextContent("0.300000 ꜩ");
+    });
+
+    it("renders combination of staked, unstaked and frozen", () => {
+      store.dispatch(
+        assetsActions.updateAccountStates([
+          rawAccountFixture({
+            address: account.address.pkh,
+            balance: 1234567,
+            stakedBalance: 1000000,
+          }),
+        ])
+      );
+
+      store.dispatch(
+        assetsActions.updateUnstakeRequests([
+          {
+            cycle: 1,
+            amount: 10000,
+            staker: { address: stakerAddress },
+            status: "pending",
+          },
+          {
+            cycle: 1,
+            amount: 200000,
+            staker: { address: stakerAddress },
+            status: "pending",
+          },
+          {
+            cycle: 2,
+            amount: 3000000,
+            staker: { address: stakerAddress },
+            status: "finalizable",
+          },
+          {
+            cycle: 5,
+            amount: 40000000,
+            staker: { address: stakerAddress },
+            status: "finalized",
+          },
+        ])
+      );
+
+      render(<AccountBalanceDetails />, { store });
+
+      expect(screen.getByTestId("spendable-balance")).toHaveTextContent("Spendable:");
+      expect(screen.getByTestId("spendable-balance")).toHaveTextContent("0.234567 ꜩ");
+      expect(screen.getByTestId("staked-balance")).toHaveTextContent("Staked:");
+      expect(screen.getByTestId("staked-balance")).toHaveTextContent("1.000000 ꜩ");
+      expect(screen.getByTestId("frozen-unstaked-balance")).toHaveTextContent("Frozen unstaked:");
+      expect(screen.getByTestId("frozen-unstaked-balance")).toHaveTextContent("0.210000 ꜩ");
+      expect(screen.getByTestId("finalizable-unstaked-balance")).toHaveTextContent(
+        "Finalizable unstaked:"
+      );
+      expect(screen.getByTestId("finalizable-unstaked-balance")).toHaveTextContent("3.000000 ꜩ");
+    });
+  });
+});

--- a/apps/web/src/components/AccountCard/AccountBalanceDetails.tsx
+++ b/apps/web/src/components/AccountCard/AccountBalanceDetails.tsx
@@ -1,0 +1,110 @@
+import { Box, Flex, Text } from "@chakra-ui/react";
+import {
+  useCurrentAccount,
+  useGetAccountBalanceDetails,
+  useGetAccountDelegate,
+} from "@umami/state";
+import { prettyTezAmount } from "@umami/tezos";
+import { BigNumber } from "bignumber.js";
+
+import { useColor } from "../../styles/useColor";
+import { AddressPill } from "../AddressPill";
+
+const RoundStatusDot = ({ background }: { background: string }) => (
+  <Box
+    display="inline-block"
+    width="8px"
+    height="8px"
+    marginRight="5px"
+    background={background}
+    borderRadius="100%"
+  />
+);
+
+export const AccountBalanceDetails = () => {
+  const color = useColor();
+  const currentAccount = useCurrentAccount()!;
+  const address = currentAccount.address.pkh;
+  const {
+    spendableBalance,
+    stakedBalance,
+    totalFinalizableAmount,
+    totalPendingAmount,
+    totalBalance,
+  } = useGetAccountBalanceDetails(address);
+  const delegate = useGetAccountDelegate()(address);
+
+  const BalanceLabel = ({ label }: { label: string }) => (
+    <Text color={color("600")} fontWeight="600" size="sm">
+      {label}
+    </Text>
+  );
+  const BalanceRow = ({
+    label,
+    testid,
+    value,
+  }: {
+    label: string;
+    testid: string;
+    value: BigNumber | string | number;
+  }) => (
+    <Flex alignItems="center" justifyContent="space-between" width="100%" data-testid={testid}>
+      <BalanceLabel label={label} />
+      <Text color={color("700")} fontWeight="600" size="sm">
+        {prettyTezAmount(value)}
+      </Text>
+    </Flex>
+  );
+
+  return (
+    <Box data-testid="balance-details" paddingX="12px">
+      <Flex flexDirection="column" gap="4px">
+        {!delegate && !spendableBalance.isEqualTo(totalBalance) && (
+          <Flex
+            alignItems="center"
+            justifyContent="space-between"
+            width="100%"
+            data-testid="delegation"
+          >
+            <BalanceLabel label="Delegation:" />
+            <Flex alignItems="center" justifyContent="flex-end" gap="2">
+              <RoundStatusDot background={color("orange")} />
+              <Text size="sm">Inactive</Text>
+            </Flex>
+          </Flex>
+        )}
+        {delegate && (
+          <Flex
+            alignItems="center"
+            justifyContent="space-between"
+            width="100%"
+            data-testid="delagated-to"
+          >
+            <BalanceLabel label="Delegated to:" />
+            <AddressPill address={delegate} data-testid="current-baker" />
+          </Flex>
+        )}
+        {!spendableBalance.isEqualTo(totalBalance) && (
+          <BalanceRow label="Spendable:" testid="spendable-balance" value={spendableBalance} />
+        )}
+        {stakedBalance > 0 && (
+          <BalanceRow label="Staked:" testid="staked-balance" value={stakedBalance} />
+        )}
+        {totalPendingAmount > BigNumber(0) && (
+          <BalanceRow
+            label="Frozen unstaked:"
+            testid="frozen-unstaked-balance"
+            value={totalPendingAmount}
+          />
+        )}
+        {totalFinalizableAmount > BigNumber(0) && (
+          <BalanceRow
+            label="Finalizable unstaked:"
+            testid="finalizable-unstaked-balance"
+            value={totalFinalizableAmount}
+          />
+        )}
+      </Flex>
+    </Box>
+  );
+};

--- a/apps/web/src/components/AccountCard/AccountButtons.test.tsx
+++ b/apps/web/src/components/AccountCard/AccountButtons.test.tsx
@@ -1,0 +1,88 @@
+import { mockImplicitAccount } from "@umami/core";
+import {
+  type UmamiStore,
+  accountsActions,
+  addTestAccount,
+  makeStore,
+  networksActions,
+} from "@umami/state";
+import { GHOSTNET, MAINNET } from "@umami/tezos";
+
+import { AccountButtons } from "./AccountButtons";
+import { act, render, screen, userEvent, waitFor, within } from "../../testUtils";
+
+let store: UmamiStore;
+const account = mockImplicitAccount(0);
+
+beforeEach(() => {
+  store = makeStore();
+  addTestAccount(store, account);
+  store.dispatch(accountsActions.setCurrent(account.address.pkh));
+});
+
+describe("<AccountButtons />", () => {
+  it("renders a buy tez link for mainnet", () => {
+    store.dispatch(networksActions.setCurrent(MAINNET));
+
+    render(<AccountButtons />, { store });
+
+    const link = screen.getByRole("link", { name: "Buy" });
+    expect(link).toBeVisible();
+    expect(link).toHaveAttribute(
+      "href",
+      "https://widget.wert.io/default/widget/?commodity=XTZ&address=tz1gUNyn3hmnEWqkusWPzxRaon1cs7ndWh7h&network=tezos&commodity_id=xtz.simple.tezos"
+    );
+  });
+
+  it("renders a buy tez link for ghostnet", () => {
+    store.dispatch(networksActions.setCurrent(GHOSTNET));
+
+    render(<AccountButtons />, { store });
+
+    const link = screen.getByRole("link", { name: "Buy" });
+    expect(link).toBeVisible();
+    expect(link).toHaveAttribute("href", "https://faucet.ghostnet.teztnets.com/");
+  });
+
+  it("renders a receive button", () => {
+    render(<AccountButtons />, { store });
+
+    expect(screen.getByRole("button", { name: "Receive" })).toBeVisible();
+  });
+
+  it("renders a send button", async () => {
+    const user = userEvent.setup();
+    render(<AccountButtons />, { store });
+
+    const button = screen.getByRole("button", { name: "Send" });
+
+    expect(button).toBeVisible();
+
+    await waitFor(async () => {
+      await act(() => user.click(button));
+    });
+
+    await waitFor(() =>
+      expect(
+        within(screen.getByRole("dialog")).getByRole("heading", { name: "Send" })
+      ).toBeVisible()
+    );
+  });
+
+  describe("if user is unverified", () => {
+    beforeEach(() => {
+      store.dispatch(
+        accountsActions.setIsVerified({ pkh: account.address.pkh, isVerified: false })
+      );
+    });
+
+    it.each(["Buy", "Send", "Receive"])("%s button is disabled", buttonName => {
+      render(<AccountButtons />, { store });
+
+      const button = screen.getByLabelText(buttonName);
+
+      // eslint-disable-next-line jest-dom/prefer-enabled-disabled
+      expect(button).toHaveAttribute("disabled");
+    });
+  });
+});

--- a/apps/web/src/components/AccountCard/AccountButtons.tsx
+++ b/apps/web/src/components/AccountCard/AccountButtons.tsx
@@ -1,0 +1,48 @@
+import { Box, Flex, Link } from "@chakra-ui/react";
+import { useDynamicModalContext } from "@umami/components";
+import { useBuyTezUrl, useCurrentAccount } from "@umami/state";
+
+import { SendTezButton } from "./SendTezButton";
+import { ArrowDownLeftIcon, WalletIcon } from "../../assets/icons";
+import { AccountInfoModal } from "../AccountSelectorModal";
+import { IconButtonWithText } from "../IconButtonWithText";
+import { useIsAccountVerified } from "../Onboarding/VerificationFlow";
+
+export const AccountButtons = () => {
+  const { openWith } = useDynamicModalContext();
+  const currentAccount = useCurrentAccount()!;
+  const address = currentAccount.address.pkh;
+  const buyTezUrl = useBuyTezUrl(address);
+  const isVerified = useIsAccountVerified();
+
+  return (
+    <Box data-testid="account-buttons" paddingX="12px">
+      <Flex
+        alignItems="center"
+        justifyContent="space-between"
+        marginTop={{ base: "20px", md: "40px" }}
+      >
+        <IconButtonWithText
+          as={Link}
+          pointerEvents={isVerified ? "auto" : "none"}
+          href={isVerified ? buyTezUrl : ""}
+          icon={WalletIcon}
+          isDisabled={!isVerified}
+          isExternal
+          label="Buy"
+          variant="iconButtonSolid"
+        />
+        <Flex gap="24px">
+          <IconButtonWithText
+            icon={ArrowDownLeftIcon}
+            isDisabled={!isVerified}
+            label="Receive"
+            onClick={() => openWith(<AccountInfoModal account={currentAccount} />)}
+            variant="iconButtonSolid"
+          />
+          <SendTezButton />
+        </Flex>
+      </Flex>
+    </Box>
+  );
+};

--- a/apps/web/src/components/AccountCard/AccountCard.test.tsx
+++ b/apps/web/src/components/AccountCard/AccountCard.test.tsx
@@ -14,15 +14,12 @@ beforeEach(() => {
 });
 
 describe("<AccountCard />", () => {
-  it("renders account tile", () => {
+  it("renders account card", () => {
     render(<AccountCard />, { store });
 
     expect(screen.getByTestId("account-tile")).toBeVisible();
-  });
-
-  it("renders account balance", () => {
-    render(<AccountCard />, { store });
-
     expect(screen.getByTestId("account-balance")).toBeVisible();
+    expect(screen.getByTestId("balance-details")).toBeVisible();
+    expect(screen.getByTestId("account-buttons")).toBeVisible();
   });
 });

--- a/apps/web/src/components/AccountCard/AccountCard.tsx
+++ b/apps/web/src/components/AccountCard/AccountCard.tsx
@@ -7,6 +7,8 @@ import { SelectorIcon } from "../../assets/icons";
 import { useColor } from "../../styles/useColor";
 import { AccountSelectorModal } from "../AccountSelectorModal";
 import { AccountTile } from "../AccountTile";
+import { AccountBalanceDetails } from "./AccountBalanceDetails";
+import { AccountButtons } from "./AccountButtons"; // Import AccountButtons component
 
 export const AccountCard = () => {
   const color = useColor();
@@ -39,6 +41,8 @@ export const AccountCard = () => {
         />
       </AccountTile>
       <AccountBalance />
+      <AccountBalanceDetails />
+      <AccountButtons />
     </Card>
   );
 };

--- a/packages/components/src/components/AddressPill/AddressPillText.tsx
+++ b/packages/components/src/components/AddressPill/AddressPillText.tsx
@@ -22,5 +22,5 @@ export const AddressPillText = ({
     return <Text {...props}>{formattedPkh}</Text>;
   }
 
-  return <Text {...props}>{nameOrLabel ? truncate(nameOrLabel, 21) : formattedPkh}</Text>;
+  return <Text {...props}>{nameOrLabel ? truncate(nameOrLabel, 25) : formattedPkh}</Text>;
 };

--- a/packages/state/src/hooks/assets.test.ts
+++ b/packages/state/src/hooks/assets.test.ts
@@ -6,7 +6,7 @@ import {
   useBakerList,
   useGetAccountDelegate,
   useIsBlockFinalised,
-  useTotalBalance,
+  useSpendableBalanceOfAllAccounts,
 } from "./assets";
 import { assetsActions } from "../slices";
 import { type UmamiStore, makeStore } from "../store";
@@ -27,9 +27,9 @@ describe("useBakerList", () => {
   });
 });
 
-describe("useTotalBalance", () => {
+describe("useSpendableBalanceOfAllAccounts", () => {
   it("returns null if there are no balances", () => {
-    const { result } = renderHook(() => useTotalBalance(), { store });
+    const { result } = renderHook(() => useSpendableBalanceOfAllAccounts(), { store });
 
     expect(result.current).toBeNull();
   });
@@ -42,7 +42,7 @@ describe("useTotalBalance", () => {
       ])
     );
 
-    const { result } = renderHook(() => useTotalBalance(), { store });
+    const { result } = renderHook(() => useSpendableBalanceOfAllAccounts(), { store });
 
     expect(result.current).toEqual({ mutez: "1000000", usd: BigNumber("0.5") });
   });

--- a/packages/state/src/hooks/assets.ts
+++ b/packages/state/src/hooks/assets.ts
@@ -25,6 +25,7 @@ export const useGetAccountDelegate = () => {
   return (pkh: string) => getAccountState(pkh)?.delegate;
 };
 
+// returns spendable balance
 export const useGetAccountBalance = () => {
   const getAccountState = useGetAccountState();
 
@@ -113,8 +114,14 @@ export const useTezToDollar = () => {
   }
 
   // tezosBalance is in tez
-  return (tezosBalance: string): BigNumber =>
-    BigNumber(tezosBalance).multipliedBy(rate).decimalPlaces(2, BigNumber.ROUND_UP);
+  return (tezosBalanceTez: string): BigNumber =>
+    BigNumber(tezosBalanceTez).multipliedBy(rate).decimalPlaces(2, BigNumber.ROUND_UP);
+};
+
+export const useMutezToUsd = () => {
+  const tezToDollar = useTezToDollar();
+
+  return (tezosBalanceMutez: string) => tezToDollar(mutezToTez(tezosBalanceMutez).toFixed());
 };
 
 export const useGetDollarBalance = () => {
@@ -130,10 +137,10 @@ export const useGetDollarBalance = () => {
 };
 
 /**
- * @returns Total balance across all accounts in both mutez and USD
+ * @returns Total spendable balance across all accounts in both mutez and USD
  *          or null if there are no balances (not fetched yet, for example)
  */
-export const useTotalBalance = () => {
+export const useSpendableBalanceOfAllAccounts = () => {
   const accountStates = useGetAccountStates();
   const tezToDollar = useTezToDollar();
 

--- a/packages/state/src/hooks/staking.ts
+++ b/packages/state/src/hooks/staking.ts
@@ -1,6 +1,6 @@
 import { BigNumber } from "bignumber.js";
 
-import { useGetAccountState } from "./assets";
+import { useGetAccountBalance, useGetAccountState } from "./assets";
 import { useGetProtocolSettings } from "./protocolSettings";
 
 export const useGetAccountStakedBalance = (pkh: string) =>
@@ -15,8 +15,34 @@ export const useGetFirstFinalizableCycle = () => {
   return (requestedOnCycle: number) => requestedOnCycle + maxSlashingPeriod + consensusRightsDelay;
 };
 
+export const useGetAccountBalanceDetails = (pkh: string) => {
+  const spendableBalance = BigNumber(useGetAccountBalance()(pkh) ?? 0);
+  const stakedBalance = useGetAccountStakedBalance(pkh);
+  const totalFinalizableAmount = useAccountTotalFinalizableUnstakeAmount(pkh);
+  const totalPendingAmount = useAccountTotalPendingUnstakeAmount(pkh);
+  const totalBalance = spendableBalance
+    .plus(stakedBalance)
+    .plus(totalPendingAmount)
+    .plus(totalFinalizableAmount);
+  return {
+    spendableBalance,
+    stakedBalance,
+    totalFinalizableAmount,
+    totalPendingAmount,
+    totalBalance,
+  };
+};
+
 export const useAccountPendingUnstakeRequests = (pkh: string) =>
   useGetAccountUnstakeRequests(pkh).filter(req => req.status === "pending");
+
+export const useAccountTotalPendingUnstakeAmount = (pkh: string) => {
+  const unstakeRequests = useGetAccountUnstakeRequests(pkh);
+
+  return unstakeRequests
+    .filter(req => req.status === "pending")
+    .reduce((acc, req) => acc.plus(req.amount), BigNumber(0));
+};
 
 export const useAccountTotalFinalizableUnstakeAmount = (pkh: string) => {
   const unstakeRequests = useGetAccountUnstakeRequests(pkh);


### PR DESCRIPTION
## Proposed changes

[UMA-1037](https://linear.app/tezos/issue/UMA-1037)

Added detailed balance view:
- conversion rate next to the USD balance - always visible
- `Delegated to:` and `Baker name` - shown if delegated
- `Delegation: Inactive` - shown if no delegate and spendable balance is not equal to total balance
- `Spendable:` and value - shown if not equal to the total balance
- `Staked:` and value - shown if not 0
- `Frozen unstaked:` and value - shown if not 0
- `Finalizable:` and value - shown if not 0

The sum of all balance lines is equal to the total balance.

The main principle: the shown information is minimised depending on the account state.

## Types of changes

- [ ] Bugfix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] UI fix

## Steps to reproduce

Open main screen.
Play with stake/delegate/unstake

## Screenshots

Add the screenshots of how the app used to look like and how it looks now

Before:
The view is always the same:
 - spendable balance is shown
 - total balance is not shown
 - baker is not shown
 - balance details are not shown
 - conversion rate is not shown
<img width="700" alt="image" src="https://github.com/user-attachments/assets/decdd8ed-4042-40c1-b1b7-d1f73a920332" />

Updated screenshots:

| Status | Now |
| ------ | --- |
| New / 0 balance | <img width="400" alt="image" src="https://github.com/user-attachments/assets/e56f4cf6-3279-4ada-9448-3eec0006afa2" /> |
| Basic / not delegated  |  <img width="400" alt="image" src="https://github.com/user-attachments/assets/d49c67dc-e27b-4926-8f4c-05585d5ecb19" /> |
| Delegated | <img width="400" alt="image" src="https://github.com/user-attachments/assets/7c47b96c-e7c6-482f-b556-de035578e0e0" /> |
| Staked  | <img width="400" alt="image" src="https://github.com/user-attachments/assets/81af50bc-a3f8-4283-8f87-80afd9bb9c20" /> |
| Staked and unstaked |  <img width="400" alt="image" src="https://github.com/user-attachments/assets/bc506ac1-250c-4e77-9bfc-89804ded5e08" /> |
| Delegation ended after staking | <img width="400" alt="image" src="https://github.com/user-attachments/assets/8a7c8f7e-1ec4-4abf-add2-05bd98923063" /> |


## Checklist

- [ ] Tests that prove my fix is effective or that my feature works have been added
- [ ] Documentation has been added (if appropriate)
- [x] Screenshots are added (if any UI changes have been made)
- [ ] All TODOs have a corresponding task created (and the link is attached to it)
