### PR TITLE
[Web][UMA-1123] WalletConnect reports unsupported method correctly

### DIFF
--- a/packages/core/src/beaconUtils.ts
+++ b/packages/core/src/beaconUtils.ts
@@ -1,6 +1,6 @@
 import { type PartialTezosOperation, TezosOperationType } from "@airgap/beacon-wallet";
 import { isValidImplicitPkh, parseImplicitPkh, parsePkh } from "@umami/tezos";
-import { CustomError } from "@umami/utils";
+import { WalletConnectError, WcErrorCode } from "@umami/utils";
 
 import { type ImplicitAccount } from "./Account";
 import { type ImplicitOperations } from "./AccountOperations";
@@ -19,7 +19,7 @@ export const toAccountOperations = (
   signer: ImplicitAccount
 ): ImplicitOperations => {
   if (operationDetails.length === 0) {
-    throw new CustomError("Empty operation details!");
+    throw new WalletConnectError("Empty operation details!", WcErrorCode.INVALID_PARAMS, null);
   }
 
   const operations = operationDetails.map(operation =>
@@ -106,6 +106,10 @@ export const partialOperationToOperation = (
       };
     }
     default:
-      throw new CustomError(`Unsupported operation kind: ${partialOperation.kind}`);
+      throw new WalletConnectError(
+        `Unsupported operation kind: ${partialOperation.kind}`,
+        WcErrorCode.METHOD_UNSUPPORTED,
+        null
+      );
   }
 };


### PR DESCRIPTION
## Proposed changes

[UMA-1123](https://linear.app/tezos/issue/UMA-1123/walletconnect-bug-unsupported-method-is-reported-to-dapp-as)

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] UI fix

## Steps to reproduce

1. connect Tezos Provider Test dApp [PR#697](https://github.com/WalletConnect/web-examples/pull/697)
2. Run `Increase paid storage`
3. See the reported error

## Screenshots

Add the screenshots of how the app used to look like and how it looks now

| Before | Now |
| ------ | --- |
| <img width="300" alt="image" src="https://github.com/user-attachments/assets/c69a8788-0e21-42c2-b0ca-38c7d9e01654" /> | <img width="500" alt="image" src="https://github.com/user-attachments/assets/230c4e32-c99a-4454-ba40-3032a085e11d" /> |

## Checklist

- [ ] Tests that prove my fix is effective or that my feature works have been added
- [ ] Documentation has been added (if appropriate)
- [x] Screenshots are added (if any UI changes have been made)
- [ ] All TODOs have a corresponding task created (and the link is attached to it)
