### PR TITLE
[Web][UMA-1105] WC and Beacon hang on unanswered request

### DIFF
--- a/apps/web/src/components/AccountCard/AccountBalance.tsx
+++ b/apps/web/src/components/AccountCard/AccountBalance.tsx
@@ -1,5 +1,4 @@
 import { Box, Flex, Text } from "@chakra-ui/react";
-import { useDynamicModalContext } from "@umami/components";
 import { useCurrentAccount, useGetAccountBalanceDetails, useMutezToUsd } from "@umami/state";
 import { prettyTezAmount } from "@umami/tezos";
 import { BigNumber } from "bignumber.js";
@@ -8,7 +7,6 @@ import { useColor } from "../../styles/useColor";
 
 export const AccountBalance = () => {
   const color = useColor();
-  useDynamicModalContext();
   const currentAccount = useCurrentAccount()!;
   const address = currentAccount.address.pkh;
   const mutezToDollar = useMutezToUsd();

--- a/apps/web/src/components/AccountCard/AccountCard.tsx
+++ b/apps/web/src/components/AccountCard/AccountCard.tsx
@@ -28,7 +28,7 @@ export const AccountCard = () => {
         background={color("100")}
         account={currentAccount}
         id="account-tile"
-        onClick={() => openWith(<AccountSelectorModal />)}
+        onClick={() => openWith(<AccountSelectorModal />, { canBeOverridden: true })}
       >
         <IconButton
           alignSelf="center"

--- a/apps/web/src/components/Header/Header.tsx
+++ b/apps/web/src/components/Header/Header.tsx
@@ -62,7 +62,7 @@ export const Header = () => {
         <AccountTile
           background={color("100")}
           account={currentAccount}
-          onClick={() => openWith(<AccountSelectorModal />)}
+          onClick={() => openWith(<AccountSelectorModal />, { canBeOverridden: true })}
           size="xs"
         />
       </SlideFade>

--- a/apps/web/src/components/SendFlow/Beacon/useSignWithBeacon.tsx
+++ b/apps/web/src/components/SendFlow/Beacon/useSignWithBeacon.tsx
@@ -37,7 +37,7 @@ export const useSignWithBeacon = ({
         };
         await WalletClient.respond(response);
 
-        return openWith(<SuccessStep hash={opHash} />);
+        return openWith(<SuccessStep hash={opHash} />, { canBeOverridden: true });
       },
       (error: any) => {
         const context = getErrorContext(error);

--- a/apps/web/src/components/SendFlow/WalletConnect/useSignWithWalletConnect.tsx
+++ b/apps/web/src/components/SendFlow/WalletConnect/useSignWithWalletConnect.tsx
@@ -45,12 +45,13 @@ export const useSignWithWalletConnect = ({
         } catch (error: any) {
           const errorContext = getErrorContext(error);
           await openWith(
-            <SuccessStep dAppNotificationError={errorContext.description} hash={opHash} />
+            <SuccessStep dAppNotificationError={errorContext.description} hash={opHash} />,
+            { canBeOverridden: true }
           );
           error.processed = true; // no toast for this error
           throw error;
         }
-        return openWith(<SuccessStep hash={opHash} />);
+        return openWith(<SuccessStep hash={opHash} />, { canBeOverridden: true });
       },
       (error: { message: any }) => ({
         description: `Failed to perform WalletConnect operation: ${error.message}`,

--- a/apps/web/src/components/SendFlow/common/BatchSignPage.test.tsx
+++ b/apps/web/src/components/SendFlow/common/BatchSignPage.test.tsx
@@ -120,7 +120,9 @@ describe("<BatchSignPage />", () => {
         transactionHash: "ophash",
       })
     );
-    expect(dynamicModalContextMock.openWith).toHaveBeenCalledWith(<SuccessStep hash="ophash" />);
+    expect(dynamicModalContextMock.openWith).toHaveBeenCalledWith(<SuccessStep hash="ophash" />, {
+      canBeOverridden: true,
+    });
     dynamicModalContextMock.openWith.mockClear();
   });
 });

--- a/apps/web/src/components/SendFlow/common/OriginationOperationSignPage.test.tsx
+++ b/apps/web/src/components/SendFlow/common/OriginationOperationSignPage.test.tsx
@@ -102,6 +102,8 @@ describe("<OriginationOperationSignPage />", () => {
         transactionHash: "ophash",
       })
     );
