### PR TITLE
[Web][UMA-1068][UMA-1165] Fix Logic for having both - verified & unverified accs

### DIFF
--- a/apps/web/src/components/AccountSelectorModal/AccountSelectorModal.test.tsx
+++ b/apps/web/src/components/AccountSelectorModal/AccountSelectorModal.test.tsx
@@ -2,6 +2,7 @@ import {
   getAccountGroupLabel,
   mockLedgerAccount,
   mockMnemonicAccount,
+  mockSecretKeyAccount,
   mockSocialAccount,
 } from "@umami/core";
 import {
@@ -43,26 +44,29 @@ describe("<AccountSelectorModal />", () => {
   });
 
   it.each([
-    [
-      "mnemonic",
-      mockMnemonicAccount(0),
-      () => <DeriveMnemonicAccountModal account={mockMnemonicAccount(0)} />,
-    ],
-    ["ledger", mockLedgerAccount(1), () => <OnboardOptionsModal />],
-    ["social", mockSocialAccount(2), () => <OnboardOptionsModal />],
-  ])(
-    "open appropriate modal when clicking 'Add %s Account' button",
-    async (_, account, getModalComponent) => {
-      const user = userEvent.setup();
-      const accountLabel = getAccountGroupLabel(account);
-      const { openWith } = dynamicModalContextMock;
-      await renderInModal(<AccountSelectorModal />, store);
+    ["ledger", mockLedgerAccount(1)],
+    ["social", mockSocialAccount(2)],
+    ["secret_key", mockSecretKeyAccount(1)],
+  ])("doesn't have 'Derive account' button for %s group", async (_, account) => {
+    const accountLabel = getAccountGroupLabel(account);
 
-      await act(() => user.click(screen.getByLabelText(`Add ${accountLabel} account`)));
+    await renderInModal(<AccountSelectorModal />, store);
 
-      expect(openWith).toHaveBeenCalledWith(getModalComponent());
-    }
-  );
+    expect(screen.queryByLabelText(`Add ${accountLabel} account`)).not.toBeInTheDocument();
+  });
+
+  it("opens modal when clicking 'Derive account' button for mnemonic group", async () => {
+    const user = userEvent.setup();
+    const accountLabel = getAccountGroupLabel(mockMnemonicAccount(0));
+    const { openWith } = dynamicModalContextMock;
+
+    await renderInModal(<AccountSelectorModal />, store);
+
+    await act(() => user.click(screen.getByLabelText(`Add ${accountLabel} account`)));
+    expect(openWith).toHaveBeenCalledWith(
+      <DeriveMnemonicAccountModal account={mockMnemonicAccount(0)} />
+    );
+  });
 
   describe("when clicking 'Remove account group' button", () => {
     it.each([

--- a/apps/web/src/components/AccountSelectorModal/AccountSelectorModal.test.tsx
+++ b/apps/web/src/components/AccountSelectorModal/AccountSelectorModal.test.tsx
@@ -183,10 +183,20 @@ describe("<AccountSelectorModal />", () => {
       );
     });
 
-    it("does not render 'Add Account' button", async () => {
+    it("renders 'Add account' button", async () => {
       await renderInModal(<AccountSelectorModal />, store);
 
-      expect(screen.queryByText("Add account")).not.toBeInTheDocument();
+      expect(screen.queryByText("Add account")).toBeVisible();
+    });
+
+    it("opens appropriate modal when clicking 'Add Account' button", async () => {
+      const user = userEvent.setup();
+      const { openWith } = dynamicModalContextMock;
+      await renderInModal(<AccountSelectorModal />, store);
+
+      await act(() => user.click(screen.getByText("Add account")));
+
+      expect(openWith).toHaveBeenCalledWith(<OnboardOptionsModal />);
     });
   });
 });

--- a/apps/web/src/components/AccountSelectorModal/AccountSelectorModal.tsx
+++ b/apps/web/src/components/AccountSelectorModal/AccountSelectorModal.tsx
@@ -192,35 +192,29 @@ export const AccountSelectorModal = () => {
         margin="0"
         paddingX={{ base: "32px", md: "42px" }}
       >
-        {isVerified && (
-          <Flex
-            position="absolute"
-            top="-25px"
-            justifyContent="center"
-            width="full"
-            padding="8px"
-            background="white"
-            borderRadius="100px"
-            boxShadow={
-              showShadow
-                ? color(
-                    "0px -4px 10px 0px rgba(45, 55, 72, 0.10)",
-                    "0px -4px 10px 0px rgba(0, 0, 0, 0.20)"
-                  )
-                : "transparent"
-            }
-            transition="box-shadow 0.2s ease-in"
-            backdropFilter="blur(40px)"
-          >
-            <Button
-              width="full"
-              onClick={() => openWith(<OnboardOptionsModal />)}
-              variant="primary"
-            >
-              Add account
-            </Button>
-          </Flex>
-        )}
+        <Flex
+          position="absolute"
+          top="-25px"
+          justifyContent="center"
+          width="full"
+          padding="8px"
+          background="white"
+          borderRadius="100px"
+          boxShadow={
+            showShadow
+              ? color(
+                  "0px -4px 10px 0px rgba(45, 55, 72, 0.10)",
+                  "0px -4px 10px 0px rgba(0, 0, 0, 0.20)"
+                )
+              : "transparent"
+          }
+          transition="box-shadow 0.2s ease-in"
+          backdropFilter="blur(40px)"
+        >
+          <Button width="full" onClick={() => openWith(<OnboardOptionsModal />)} variant="primary">
+            Add account
+          </Button>
+        </Flex>
       </ModalFooter>
     </ModalContent>
   );

--- a/apps/web/src/components/AccountSelectorModal/AccountSelectorModal.tsx
+++ b/apps/web/src/components/AccountSelectorModal/AccountSelectorModal.tsx
@@ -74,20 +74,8 @@ export const AccountSelectorModal = () => {
 
   const groupedAccounts = groupBy(implicitAccounts, getAccountGroupLabel);
 
-  const handleDeriveAccount = (account?: ImplicitAccount) => {
-    if (!account) {
-      return;
-    }
-
-    switch (account.type) {
-      case "mnemonic":
-        return openWith(<DeriveMnemonicAccountModal account={account as MnemonicAccount} />);
-      case "social":
-      case "ledger":
-      case "secret_key":
-        return openWith(<OnboardOptionsModal />);
-    }
-  };
+  const showDeriveAccountButton = (account?: ImplicitAccount) =>
+    account && account.type === "mnemonic";
 
   const buttonLabel = (isLast: boolean) => (isLast ? "Remove & off-board" : "Remove");
   const description = (isLast: boolean, type: string) => {
@@ -155,14 +143,20 @@ export const AccountSelectorModal = () => {
                       size="sm"
                       variant="ghost"
                     />
-                    <IconButton
-                      color={color("500")}
-                      aria-label={`Add ${type} account`}
-                      icon={<PlusCircleIcon />}
-                      onClick={() => handleDeriveAccount(accounts[0])}
-                      size="sm"
-                      variant="ghost"
-                    />
+                    {showDeriveAccountButton(accounts[0]) && (
+                      <IconButton
+                        color={color("500")}
+                        aria-label={`Add ${type} account`}
+                        icon={<PlusCircleIcon />}
+                        onClick={() =>
+                          openWith(
+                            <DeriveMnemonicAccountModal account={accounts[0] as MnemonicAccount} />
+                          )
+                        }
+                        size="sm"
+                        variant="ghost"
+                      />
+                    )}
                   </Flex>
                 )}
               </Center>

--- a/apps/web/src/components/Menu/Menu.test.tsx
+++ b/apps/web/src/components/Menu/Menu.test.tsx
@@ -152,11 +152,115 @@ describe("<Menu />", () => {
 
       expect(screen.getByText("Advanced")).toBeVisible();
       expect(screen.queryByText("Address book")).not.toBeInTheDocument();
-      expect(screen.queryByText("Add account")).not.toBeInTheDocument();
+      expect(screen.queryByText("Add account")).toBeVisible();
       expect(screen.queryByText("Save backup")).not.toBeInTheDocument();
       expect(screen.queryByText("Apps")).not.toBeInTheDocument();
       expect(screen.getByText("Light mode")).toBeVisible();
       expect(screen.getByText("Log out")).toBeVisible();
+    });
+
+    it("opens Add account modal when Add account button is clicked", async () => {
+      const { openWith } = dynamicModalContextMock;
+      const user = userEvent.setup();
+      await renderInDrawer(<Menu />, store);
+
+      await user.click(screen.getByText("Add account"));
+
+      expect(openWith).toHaveBeenCalledWith(<OnboardOptionsModal />);
+    });
+  });
+
+  describe.each([
+    { selectedAccount: "verified", isVerifiedSelected: true },
+    { selectedAccount: "unverified", isVerifiedSelected: false },
+  ])("when user has both and $selectedAccount account is selected", ({ isVerifiedSelected }) => {
+    const unverifiedAccount = mockImplicitAccount(1);
+
+    beforeEach(() => {
+      addTestAccount(store, unverifiedAccount);
+      store.dispatch(
+        accountsActions.setIsVerified({
+          pkh: unverifiedAccount.address.pkh,
+          isVerified: false,
+        })
+      );
+      if (isVerifiedSelected) {
+        store.dispatch(accountsActions.setCurrent(account.address.pkh));
+      } else {
+        store.dispatch(accountsActions.setCurrent(unverifiedAccount.address.pkh));
+      }
+    });
+
+    it("renders menu items correctly", async () => {
+      await renderInDrawer(<Menu />, store);
+
+      expect(screen.getByText("Advanced")).toBeVisible();
+      expect(screen.getByText("Address book")).toBeVisible();
+      expect(screen.getByText("Add account")).toBeVisible();
+      expect(screen.getByText("Save backup")).toBeVisible();
+      expect(screen.getByText("Apps")).toBeVisible();
+      expect(screen.getByText("Light mode")).toBeVisible();
+      expect(screen.getByText("Log out")).toBeVisible();
+    });
+
+    it.each([
+      ["Advanced", AdvancedMenu],
+      ["Address book", AddressBookMenu],
+      ["Apps", AppsMenu],
+    ])("opens %s menu correctly", async (label, Component) => {
+      const user = userEvent.setup();
+      const { openWith } = dynamicDrawerContextMock;
+      jest.spyOn(walletKit, "getActiveSessions").mockImplementation(() => ({}));
+
+      await renderInDrawer(<Menu />, store);
+
+      await user.click(screen.getByText(label));
+      expect(openWith).toHaveBeenCalledWith(<Component />);
+    });
+
+    it("opens Log out menu correctly", async () => {
+      const user = userEvent.setup();
+      const { openWith } = dynamicModalContextMock;
+
+      await renderInDrawer(<Menu />, store);
+
+      await user.click(screen.getByText("Log out"));
+      expect(openWith).toHaveBeenCalledWith(<LogoutModal />);
+    });
+
+    it("calls downloadBackupFile function when Save Backup is clicked", async () => {
+      const user = userEvent.setup();
+      const mockDownloadBackupFile = jest.fn();
+      jest.mocked(useDownloadBackupFile).mockReturnValue(mockDownloadBackupFile);
+
+      await renderInDrawer(<Menu />, store);
+
+      await user.click(screen.getByText("Save backup"));
+
+      await user.type(screen.getByLabelText("Set password"), password);
+      await user.type(screen.getByLabelText("Confirm password"), password);
+      await user.click(screen.getByRole("button", { name: "Save backup" }));
+
+      expect(mockDownloadBackupFile).toHaveBeenCalled();
+    });
+
+    it("calls toggleColorMode function when Light mode is clicked", async () => {
+      const user = userEvent.setup();
+      await renderInDrawer(<Menu />, store);
+
+      await user.click(screen.getByText("Light mode"));
+
+      expect(useColorMode().toggleColorMode).toHaveBeenCalled();
+    });
+
+    it("opens Add Account modal when Add Account button is clicked", async () => {
+      const { openWith } = dynamicModalContextMock;
+      const user = userEvent.setup();
+      await renderInDrawer(<Menu />, store);
+
+      await user.click(screen.getByText("Add account"));
+
+      expect(openWith).toHaveBeenCalledWith(<OnboardOptionsModal />);
     });
   });
 });

