### PR TITLE
[Umami mobile][UMA-1102] feat: Batch Request modal header

### DIFF
--- a/apps/desktop/src/components/SendFlow/Beacon/TezSignPage.tsx
+++ b/apps/desktop/src/components/SendFlow/Beacon/TezSignPage.tsx
@@ -19,7 +19,7 @@ export const TezSignPage = ({ operation, message }: BeaconSignPageProps) => {
 
   return (
     <FormProvider {...form}>
-      <ModalContent data-testId="TezSignPage">
+      <ModalContent data-testid="TezSignPage">
         <form>
           <Header message={message} mode="single" operation={operation} />
           <ModalBody>

--- a/apps/web/src/components/SendFlow/common/BatchSignPage.test.tsx
+++ b/apps/web/src/components/SendFlow/common/BatchSignPage.test.tsx
@@ -1,0 +1,126 @@
+import { BeaconMessageType, NetworkType, type OperationRequestOutput } from "@airgap/beacon-wallet";
+import type { BatchWalletOperation } from "@taquito/taquito/dist/types/wallet/batch-operation";
+import {
+  type EstimatedAccountOperations,
+  type Operation,
+  executeOperations,
+  mockContractCall,
+  mockImplicitAccount,
+  mockTezOperation,
+} from "@umami/core";
+import { WalletClient, makeStore, networksActions, useGetSecretKey } from "@umami/state";
+import { executeParams } from "@umami/test-utils";
+import { GHOSTNET, makeToolkit } from "@umami/tezos";
+
+import {
+  act,
+  dynamicModalContextMock,
+  renderInModal,
+  screen,
+  userEvent,
+  waitFor,
+} from "../../../testUtils";
+import { SuccessStep } from "../SuccessStep";
+import { type SdkSignPageProps, type SignHeaderProps } from "../utils";
+import { BatchSignPage } from "./BatchSignPage";
+import { Titles } from "../../Titles";
+
+jest.mock("@umami/core", () => ({
+  ...jest.requireActual("@umami/core"),
+  executeOperations: jest.fn(),
+  makeToolkit: jest.fn(),
+}));
+
+jest.mock("@umami/tezos", () => ({
+  ...jest.requireActual("@umami/tezos"),
+  makeToolkit: jest.fn(),
+}));
+
+jest.mock("@umami/state", () => ({
+  ...jest.requireActual("@umami/state"),
+  useGetSecretKey: jest.fn(),
+}));
+
+describe("<BatchSignPage />", () => {
+  it("calls the correct modal", async () => {
+    const store = makeStore();
+    const user = userEvent.setup();
+
+    const message = {
+      id: "messageid",
+      type: BeaconMessageType.OperationRequest,
+      network: { type: NetworkType.GHOSTNET },
+      appMetadata: { name: "mockDappName", icon: "mockIcon" },
+    } as OperationRequestOutput;
+
+    // check all types of Modals called by SingleSignOperation
+    const mockedOperations: Record<string, Operation> = {
+      TezSignPage: mockTezOperation(0),
+      ContractCallSignPage: mockContractCall(0),
+    };
+
+    const operation: EstimatedAccountOperations = {
+      type: "implicit" as const,
+      sender: mockImplicitAccount(0),
+      signer: mockImplicitAccount(0),
+      operations: [],
+      estimates: [executeParams({ fee: 123 })],
+    };
+    const headerProps: SignHeaderProps = {
+      network: GHOSTNET,
+      appName: message.appMetadata.name,
+      appIcon: message.appMetadata.icon,
+      requestId: { sdkType: "beacon", id: message.id },
+    };
+    store.dispatch(networksActions.setCurrent(GHOSTNET));
+
+    operation.operations = [
+      mockedOperations["TezSignPage"],
+      mockedOperations["ContractCallSignPage"],
+    ];
+    const signProps: SdkSignPageProps = {
+      headerProps: headerProps,
+      operation: operation,
+    };
+
+    jest.mocked(useGetSecretKey).mockImplementation(() => () => Promise.resolve("secretKey"));
+
+    jest.mocked(executeOperations).mockResolvedValue({ opHash: "ophash" } as BatchWalletOperation);
+    jest.spyOn(WalletClient, "respond").mockResolvedValue();
+
+    await renderInModal(<BatchSignPage {...signProps} />, store);
+
+    expect(screen.getByText("Ghostnet")).toBeInTheDocument();
+    expect(screen.queryByText("Mainnet")).not.toBeInTheDocument();
+    expect(screen.getByTestId("BatchSignPage")).toBeInTheDocument();
+
+    expect(screen.getByTestId("sign-page-header")).toHaveTextContent(Titles["BatchSignPage"]);
+    expect(screen.getByTestId("app-name")).toHaveTextContent("mockDappName");
+
+    const signButton = screen.getByRole("button", {
+      name: "Confirm Transaction",
+    });
+    await waitFor(() => expect(signButton).toBeDisabled());
+
+    await act(() => user.type(screen.getByLabelText("Password"), "ThisIsAPassword"));
+
+    await waitFor(() => expect(signButton).toBeEnabled());
+    await act(() => user.click(signButton));
+
+    expect(makeToolkit).toHaveBeenCalledWith({
+      type: "mnemonic",
+      secretKey: "secretKey",
+      network: GHOSTNET,
+    });
+
+    await waitFor(() =>
+      expect(WalletClient.respond).toHaveBeenCalledWith({
+        type: BeaconMessageType.OperationResponse,
+        id: message.id,
+        transactionHash: "ophash",
+      })
+    );
+    expect(dynamicModalContextMock.openWith).toHaveBeenCalledWith(<SuccessStep hash="ophash" />);
+    dynamicModalContextMock.openWith.mockClear();
+  });
+});

--- a/apps/web/src/components/SendFlow/common/BatchSignPage.tsx
+++ b/apps/web/src/components/SendFlow/common/BatchSignPage.tsx
@@ -19,6 +19,7 @@ import { Header } from "./Header";
 import { useColor } from "../../../styles/useColor";
 import { AddressTile } from "../../AddressTile/AddressTile";
 import { JsValueWrap } from "../../JsValueWrap";
+import { Titles } from "../../Titles";
 import { useSignWithBeacon } from "../Beacon/useSignWithBeacon";
 import { SignButton } from "../SignButton";
 import { SignPageFee } from "../SignPageFee";
@@ -45,9 +46,9 @@ export const BatchSignPage = (
 
   return (
     <FormProvider {...form}>
-      <ModalContent>
+      <ModalContent data-testId="BatchSignPage">
         <form>
-          <Header headerProps={signProps.headerProps} />
+          <Header headerProps={signProps.headerProps} title={Titles.BatchSignPage} />
 
           <ModalBody>
             <Accordion allowToggle>

--- a/apps/web/src/components/SendFlow/common/ContractCallSignPage.tsx
+++ b/apps/web/src/components/SendFlow/common/ContractCallSignPage.tsx
@@ -20,7 +20,7 @@ import { AddressTile } from "../../AddressTile/AddressTile";
 import { AdvancedSettingsAccordion } from "../../AdvancedSettingsAccordion";
 import { TezTile } from "../../AssetTiles/TezTile";
 import { JsValueWrap } from "../../JsValueWrap";
-import { Titles } from "../../Titles/Titles";
+import { Titles } from "../../Titles";
 import { SignButton } from "../SignButton";
 import { SignPageFee } from "../SignPageFee";
 import { type CalculatedSignProps, type SdkSignPageProps } from "../utils";

--- a/apps/web/src/components/SendFlow/common/DelegationSignPage.tsx
+++ b/apps/web/src/components/SendFlow/common/DelegationSignPage.tsx
@@ -5,7 +5,7 @@ import { FormProvider, useForm } from "react-hook-form";
 import { Header } from "./Header";
 import { AddressTile } from "../../AddressTile/AddressTile";
 import { AdvancedSettingsAccordion } from "../../AdvancedSettingsAccordion";
-import { Titles } from "../../Titles/Titles";
+import { Titles } from "../../Titles";
 import { SignButton } from "../SignButton";
 import { SignPageFee } from "../SignPageFee";
 import { type CalculatedSignProps, type SdkSignPageProps } from "../utils";

--- a/apps/web/src/components/SendFlow/common/FinalizeUnstakeSignPage.tsx
+++ b/apps/web/src/components/SendFlow/common/FinalizeUnstakeSignPage.tsx
@@ -5,7 +5,7 @@ import { FormProvider, useForm } from "react-hook-form";
 import { Header } from "./Header";
 import { AddressTile } from "../../AddressTile/AddressTile";
 import { TezTile } from "../../AssetTiles/TezTile";
-import { Titles } from "../../Titles/Titles";
+import { Titles } from "../../Titles";
 import { SignButton } from "../SignButton";
 import { SignPageFee } from "../SignPageFee";
 import { type CalculatedSignProps, type SdkSignPageProps } from "../utils";

--- a/apps/web/src/components/SendFlow/common/OriginationOperationSignPage.tsx
+++ b/apps/web/src/components/SendFlow/common/OriginationOperationSignPage.tsx
@@ -20,7 +20,7 @@ import { SignButton } from "../SignButton";
 import { SignPageFee } from "../SignPageFee";
 import { type CalculatedSignProps, type SdkSignPageProps } from "../utils";
 import { Header } from "./Header";
-import { Titles } from "../../Titles/Titles";
+import { Titles } from "../../Titles";
 
 export const OriginationOperationSignPage = ({
   operation,

--- a/apps/web/src/components/SendFlow/common/StakeSignPage.tsx
+++ b/apps/web/src/components/SendFlow/common/StakeSignPage.tsx
@@ -5,7 +5,7 @@ import { FormProvider, useForm } from "react-hook-form";
 import { Header } from "./Header";
 import { AddressTile } from "../../AddressTile/AddressTile";
 import { TezTile } from "../../AssetTiles/TezTile";
-import { Titles } from "../../Titles/Titles";
+import { Titles } from "../../Titles";
 import { SignButton } from "../SignButton";
 import { SignPageFee } from "../SignPageFee";
 import { type CalculatedSignProps, type SdkSignPageProps } from "../utils";

--- a/apps/web/src/components/SendFlow/common/TezSignPage.tsx
+++ b/apps/web/src/components/SendFlow/common/TezSignPage.tsx
@@ -6,7 +6,7 @@ import { Header } from "./Header";
 import { AddressTile } from "../../AddressTile/AddressTile";
 import { AdvancedSettingsAccordion } from "../../AdvancedSettingsAccordion";
 import { TezTile } from "../../AssetTiles/TezTile";
-import { Titles } from "../../Titles/Titles";
+import { Titles } from "../../Titles";
 import { SignButton } from "../SignButton";
 import { SignPageFee } from "../SignPageFee";
 import { type CalculatedSignProps, type SdkSignPageProps } from "../utils";

--- a/apps/web/src/components/SendFlow/common/UndelegationSignPage.tsx
+++ b/apps/web/src/components/SendFlow/common/UndelegationSignPage.tsx
@@ -4,7 +4,7 @@ import { FormProvider, useForm } from "react-hook-form";
 import { Header } from "./Header";
 import { AddressTile } from "../../AddressTile/AddressTile";
 import { AdvancedSettingsAccordion } from "../../AdvancedSettingsAccordion";
-import { Titles } from "../../Titles/Titles";
+import { Titles } from "../../Titles";
 import { SignButton } from "../SignButton";
 import { SignPageFee } from "../SignPageFee";
 import { type CalculatedSignProps, type SdkSignPageProps } from "../utils";

--- a/apps/web/src/components/SendFlow/common/UnstakeSignPage.tsx
+++ b/apps/web/src/components/SendFlow/common/UnstakeSignPage.tsx
@@ -5,7 +5,7 @@ import { FormProvider, useForm } from "react-hook-form";
 import { Header } from "./Header";
 import { AddressTile } from "../../AddressTile/AddressTile";
 import { TezTile } from "../../AssetTiles/TezTile";
-import { Titles } from "../../Titles/Titles";
+import { Titles } from "../../Titles";
 import { SignButton } from "../SignButton";
 import { SignPageFee } from "../SignPageFee";
 import { type CalculatedSignProps, type SdkSignPageProps } from "../utils";

--- a/apps/web/src/components/Titles/Titles.tsx
+++ b/apps/web/src/components/Titles/Titles.tsx
@@ -7,4 +7,5 @@ export const Titles: Record<string, string> = {
   StakeSignPage: "Stake Request",
   UnstakeSignPage: "Unstake Request",
   FinalizeUnstakeSignPage: "Finalize Unstake Request",
+  BatchSignPage: "Batch Request",
 };

--- a/apps/web/src/components/Titles/index.ts
+++ b/apps/web/src/components/Titles/index.ts
@@ -1,0 +1,1 @@
+export * from "./Titles";


### PR DESCRIPTION
## Proposed changes

[UMA-1102](https://linear.app/tezos/issue/UMA-1102/walletconnect-bug-header-not-set-for-batch-operation) WalletConnect bug: header not set for batch operation

## Types of changes

- [ ] Bugfix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] UI fix

## Steps to reproduce

1. Connect kukai wallet
2. run batch operation


## Screenshots

Add the screenshots of how the app used to look like and how it looks now

| Before | Now |
| ------ | --- |
| <img width="445" alt="image" src="https://github.com/user-attachments/assets/7d728438-eaae-4544-b745-131bb9497dbe" /> | <img width="447" alt="image" src="https://github.com/user-attachments/assets/c573c407-c9b1-4634-bc53-ad26f3696766" /> |

## Checklist

- [x] Tests that prove my fix is effective or that my feature works have been added
- [ ] Documentation has been added (if appropriate)
- [x] Screenshots are added (if any UI changes have been made)
- [ ] All TODOs have a corresponding task created (and the link is attached to it)