-    expect(dynamicModalContextMock.openWith).toHaveBeenCalledWith(<SuccessStep hash="ophash" />);
+    expect(dynamicModalContextMock.openWith).toHaveBeenCalledWith(<SuccessStep hash="ophash" />, {
+      canBeOverridden: true,
+    });
   });
 });

--- a/apps/web/src/components/SendFlow/common/SingleSignPage.test.tsx
+++ b/apps/web/src/components/SendFlow/common/SingleSignPage.test.tsx
@@ -143,7 +143,9 @@ describe("<SingleSignPage />", () => {
           transactionHash: "ophash",
         })
       );
-      expect(dynamicModalContextMock.openWith).toHaveBeenCalledWith(<SuccessStep hash="ophash" />);
+      expect(dynamicModalContextMock.openWith).toHaveBeenCalledWith(<SuccessStep hash="ophash" />, {
+        canBeOverridden: true,
+      });
       dynamicModalContextMock.openWith.mockClear();
     }
   });

--- a/apps/web/src/components/SendFlow/common/TezSignPage.test.tsx
+++ b/apps/web/src/components/SendFlow/common/TezSignPage.test.tsx
@@ -98,6 +98,8 @@ describe("<TezSignPage />", () => {
         transactionHash: "ophash",
       })
     );
-    expect(dynamicModalContextMock.openWith).toHaveBeenCalledWith(<SuccessStep hash="ophash" />);
+    expect(dynamicModalContextMock.openWith).toHaveBeenCalledWith(<SuccessStep hash="ophash" />, {
+      canBeOverridden: true,
+    });
   });
 });

--- a/apps/web/src/components/SendFlow/utils.tsx
+++ b/apps/web/src/components/SendFlow/utils.tsx
@@ -175,7 +175,7 @@ export const useSignPageHelpers = (
         { ...operations, estimates: form.watch("executeParams") },
         tezosToolkit
       );
-      await openWith(<SuccessStep hash={operation.opHash} />);
+      await openWith(<SuccessStep hash={operation.opHash} />, { canBeOverridden: true });
       return operation;
     });
 

