### PR TITLE
[Web][UMA-1066] Add fallback for tz symbol on iOS

### DIFF
--- a/apps/desktop/.eslintrc.js
+++ b/apps/desktop/.eslintrc.js
@@ -5,12 +5,4 @@ module.exports = {
     parser: "@typescript-eslint/parser",
     tsconfigRootDir: __dirname,
   },
-  overrides: [
-    {
-      files: ["*.ts", "*.tsx"],
-      rules: {
-        "import/no-unused-modules": "off",
-      },
-    },
-  ],
 };

--- a/apps/web/.eslintrc.cjs
+++ b/apps/web/.eslintrc.cjs
@@ -6,12 +6,4 @@ module.exports = {
     parser: "@typescript-eslint/parser",
     tsconfigRootDir: __dirname,
   },
-  overrides: [
-    {
-      files: ["*.ts", "*.tsx"],
-      rules: {
-        "import/no-unused-modules": "off",
-      },
-    },
-  ],
 };

--- a/packages/components/.eslintrc.cjs
+++ b/packages/components/.eslintrc.cjs
@@ -6,12 +6,4 @@ module.exports = {
     parser: "@typescript-eslint/parser",
     tsconfigRootDir: __dirname,
   },
-  overrides: [
-    {
-      files: ["*.ts", "*.tsx"],
-      rules: {
-        "import/no-unused-modules": "off",
-      },
-    },
-  ],
 };

--- a/packages/core/jest.config.ts
+++ b/packages/core/jest.config.ts
@@ -3,7 +3,8 @@ import type { Config } from "jest";
 
 const config: Config = {
   ...baseConfig,
-  testEnvironment: "node",
+  testEnvironment: "jsdom",
   rootDir: "./",
+  setupFiles: ["<rootDir>/src/setupTests.ts"],
 };
 export default config;

--- a/packages/core/src/setupTests.ts
+++ b/packages/core/src/setupTests.ts
@@ -1,0 +1,9 @@
+import { webcrypto } from "crypto";
+import { TextDecoder, TextEncoder } from "util";
+
+Object.defineProperties(global, {
+  crypto: { value: webcrypto, writable: true },
+  TextDecoder: { value: TextDecoder, writable: true },
+  TextEncoder: { value: TextEncoder, writable: true },
+  fetch: { value: jest.fn(), writable: true },
+});

--- a/packages/data-polling/.eslintrc.cjs
+++ b/packages/data-polling/.eslintrc.cjs
@@ -6,12 +6,4 @@ module.exports = {
     parser: "@typescript-eslint/parser",
     tsconfigRootDir: __dirname,
   },
-  overrides: [
-    {
-      files: ["*.ts", "*.tsx"],
-      rules: {
-        "import/no-unused-modules": "off",
-      },
-    },
-  ],
 };