--- a/apps/web/src/components/Menu/Menu.tsx
+++ b/apps/web/src/components/Menu/Menu.tsx
@@ -18,68 +18,68 @@ import {
   UserPlusIcon,
 } from "../../assets/icons";
 import { OnboardOptionsModal } from "../Onboarding/OnboardOptions";
-import { useIsAccountVerified } from "../Onboarding/VerificationFlow";
+import { useHasVerifiedAccounts } from "../Onboarding/VerificationFlow";
 
 export const Menu = () => {
   const { openWith: openModal } = useDynamicModalContext();
   const { openWith: openDrawer } = useDynamicDrawerContext();
   const { colorMode, toggleColorMode } = useColorMode();
-  const isVerified = useIsAccountVerified();
+  const hasVerified = useHasVerifiedAccounts();
   const saveBackup = useSaveBackup();
 
   const colorModeSwitchLabel = colorMode === "light" ? "Light mode" : "Dark mode";
 
-  const menuItemsForVerifiedUser = [
+  const advanced = {
+    label: "Advanced",
+    icon: <SettingsIcon />,
+    onClick: () => openDrawer(<AdvancedMenu />),
+    hasArrow: true,
+  };
+  const addressBook = {
+    label: "Address book",
+    icon: <BookIcon />,
+    onClick: () => openDrawer(<AddressBookMenu />),
+    hasArrow: true,
+  };
+  const addAccount = {
+    label: "Add account",
+    icon: <UserPlusIcon />,
+    onClick: () => openModal(<OnboardOptionsModal />),
+    hasArrow: false,
+  };
+  const backup = {
+    label: "Save backup",
+    icon: <DownloadIcon />,
+    onClick: saveBackup,
+    hasArrow: false,
+  };
+  const apps = {
+    label: "Apps",
+    icon: <CodeSandboxIcon />,
+    onClick: () => openDrawer(<AppsMenu />),
+    hasArrow: true,
+  };
+
+  const coreMenuItems = hasVerified
+    ? [advanced, addressBook, addAccount, backup, apps]
+    : [advanced, addAccount];
+
+  const themeMenuItems = [
     {
-      label: "Address book",
-      icon: <BookIcon />,
-      onClick: () => openDrawer(<AddressBookMenu />),
-      hasArrow: true,
-    },
-    {
-      label: "Add account",
-      icon: <UserPlusIcon />,
-      onClick: () => openModal(<OnboardOptionsModal />),
-    },
-    {
-      label: "Save backup",
-      icon: <DownloadIcon />,
-      onClick: saveBackup,
-    },
-    {
-      label: "Apps",
-      icon: <CodeSandboxIcon />,
-      onClick: () => openDrawer(<AppsMenu />),
-      hasArrow: true,
+      label: colorModeSwitchLabel,
+      icon: <MoonIcon />,
+      onClick: toggleColorMode,
+      rightElement: <Switch isChecked={colorMode === "dark"} onChange={toggleColorMode} />,
     },
   ];
 
-  const menuItems = [
-    [
-      {
-        label: "Advanced",
-        icon: <SettingsIcon />,
-        onClick: () => openDrawer(<AdvancedMenu />),
-        hasArrow: true,
-      },
-      ...(isVerified ? menuItemsForVerifiedUser : []),
-    ],
-    [
-      {
-        label: colorModeSwitchLabel,
-        icon: <MoonIcon />,
-        onClick: toggleColorMode,
-        rightElement: <Switch isChecked={colorMode === "dark"} onChange={toggleColorMode} />,
-      },
-    ],
-    [
-      {
-        label: "Log out",
-        icon: <LogoutIcon />,
-        onClick: () => openModal(<LogoutModal />),
-      },
-    ],
+  const logoutMenuItems = [
+    {
+      label: "Log out",
+      icon: <LogoutIcon />,
+      onClick: () => openModal(<LogoutModal />),
+    },
   ];
 
-  return <GenericMenu menuItems={menuItems} />;
+  return <GenericMenu menuItems={[coreMenuItems, themeMenuItems, logoutMenuItems]} />;
 };


### PR DESCRIPTION
## Proposed changes


- [Remove derive account button for non-mnemonic account groups](https://linear.app/tezos/issue/UMA-1068/account-groupsselector-button-should-probably-only-be-there-for-social)
- [Unify logic for verified & unverified accs](https://linear.app/tezos/issue/UMA-1165/unify-logic-for-verified-and-unverified-accs)

1. Reducing amount of states handled by the wallet:
- states before:
  - unverified only (simple menu)
  - verified + unverified (menu looks different from verified & unverified accs)
  - verified only (full menu)
- states now:
  - unverified only (simple menu)
  - 1+ verified account (full menu)

2. Adding new accounts is always allowed now

3. Derive account button is removed from non-mnemonic groups

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] UI fix

## Steps to reproduce

## Screenshots

Add the screenshots of how the app used to look like and how it looks now

| Before | Now |
| ------ | --- |
|        |     |

## Checklist

- [ ] Tests that prove my fix is effective or that my feature works have been added
- [ ] Documentation has been added (if appropriate)
- [ ] Screenshots are added (if any UI changes have been made)
- [ ] All TODOs have a corresponding task created (and the link is attached to it)
