### PR TITLE
[Web][UMA-1137] Design for SuccessStep when notification failed

### DIFF
--- a/apps/web/src/components/SendFlow/SuccessStep.test.tsx
+++ b/apps/web/src/components/SendFlow/SuccessStep.test.tsx
@@ -21,15 +21,10 @@ describe("<SuccessStep />", () => {
   it("renders warning message when dAppNotificationError is present", async () => {
     await renderInModal(<SuccessStep dAppNotificationError="testError" hash="testHash" />);
 
-    expect(screen.getByTestId("success-no-notify-text")).toHaveTextContent(
-      "Transaction was performed successfully and stored on the blockchain. However, the dApp was not notified."
-    );
     expect(screen.getByTestId("do-not-retry-text")).toHaveTextContent(
-      "Do not retry this operation — it has already been completed. You may need to reload the dApp page to see the updated status."
+      "Do not retry this operation; it has already been processed. You may need to reload the dApp to see the updated status."
     );
-    expect(screen.getByTestId("dapp-noticaition-error")).toHaveTextContent(
-      "Error on dApp notification: testError"
-    );
+    expect(screen.getByTestId("dapp-noticaition-error")).toHaveTextContent("testError");
     expect(screen.getByTestId("success-text")).toHaveTextContent(
       "You can follow this operation's progress in the Operations section. It may take up to 30 seconds to appear."
     );

--- a/apps/web/src/components/SendFlow/SuccessStep.tsx
+++ b/apps/web/src/components/SendFlow/SuccessStep.tsx
@@ -35,7 +35,7 @@ export const SuccessStep = ({
 
   const getIconAndHeader = (): StepData => {
     if (dAppNotificationError) {
-      return [AlertTriangleIcon, color("orange"), "Operation Submitted but dApp Not Notified"];
+      return [AlertTriangleIcon, color("red"), "Operation submitted but dApp not notified"];
     }
 
     return [CheckCircleIcon, color("green"), "Operation Submitted"];
@@ -48,16 +48,12 @@ export const SuccessStep = ({
     if (dAppNotificationError) {
       return (
         <>
-          <Text data-testid="success-no-notify-text" size="md">
-            Transaction was performed successfully and stored on the blockchain. However, the dApp
-            was not notified.
-          </Text>
           <Text marginTop="12px" data-testid="do-not-retry-text" size="md">
-            <strong>Do not retry this operation</strong> — it has already been completed. You may
-            need to reload the dApp page to see the updated status.
+            Do <strong>not</strong> retry this operation; it has already been processed. You may
+            need to reload the dApp to see the updated status.
           </Text>
           <Text marginTop="12px" data-testid="dapp-noticaition-error" size="md">
-            <strong>Error on dApp notification:</strong> {dAppNotificationError}
+            {dAppNotificationError}
           </Text>
           <Text marginTop="12px" data-testid="success-text" size="md">
             {successText}


### PR DESCRIPTION
## Proposed changes

[UMA-1137](https://linear.app/tezos/issue/UMA-1137/design-notification-to-dapp-failed)

## Types of changes

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] UI fix

## Steps to reproduce

Added exception in apps/web/src/components/SendFlow/WalletConnect/useSignWithWalletConnect.tsx:
```
          await walletKit.respondSessionRequest({ topic: requestId.topic, response });
          throw new CustomError("dApp was not notified test message");
```

## Screenshots

Add the screenshots of how the app used to look like and how it looks now

| Before | Now |
| ------ | --- |
| <img width="500" alt="image" src="https://github.com/user-attachments/assets/28ca9581-0588-41c6-9774-ea9ede53a3a7" /> | <img width="500" alt="image" src="https://github.com/user-attachments/assets/dc591bca-9d7c-4c64-bc09-8c586743402c" /> |

## Checklist

- [x] Tests that prove my fix is effective or that my feature works have been added
- [ ] Documentation has been added (if appropriate)
- [x] Screenshots are added (if any UI changes have been made)
- [ ] All TODOs have a corresponding task created (and the link is attached to it)