--- a/packages/data-polling/jest.config.ts
+++ b/packages/data-polling/jest.config.ts
@@ -4,6 +4,7 @@ import type { Config } from "jest";
 const config: Config = {
   ...baseConfig,
   setupFilesAfterEnv: ["<rootDir>/src/setupTests.ts"],
+  testEnvironment: "jsdom",
   rootDir: "./",
 };
 export default config;

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -50,7 +50,10 @@ module.exports = {
     "@typescript-eslint/require-await": "warn",
     "@typescript-eslint/no-floating-promises": "warn",
     "@typescript-eslint/no-misused-promises": ["warn", { checksVoidReturn: { attributes: false } }],
-    "@typescript-eslint/no-unused-expressions": ["warn", { allowShortCircuit: true, allowTernary: true, enforceForJSX: true }],
+    "@typescript-eslint/no-unused-expressions": [
+      "warn",
+      { allowShortCircuit: true, allowTernary: true, enforceForJSX: true },
+    ],
     "@typescript-eslint/consistent-type-imports": ["error", { fixStyle: "inline-type-imports" }],
 
     "react/jsx-curly-brace-presence": ["warn", "never"],
@@ -106,16 +109,19 @@ module.exports = {
 
     "prefer-const": "warn",
     "arrow-body-style": ["warn", "as-needed"],
-    "curly": ["warn", "all"],
-    "eqeqeq": ["warn", "always"],
+    curly: ["warn", "all"],
+    eqeqeq: ["warn", "always"],
     "no-restricted-imports": [
-      "warn", {
-        "paths": [{
-          "name": "react",
-          "importNames": ["default"],
-          "message": "use `import { <...> } from 'react'` instead"
-        }]
-      }
+      "warn",
+      {
+        paths: [
+          {
+            name: "react",
+            importNames: ["default"],
+            message: "use `import { <...> } from 'react'` instead",
+          },
+        ],
+      },
     ],
     "no-duplicate-imports": "warn",
     "sort-imports": [
@@ -133,7 +139,7 @@ module.exports = {
   },
   overrides: [
     {
-      files: ["jest.config.ts", "vite.config.ts"],
+      files: ["jest.config.ts", "vite.config.ts", "*.ts", "*.tsx"],
       rules: {
         "import/no-unused-modules": "off",
       },

--- a/packages/multisig/.eslintrc.cjs
+++ b/packages/multisig/.eslintrc.cjs
@@ -6,12 +6,4 @@ module.exports = {
     parser: "@typescript-eslint/parser",
     tsconfigRootDir: __dirname,
   },
-  overrides: [
-    {
-      files: ["*.ts", "*.tsx"],
-      rules: {
-        "import/no-unused-modules": "off",
-      },
-    },
-  ],
 };

--- a/packages/multisig/jest.config.ts
+++ b/packages/multisig/jest.config.ts
@@ -3,7 +3,8 @@ import type { Config } from "jest";
 
 const config: Config = {
   ...baseConfig,
-  testEnvironment: "node",
+  testEnvironment: "jsdom",
+  setupFiles: ["<rootDir>/src/setupTests.ts"],
   rootDir: "./",
 };
 export default config;

--- a/packages/multisig/src/setupTests.ts
+++ b/packages/multisig/src/setupTests.ts
@@ -1,0 +1,9 @@
+import { webcrypto } from "crypto";
+import { TextDecoder, TextEncoder } from "util";
+
+Object.defineProperties(global, {
+  crypto: { value: webcrypto, writable: true },
+  TextDecoder: { value: TextDecoder, writable: true },
+  TextEncoder: { value: TextEncoder, writable: true },
+  fetch: { value: jest.fn(), writable: true },
+});

--- a/packages/social-auth/.eslintrc.cjs
+++ b/packages/social-auth/.eslintrc.cjs
@@ -6,12 +6,4 @@ module.exports = {
     parser: "@typescript-eslint/parser",
     tsconfigRootDir: __dirname,
   },
-  overrides: [
-    {
-      files: ["*.ts", "*.tsx"],
-      rules: {
-        "import/no-unused-modules": "off",
-      },
-    },
-  ],
 };

--- a/packages/state/.eslintrc.cjs
+++ b/packages/state/.eslintrc.cjs
@@ -5,12 +5,4 @@ module.exports = {
     parser: "@typescript-eslint/parser",
     tsconfigRootDir: __dirname,
   },
-  overrides: [
-    {
-      files: ["*.ts", "*.tsx"],
-      rules: {
-        "import/no-unused-modules": "off",
-      },
-    },
-  ],
 };

--- a/packages/tezos/jest.config.ts
+++ b/packages/tezos/jest.config.ts
@@ -4,8 +4,8 @@ import type { Config } from "jest";
 const config: Config = {
   ...baseConfig,
 
-  testEnvironment: "node",
-
+  testEnvironment: "jsdom",
+  setupFiles: ["<rootDir>/src/setupTests.ts"],
   rootDir: "./",
 };
 export default config;

--- a/packages/tezos/src/constants.test.ts
+++ b/packages/tezos/src/constants.test.ts
@@ -1,0 +1,24 @@
+import { TEZ } from "./constants";
+
+describe("TEZ", () => {
+  it("should return ꜩ by default", () => {
+    expect(TEZ).toBe("ꜩ");
+  });
+
+  it("should return XTZ for iOS", () => {
+    Object.defineProperty(navigator, "userAgent", {
+      value:
+        "Mozilla/5.0 (iPhone; CPU iPhone OS 14_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko)",
+    });
+
+    let constants: any;
+
+    // Need to isolate the module to make it use the mocked navigator before importing the constants
+    jest.isolateModules(() => {
+      // eslint-disable-next-line
+      constants = require("./constants");
+    });
+
+    expect(constants.TEZ).toBe("XTZ");
+  });
+});

--- a/packages/tezos/src/constants.ts
+++ b/packages/tezos/src/constants.ts
@@ -1,4 +1,9 @@
-export const TEZ = "ꜩ";
+const getTezSymbol = () => {
+  const isIOS = /iPad|iPhone|iPod/i.test(navigator.userAgent);
+  return isIOS ? "XTZ" : "ꜩ";
+};
+
+export const TEZ = getTezSymbol();
 export const TEZ_DECIMALS = 6;
 export const BLOCK_TIME = 10 * 1000; // 10 seconds
 

--- a/packages/tezos/src/constants.ts
+++ b/packages/tezos/src/constants.ts
@@ -1,4 +1,9 @@
 const getTezSymbol = () => {
+  // This is a workaround to avoid the error "navigator is not defined".
+  if (typeof navigator === "undefined") {
+    return "ꜩ";
+  }
+
   const isIOS = /iPad|iPhone|iPod/i.test(navigator.userAgent);
   return isIOS ? "XTZ" : "ꜩ";
 };

--- a/packages/tezos/src/setupTests.ts
+++ b/packages/tezos/src/setupTests.ts
@@ -1,0 +1,9 @@
+import { webcrypto } from "crypto";
+import { TextDecoder, TextEncoder } from "util";
+
+Object.defineProperties(global, {
+  crypto: { value: webcrypto, writable: true },
+  TextDecoder: { value: TextDecoder, writable: true },
+  TextEncoder: { value: TextEncoder, writable: true },
+  fetch: { value: jest.fn(), writable: true },
+});

--- a/packages/tzkt/jest.config.ts
+++ b/packages/tzkt/jest.config.ts
@@ -3,9 +3,8 @@ import type { Config } from "jest";
 
 const config: Config = {
   ...baseConfig,
-
-  testEnvironment: "node",
-
+  testEnvironment: "jsdom",
+  setupFilesAfterEnv: ["<rootDir>/src/setupTests.ts"],
   rootDir: "./",
 };
 export default config;

--- a/packages/tzkt/src/setupTests.ts
+++ b/packages/tzkt/src/setupTests.ts
@@ -1,0 +1,9 @@
+import { webcrypto } from "crypto";
+import { TextDecoder, TextEncoder } from "util";
+
+Object.defineProperties(global, {
+  crypto: { value: webcrypto, writable: true },
+  TextDecoder: { value: TextDecoder, writable: true },
+  TextEncoder: { value: TextEncoder, writable: true },
+  fetch: { value: jest.fn(), writable: true },
+});


### PR DESCRIPTION
## Proposed changes

[Task link 1](https://linear.app/tezos/issue/UMA-1066/account-card-balance-the-tez-symbol-doesnt-showload-correctly-tested)
[Task link 2](https://linear.app/tezos/issue/UMA-1061/activity-tab-on-iosmobile-the-tez-symbol-doesnt-showload-correctly)

Add XTZ as a fallback for ꜩ on IOS.

## Types of changes

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] UI fix