--- a/apps/web/src/components/WalletConnect/SessionProposalModal.tsx
+++ b/apps/web/src/components/WalletConnect/SessionProposalModal.tsx
@@ -43,7 +43,7 @@ export const SessionProposalModal = ({
   const toggleWcPeerListUpdated = useToggleWcPeerListUpdated();
   const color = useColor();
 
-  const { onClose } = useDynamicModalContext();
+  const { goBack } = useDynamicModalContext();
   const { isLoading, handleAsyncAction } = useAsyncActionHandler();
 
   const verifyContext: Verify.Context = proposal.verifyContext;
@@ -82,13 +82,13 @@ export const SessionProposalModal = ({
       });
       console.log("WC session approved", session);
       toggleWcPeerListUpdated();
-      onClose();
+      goBack();
     });
 
   const onReject = () =>
     handleAsyncAction(async () => {
-      // close immediately assuming that the user wants to get rid of the modal
-      onClose();
+      // Close immediately assuming that the user wants to get rid of the modal
+      goBack();
       console.log("WC session rejected");
       await walletKit.rejectSession({
         id: proposal.id,

--- a/apps/web/src/components/beacon/PermissionRequestModal.tsx
+++ b/apps/web/src/components/beacon/PermissionRequestModal.tsx
@@ -43,7 +43,7 @@ export const PermissionRequestModal = ({ request }: { request: PermissionRequest
   const color = useColor();
   const addConnectionToBeaconSlice = useAddBeaconConnection();
   const getAccount = useGetImplicitAccount();
-  const { onClose } = useDynamicModalContext();
+  const { goBack } = useDynamicModalContext();
   const { handleAsyncAction } = useAsyncActionHandler();
   const form = useForm<{ address: string }>({
     mode: "onBlur",
@@ -69,7 +69,7 @@ export const PermissionRequestModal = ({ request }: { request: PermissionRequest
       await WalletClient.respond(response);
 
       addConnectionToBeaconSlice(request.senderId, account.address.pkh, request.network.type);
-    }).finally(onClose);
+    }).finally(goBack);
 
   return (
     <ModalContent>

--- a/packages/components/src/components/DynamicDisclosure/DynamicDisclosure.tsx
+++ b/packages/components/src/components/DynamicDisclosure/DynamicDisclosure.tsx
@@ -24,6 +24,7 @@ interface DynamicDisclosureContextType {
     props?: ThemingProps & {
       onClose?: () => void | Promise<void>;
       closeOnEsc?: boolean;
+      canBeOverridden?: boolean;
     }
   ) => Promise<void>;
   onClose: () => void;
@@ -31,6 +32,7 @@ interface DynamicDisclosureContextType {
   goBack: () => void;
   goToIndex: (index: number) => void;
   hasPrevious: boolean;
+  canBeOverridden: boolean;
   formValues: Record<string, any>;
   allFormValues: RefObject<Record<string, any>>;
 }
@@ -42,6 +44,7 @@ const defaultContextValue = {
   goToIndex: () => {},
   isOpen: false,
   hasPrevious: false,
+  canBeOverridden: false,
   formValues: {},
   allFormValues: { current: {} },
 };
@@ -64,6 +67,7 @@ type DisclosureStackItem = {
   props: ThemingProps & {
     onClose: () => void | Promise<void>;
     closeOnEsc?: boolean;
+    canBeOverridden?: boolean; // protects WalletConnect and Beacon modals from being overriden
   };
   formValues: Record<string, any>;
 };
@@ -89,6 +93,7 @@ export const useDynamicDisclosure = () => {
     props: ThemingProps & {
       onClose?: () => void | Promise<void>;
       closeOnEsc?: boolean;
+      canBeOverridden?: boolean;
     } = {}
   ) => {
     const onClose = () => {
@@ -146,6 +151,7 @@ export const useDynamicDisclosure = () => {
     formValues: currentItem?.formValues || {},
     hasPrevious: stackRef.current.length > 1,
     allFormValues,
+    canBeOverridden: !!currentItem?.props.canBeOverridden,
   };
 };
 

--- a/packages/utils/src/ErrorContext.ts
+++ b/packages/utils/src/ErrorContext.ts
@@ -70,6 +70,7 @@ export enum WcErrorCode {
   REJECTED_BY_CHAIN = 4009,
   DELEGATE_UNCHANGED = 4010,
   UNKNOWN_ERROR = 4011,
+  WALLET_BUSY = 4012,
 }
 
 // Converts a known L1 error message to a more user-friendly one


### PR DESCRIPTION
## Proposed changes

[UMA-1105](https://linear.app/tezos/issue/UMA-1105/beacon-and-walletconnect-bug-wallet-stops-reacting-on-requests-after) Beacon and WalletConnect bug: wallet stops reacting on requests after dApp connected with open request modal

WalletConnect is queueing the incoming requests. If the request modal gets hidden (e.g. by Beacon request or connection proposal modal), then WalletConnect will wait forever.

FIx: reject new requests (WC or Beacon, session proposals and requests) immediately if any modal is open (except for `SuccessStep`.

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] UI fix

## Steps to reproduce

Steps for WalletConnect on Umami web:

1. connect https://taquito-test-dapp.pages.dev/
3. confirm on wallet side
4. disconnect from wallet side (to be able to reconnect via a deep link alter on)
5. connect https://wc2.kukai.tech/?network=ghostnet
6. run some operation from Kukai and see the open modal on wallet
7. connect https://taquito-test-dapp.pages.dev/, select existing pairing to activate deep link
8. now wallet opens session proposal modal. confirm
9. kukai's modal disappeared
10. run operation from Taquito - wallet doesn't react
11. run operation from Kukai  - wallet doesn't react
 
Scenario 2 (even more probable):

1. connect[ https://taquito-test-dapp.pages.dev/](https://taquito-test-dapp.pages.dev/) with Beacon
2. connect[ https://wc2.kukai.tech/?network=ghostnet](https://wc2.kukai.tech/?network=ghostnet) with WalletConnect
3. send request from Kukai. See the modal open
4. send request from Taquito. See the new modal open. Confirm
5. WalletConnect request from Kukai is now stuck

Workaround:

- reload wallet page
- now modal from Taquito appears - confirm
- now modal from Kukai appears 2 times - confirm


Steps for Beacon on Umami desktop:

1. connect [https://www.fxhash.xyz](https://www.fxhash.xyz/marketplace/generative/0)
2. go https://www.fxhash.xyz/marketplace/generative/0
3. make collection offer for 0.1 tez --> the modal is open on desktop
4. connect [ManUtd](https://collectibles.manutd.com/claim/669011ffecbeff2b91d55c10) dApp --> closes request modal and allows to connect
5. try to make a new collection offer from fxhash --> no reaction on desktop

## Screenshots

Add the screenshots of how the app used to look like and how it looks now

| Scenario | Now |
| ------ | --- |
| WC request on top of WC request | it's ok. WalletConnect maintains internal queue |
| WC request on top of Beacon request | <img width="500" alt="image" src="https://github.com/user-attachments/assets/95dbffef-8534-4e20-8f73-e0e43c0b7b61" /> |
| Beacon request on top of WC request | <img width="500" alt="image" src="https://github.com/user-attachments/assets/04acda25-9ba6-4e1a-8266-7021c60cac4d" /> |
| Beacon request on top of Beacon request | <img width="500" alt="image" src="https://github.com/user-attachments/assets/6f3718ef-36e6-4874-9a3e-3e203c42d7a1" /> |
| WC session proposal on top of WC request | <img width="500" alt="image" src="https://github.com/user-attachments/assets/9081c3c4-1e22-4acd-b009-38e6a49c3700" /> |
| WC session proposal on top of WC proposal | <img width="500" alt="image" src="https://github.com/user-attachments/assets/1f28dec0-635f-4382-8a54-a25f1613fead" /> |
| WC session proposal on top of Beacon request | <img width="500" alt="image" src="https://github.com/user-attachments/assets/7a3bbcdb-2dd4-47d3-9db2-d7ab0c3fff91" /> |
| WC session proposal on top of Beacon session proposal | <img width="500" alt="image" src="https://github.com/user-attachments/assets/404bc70f-0a23-47c3-bd09-a9eda0f8c42d" /> |
| Beacon request on top of WC session proposal | <img width="500" alt="image" src="https://github.com/user-attachments/assets/6750ff04-8f11-463b-b705-6c5a6c7a6c6b" /> |
|WalletConnect request on top of Adding Account | <img width="500" alt="image" src="https://github.com/user-attachments/assets/244dcdbb-0725-44c0-966a-e24970b8b949" /> |


I will not check all combinations.
I cannot trigger deep link Beacon session proposal so cannot run it on top of anything else.
Requests on top of `SuccessStep` work normally. Nothing to show screenshot.

## Checklist

- [ ] Tests that prove my fix is effective or that my feature works have been added
- [ ] Documentation has been added (if appropriate)
- [x] Screenshots are added (if any UI changes have been made)
- [ ] All TODOs have a corresponding task created (and the link is attached to it)
