### PR TITLE
[Web][UMA-1094] Remove native appearance of import backup input

### DIFF
--- a/apps/web/src/components/Onboarding/ImportWallet/ImportBackupTab.tsx
+++ b/apps/web/src/components/Onboarding/ImportWallet/ImportBackupTab.tsx
@@ -101,8 +101,7 @@ export const ImportBackupTab = () => {
                 ref(element);
                 inputRef.current = element;
               }}
-              width="0"
-              height="0"
+              display="none"
               accept=".json,application/JSON"
               data-testid="file-input"
               type="file"


### PR DESCRIPTION
## Proposed changes

[Task link](https://linear.app/tezos/issue/UMA-1094/add-backup-mobile-when-adding-backup-on-mobile-you-can-scroll-the)

## Types of changes

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] UI fix

## Steps to reproduce

## Screenshots

Add the screenshots of how the app used to look like and how it looks now

| Before | Now |
| ------ | --- |
|![image](https://github.com/user-attachments/assets/42f700b3-915c-4b91-b7fb-89df7852b2ae)|<img width="407" alt="image" src="https://github.com/user-attachments/assets/e8456dd6-3c8c-4df0-b7ff-44e2ab100570" />|

## Checklist

- [ ] Tests that prove my fix is effective or that my feature works have been added
- [ ] Documentation has been added (if appropriate)
- [x] Screenshots are added (if any UI changes have been made)
- [ ] All TODOs have a corresponding task created (and the link is attached to it)
