### PR TITLE
[Web][UMA-1115] WC bug: retry on failed notification to dApp

### DIFF
--- a/apps/web/src/components/SendFlow/SuccessStep.tsx
+++ b/apps/web/src/components/SendFlow/SuccessStep.tsx
@@ -1,5 +1,6 @@
 import {
   Button,
+  Card,
   Center,
   Heading,
   Icon,
@@ -13,37 +14,75 @@ import { useDynamicModalContext } from "@umami/components";
 import { useSelectedNetwork } from "@umami/state";
 import { useNavigate } from "react-router-dom";
 
-import { CheckCircleIcon, ExternalLinkIcon } from "../../assets/icons";
+import { AlertTriangleIcon, CheckCircleIcon, ExternalLinkIcon } from "../../assets/icons";
 import { useColor } from "../../styles/useColor";
 import { ModalCloseButton } from "../CloseButton";
 
-export const SuccessStep = ({ hash }: { hash: string }) => {
+export const SuccessStep = ({
+  hash,
+  dAppNotificationError,
+}: {
+  hash: string;
+  dAppNotificationError?: string;
+}) => {
   const network = useSelectedNetwork();
   const tzktUrl = `${network.tzktExplorerUrl}/${hash}`;
   const { onClose } = useDynamicModalContext();
   const navigate = useNavigate();
   const color = useColor();
 
+  type StepData = [React.ElementType, string, string];
+
+  const getIconAndHeader = (): StepData => {
+    if (dAppNotificationError) {
+      return [AlertTriangleIcon, color("orange"), "Operation Submitted but dApp Not Notified"];
+    }
+
+    return [CheckCircleIcon, color("green"), "Operation Submitted"];
+  };
+
+  const Message = () => {
+    const successText =
+      "You can follow this operation's progress in the Operations section. It may take up to 30 seconds to appear.";
+
+    if (dAppNotificationError) {
+      return (
+        <>
+          <Text size="md">
+            Transaction was performed successfully and stored on the blockchain. However, the dApp
+            was not notified.
+          </Text>
+          <Text marginTop="12px" size="md">
+            <strong>Do not retry this operation</strong> — it has already been completed. You may
+            need to reload the dApp page to see the updated status.
+          </Text>
+          <Text marginTop="12px" size="md">
+            <strong>Error on dApp notification:</strong> {dAppNotificationError}
+          </Text>
+          <Text marginTop="12px" size="md">
+            {successText}
+          </Text>
+        </>
+      );
+    } else {
+      return <Text size="md">successText</Text>;
+    }
+  };
+
+  const [icon, iconColor, heading] = getIconAndHeader();
+
   return (
     <ModalContent paddingY="20px">
       <ModalHeader textAlign="center">
         <ModalCloseButton />
         <Center flexDirection="column">
-          <Icon as={CheckCircleIcon} boxSize="24px" marginBottom="18px" color={color("green")} />
-          <Heading marginBottom="12px" size="xl">
-            Operation Submitted
+          <Icon as={icon} boxSize="24px" marginBottom="18px" color={iconColor} />
+          <Heading marginTop="24px" marginBottom="24px" size="xl">
+            {heading}
           </Heading>
-          <Text
-            maxWidth="340px"
-            color={color("700")}
-            fontWeight="400"
-            whiteSpace="break-spaces"
-            size="md"
-          >
-            {
-              "You can follow this operation's progress\n in the Operations section. It may take up to 30 seconds to appear."
-            }
-          </Text>
+          <Card maxWidth="340px" color={color("700")} fontWeight="400" whiteSpace="pre-line">
+            <Message />
+          </Card>
         </Center>
       </ModalHeader>
       <ModalBody gap="24px">


### PR DESCRIPTION
## Proposed changes

[UMA-1115](https://linear.app/tezos/issue/UMA-1115)

If the tx confirmation to the WC server failed (e.g. the dApp has disconnected), wallet allows to click Confirm over and over again performing the same operation!

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] UI fix

## Steps to reproduce

Added exception in packages/state/src/hooks/useAsyncActionHandler.ts:
```
          await walletKit.respondSessionRequest({ topic: requestId.topic, response });
          throw new CustomError("dApp was not notified test message");
```


## Screenshots

Add the screenshots of how the app used to look like and how it looks now

| Before | Now |
| ------ | --- |
| <img width="313" alt="image" src="https://github.com/user-attachments/assets/74bc3a1f-5874-4e26-9d38-fd5a8c8e8f7e" /> | <img width="400" alt="image" src="https://github.com/user-attachments/assets/06248cbd-8076-44b7-be63-c72a85504c6e" /> |

## Checklist

- [ ] Tests that prove my fix is effective or that my feature works have been added
- [ ] Documentation has been added (if appropriate)
- [x] Screenshots are added (if any UI changes have been made)
- [ ] All TODOs have a corresponding task created (and the link is attached to it)
