### PR TITLE
[Web][UMA-1116][UMA-1046] WallectConnect validates proposals and requests

### DIFF
--- a/apps/web/src/components/SendFlow/WalletConnect/useSignWithWalletConnect.tsx
+++ b/apps/web/src/components/SendFlow/WalletConnect/useSignWithWalletConnect.tsx
@@ -1,7 +1,12 @@
 import { type TezosToolkit } from "@taquito/taquito";
 import { useDynamicModalContext } from "@umami/components";
 import { executeOperations, totalFee } from "@umami/core";
-import { useAsyncActionHandler, walletKit } from "@umami/state";
+import {
+  WcScenarioType,
+  useAsyncActionHandler,
+  useValidateWcRequest,
+  walletKit,
+} from "@umami/state";
 import { getErrorContext } from "@umami/utils";
 import { formatJsonRpcResult } from "@walletconnect/jsonrpc-utils";
 import { useForm } from "react-hook-form";
@@ -14,7 +19,8 @@ export const useSignWithWalletConnect = ({
   headerProps,
 }: SdkSignPageProps): CalculatedSignProps => {
   const { isLoading: isSigning, handleAsyncAction } = useAsyncActionHandler();
-  const { openWith } = useDynamicModalContext();
+  const { openWith, goBack } = useDynamicModalContext();
+  const validateWcRequest = useValidateWcRequest();
 
   const form = useForm({ defaultValues: { executeParams: operation.estimates } });
   const requestId = headerProps.requestId;
@@ -31,6 +37,8 @@ export const useSignWithWalletConnect = ({
   const onSign = async (tezosToolkit: TezosToolkit) =>
     handleAsyncAction(
       async () => {
+        validateWcRequest("request", requestId.id, WcScenarioType.APPROVE, goBack);
+
         const { opHash } = await executeOperations(
           { ...operation, estimates: form.watch("executeParams") },
           tezosToolkit

--- a/apps/web/src/components/common/SignPayloadRequestModal.test.tsx
+++ b/apps/web/src/components/common/SignPayloadRequestModal.test.tsx
@@ -1,6 +1,13 @@
 import { SigningType } from "@airgap/beacon-wallet";
 import { mockImplicitAccount, mockMnemonicAccount } from "@umami/core";
-import { type UmamiStore, WalletClient, accountsActions, makeStore, walletKit } from "@umami/state";
+import {
+  type UmamiStore,
+  WalletClient,
+  accountsActions,
+  makeStore,
+  useValidateWcRequest,
+  walletKit,
+} from "@umami/state";
 import { encryptedMnemonic1 } from "@umami/test-utils";
 import { type JsonRpcResult } from "@walletconnect/jsonrpc-utils";
 
@@ -10,6 +17,7 @@ import { type SignPayloadProps } from "../SendFlow/utils";
 
 jest.mock("@umami/state", () => ({
   ...jest.requireActual("@umami/state"),
+  useValidateWcRequest: jest.fn(),
   walletKit: {
     core: {},
     metadata: {
@@ -98,6 +106,7 @@ describe("<SignPayloadRequestModal />", () => {
 
   it("WalletConnect sends the signed payload back to the DApp", async () => {
     const user = userEvent.setup();
+    jest.mocked(useValidateWcRequest).mockImplementation(() => () => true);
     jest.spyOn(walletKit, "respondSessionRequest");
     await renderInModal(<SignPayloadRequestModal opts={wcOpts} />, store);
 

--- a/apps/web/src/components/common/SignPayloadRequestModal.tsx
+++ b/apps/web/src/components/common/SignPayloadRequestModal.tsx
@@ -16,7 +16,7 @@ import {
 import { type TezosToolkit } from "@taquito/taquito";
 import { useDynamicModalContext } from "@umami/components";
 import { decodeBeaconPayload } from "@umami/core";
-import { WalletClient, walletKit } from "@umami/state";
+import { WalletClient, WcScenarioType, useValidateWcRequest, walletKit } from "@umami/state";
 import { formatJsonRpcResult } from "@walletconnect/jsonrpc-utils";
 import { useState } from "react";
 import { FormProvider, useForm } from "react-hook-form";
@@ -30,6 +30,7 @@ import { VerifyInfobox } from "../WalletConnect/VerifyInfobox";
 
 export const SignPayloadRequestModal = ({ opts }: { opts: SignPayloadProps }) => {
   const { goBack } = useDynamicModalContext();
+  const validateWcRequest = useValidateWcRequest();
   const toast = useToast();
   const form = useForm();
   const color = useColor();
@@ -52,6 +53,7 @@ export const SignPayloadRequestModal = ({ opts }: { opts: SignPayloadProps }) =>
       };
       await WalletClient.respond(response);
     } else {
+      validateWcRequest("request", opts.requestId.id, WcScenarioType.APPROVE, goBack);
       const response = formatJsonRpcResult(opts.requestId.id, { signature: result.prefixSig });
       await walletKit.respondSessionRequest({ topic: opts.requestId.topic, response });
     }

--- a/packages/state/src/hooks/WalletConnect.test.ts
+++ b/packages/state/src/hooks/WalletConnect.test.ts
@@ -1,0 +1,102 @@
+import { CustomError } from "@umami/utils";
+
+import {
+  WcScenarioType,
+  useDisconnectWalletConnectPeer,
+  useValidateWcRequest,
+} from "./WalletConnect";
+import { renderHook } from "../testUtils";
+import { walletKit } from "../walletConnect";
+
+jest.mock("../walletConnect", () => ({
+  ...jest.requireActual("../walletConnect"),
+  walletKit: {
+    disconnectSession: jest.fn(),
+    getPendingSessionProposals: jest.fn(),
+    getPendingSessionRequests: jest.fn(),
+  },
+}));
+
+jest.mock("./WalletConnect", () => ({
+  ...jest.requireActual("./WalletConnect"),
+  useToggleWcPeerListUpdated: jest.fn(),
+}));
+
+describe("useDisconnectWalletConnectPeer", () => {
+  it("should call disconnectSession and togglePeerListUpdated", async () => {
+    walletKit.disconnectSession = jest.fn().mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useDisconnectWalletConnectPeer());
+    await result.current({
+      topic: "test",
+      reason: {
+        code: 123,
+        message: "test error message",
+      },
+    });
+
+    expect(walletKit.disconnectSession).toHaveBeenCalledWith({
+      topic: "test",
+      reason: {
+        code: 123,
+        message: "test error message",
+      },
+    });
+  });
+});
+
+describe("useValidateWcRequest for proposals", () => {
+  it("should return true if the proposal exists", () => {
+    walletKit.getPendingSessionProposals = jest
+      .fn()
+      .mockReturnValue([{ id: 123, topic: "test", params: {}, verifyContext: {} }]);
+
+    const { result } = renderHook(() => useValidateWcRequest());
+    expect(result.current("session proposal", 123, WcScenarioType.APPROVE, jest.fn())).toBe(true);
+  });
+
+  it("should return false and call goBack if the proposal does not exist (REJECT)", () => {
+    walletKit.getPendingSessionProposals = jest
+      .fn()
+      .mockReturnValue([{ id: 123, topic: "test", params: {}, verifyContext: {} }]);
+    const { result } = renderHook(() => useValidateWcRequest());
+    expect(result.current("session proposal", 999, WcScenarioType.REJECT, jest.fn())).toBe(false);
+  });
+
+  it("should throw an error if the proposal does not exist (APPROVE)", () => {
+    walletKit.getPendingSessionProposals = jest
+      .fn()
+      .mockReturnValue([{ id: 123, topic: "test", params: {}, verifyContext: {} }]);
+    const { result } = renderHook(() => useValidateWcRequest());
+    expect(() =>
+      result.current("session proposal", 999, WcScenarioType.APPROVE, jest.fn())
+    ).toThrow(CustomError);
+  });
+});
+
+describe("useValidateWcRequest for requests", () => {
+  it("should return true if the request exists", () => {
+    walletKit.getPendingSessionRequests = jest
+      .fn()
+      .mockReturnValue([{ id: 456, topic: "test", params: {}, verifyContext: {} }]);
+
+    const { result } = renderHook(() => useValidateWcRequest());
+    expect(result.current("request", 456, WcScenarioType.APPROVE, jest.fn())).toBe(true);
+  });
+
+  it("should return false and call goBack if the request does not exist (REJECT)", () => {
+    walletKit.getPendingSessionRequests = jest.fn().mockReturnValue([]);
+
+    const { result } = renderHook(() => useValidateWcRequest());
+    expect(result.current("request", 999, WcScenarioType.REJECT, jest.fn())).toBe(false);
+  });
+
+  it("should throw an error if the request does not exist (APPROVE)", () => {
+    walletKit.getPendingSessionRequests = jest.fn().mockReturnValue([]);
+
+    const { result } = renderHook(() => useValidateWcRequest());
+    expect(() => result.current("request", 999, WcScenarioType.APPROVE, jest.fn())).toThrow(
+      CustomError
+    );
+  });
+});

--- a/packages/state/src/hooks/WalletConnect.ts
+++ b/packages/state/src/hooks/WalletConnect.ts
@@ -1,3 +1,4 @@
+import { WalletConnectError, WcErrorCode } from "@umami/utils";
 import { type ErrorResponse } from "@walletconnect/jsonrpc-utils";
 import { useDispatch } from "react-redux";
 
@@ -25,3 +26,49 @@ export const useDisconnectWalletConnectPeer = () => {
     console.log("WC session deleted on user request", params);
   };
 };
+
+export enum WcScenarioType {
+  APPROVE,
+  REJECT,
+}
+
+// if valid, returns true
+// if invalid:
+//  - on APPROVE, throws an error
+//  - on REJECT, returns false
+export const useValidateWcRequest =
+  () =>
+  (
+    type: "session proposal" | "request",
+    id: number,
+    scenario: WcScenarioType,
+    closeModalCallback: () => void
+  ) => {
+    let isValid = false;
+
+    if (type === "session proposal") {
+      const records = walletKit.getPendingSessionProposals();
+      isValid = Object.values(records).some(request => request.id === id);
+    } else {
+      walletKit.getPendingSessionRequests();
+      const records = walletKit.getPendingSessionRequests();
+      isValid = records.some(request => request.id === id);
+    }
+
+    if (!isValid) {
+      closeModalCallback();
+
+      if (scenario === WcScenarioType.APPROVE) {
+        console.warn(
+          `This ${type} is not valid anymore. Check the connection on the dApp side and retry.`
+        );
+        throw new WalletConnectError(
+          `This ${type} is not valid anymore. Check the connection on the dApp side and retry.`,
+          WcErrorCode.DAPP_NOTIFICATION_FAILED,
+          null
+        );
+      }
+      return false;
+    }
+    return true;
+  };

--- a/packages/utils/src/ErrorContext.test.ts
+++ b/packages/utils/src/ErrorContext.test.ts
@@ -77,6 +77,7 @@ describe("getErrorContext", () => {
     expect(context.description).toBe("Custom WC error message");
     expect(context.stacktrace).toBeDefined();
     expect(context.timestamp).toBeDefined();
+    expect(context.code).toBe(WcErrorCode.INTERNAL_ERROR);
   });
 
   it("should handle HttpErrorResponse instances", () => {

--- a/packages/utils/src/ErrorContext.ts
+++ b/packages/utils/src/ErrorContext.ts
@@ -69,8 +69,10 @@ export enum WcErrorCode {
   UNKNOWN_CURVE_FOR_PUBLIC_KEY = 4008,
   REJECTED_BY_CHAIN = 4009,
   DELEGATE_UNCHANGED = 4010,
-  UNKNOWN_ERROR = 4011,
+  DAPP_NOTIFICATION_FAILED = 4011,
   WALLET_BUSY = 4012,
+
+  UNKNOWN_ERROR = 4100,
 }
 
 // Converts a known L1 error message to a more user-friendly one


### PR DESCRIPTION
## Proposed changes

[UMA-1116](https://linear.app/tezos/issue/UMA-1116) Beacon and WalletConnect bug: tx confirmation is allowed after dApp has disconnected
[UMA-1046](https://linear.app/tezos/issue/UMA-1046) WalletConnect bug: wallet allows to confirm an expired request

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] UI fix

## Steps to reproduce

Request
1. connect dapp, e.g. https://taquito-test-dapp.pages.dev/
2. send request, e.g. send tez
3. wait till the modal opens on wallet; then disconnect dApp
4. try to reject or confirm the operation

Session proposal:
1. connect dapp, e.g. https://taquito-test-dapp.pages.dev/
2. wait till the modal opens on wallet; then disconnect dApp; open the QR code again
4. try to reject or confirm the session proposal

Another way to reproduce is wait for 5 minutes to make sure the request/proposal has expired.

## Screenshots

Add the screenshots of how the app used to look like and how it looks now

| Scenario | Before | Now |
| --- | --- | --- |
| Approve request, walletKit doesn't have this request | <img width="500" alt="image" src="https://github.com/user-attachments/assets/eb4392cd-afa3-45c2-8638-700c02572ac8" /> | <img width="500" alt="image" src="https://github.com/user-attachments/assets/cebefd22-73a7-4e32-aa93-a57e22ea8c8c" /> |
| Session Proposal, walletKit doesn't have this session on approval |   |  <img width="500" alt="image" src="https://github.com/user-attachments/assets/fec6ec82-22af-40f4-9acc-d829963d44a4" /> |
| Session Proposal, walletKit has this session but approval fails | <img width="245" alt="image" src="https://github.com/user-attachments/assets/ae7732e0-1e4f-4fd9-a2b8-099dd2493f75" /> |  <img width="500" alt="image" src="https://github.com/user-attachments/assets/a9019410-5a1a-4d47-99db-eddcac18930a" /> |
| Session Proposal, walletKit has session proposal but reject fails | <img width="448" alt="image" src="https://github.com/user-attachments/assets/f0d72b03-8e89-43cf-97b3-5d921e015495" /> |  |  
| Session Request rejected after dApp disconnected | <img width="424" alt="image" src="https://github.com/user-attachments/assets/f055dc08-73f0-4828-a115-b5395a57c671" /> No toast | <img width="262" alt="image" src="https://github.com/user-attachments/assets/c9197f9c-bde3-46e3-916b-e07fa2726043" /> |


## Checklist

- [x] Tests that prove my fix is effective or that my feature works have been added
- [ ] Documentation has been added (if appropriate)
- [x] Screenshots are added (if any UI changes have been made)
- [ ] All TODOs have a corresponding task created (and the link is attached to it)
