### PR TITLE
[Web] [UMA-1070] Add button to hide whole mnemonic phrase

### DIFF
--- a/apps/web/src/components/MnemonicWord/MnemonicWord.tsx
+++ b/apps/web/src/components/MnemonicWord/MnemonicWord.tsx
@@ -7,17 +7,17 @@ import { useColor } from "../../styles/useColor";
 type MnemonicWordProps = {
   index: number;
   word?: string;
-  isHidden?: boolean;
   indexProps?: TextProps;
   autocompleteProps?: ComponentProps<typeof MnemonicAutocomplete>;
+  isHidden?: boolean;
 } & GridItemProps;
 
 export const MnemonicWord = ({
   index,
   word,
-  isHidden,
   autocompleteProps,
   indexProps,
+  isHidden,
   ...props
 }: MnemonicWordProps) => {
   const color = useColor();
@@ -41,14 +41,11 @@ export const MnemonicWord = ({
       {autocompleteProps && <MnemonicAutocomplete {...autocompleteProps} />}
       {word && (
         <Text
-          sx={{
-            WebkitTextSecurity: isHidden ? "disc" : "none",
-          }}
           paddingLeft={{ base: "22px", md: "26px" }}
           fontSize={{ base: "12px", md: "14px" }}
           fontWeight="medium"
         >
-          {isHidden ? "*******" : word}
+          {isHidden ? "•".repeat(6) : word}
         </Text>
       )}
     </GridItem>

--- a/apps/web/src/components/Onboarding/ImportWallet/SeedPhraseTab.tsx
+++ b/apps/web/src/components/Onboarding/ImportWallet/SeedPhraseTab.tsx
@@ -14,7 +14,7 @@ import {
   Text,
   useBreakpointValue,
 } from "@chakra-ui/react";
-import { useDynamicModalContext, useMultiForm } from "@umami/components";
+import { useDynamicModalContext, useMultiForm, useToggleMnemonic } from "@umami/components";
 import { useAsyncActionHandler } from "@umami/state";
 import { CustomError } from "@umami/utils";
 import { validateMnemonic } from "bip39";
@@ -22,7 +22,7 @@ import { range } from "lodash";
 import { useState } from "react";
 import { FormProvider, useFieldArray } from "react-hook-form";
 
-import { CloseIcon } from "../../../assets/icons";
+import { CloseIcon, EyeIcon, EyeOffIcon } from "../../../assets/icons";
 import { useColor } from "../../../styles/useColor";
 import { MnemonicWord } from "../../MnemonicWord";
 import { RadioButtons } from "../../RadioButtons";
@@ -47,6 +47,7 @@ export const SeedPhraseTab = () => {
   });
   const { openWith } = useDynamicModalContext();
   const [showBlur, setShowBlur] = useState(true);
+  const { isVisible, toggleMnemonic } = useToggleMnemonic();
 
   const {
     handleSubmit,
@@ -182,6 +183,7 @@ export const SeedPhraseTab = () => {
                     variant: "mnemonic",
                     placeholder: `word #${index + 1}`,
                     height: "40px",
+                    type: isVisible ? "text" : "password",
                   },
                 }}
                 index={index}
@@ -206,6 +208,7 @@ export const SeedPhraseTab = () => {
                       variant: "mnemonic",
                       placeholder: `word #${index + 1}`,
                       height: "40px",
+                      type: isVisible ? "text" : "password",
                     },
                   }}
                   index={index}
@@ -215,19 +218,32 @@ export const SeedPhraseTab = () => {
             })}
           </Center>
 
-          <Center>
+          <Flex gap="8px">
             <Button
               gap="8px"
               width="full"
               marginTop="16px"
               fontSize="14px"
+              isDisabled={showBlur}
               onClick={clearAll}
               variant="ghost"
             >
               <Icon as={CloseIcon} boxSize="18px" color={color("400")} />
               Clear All
             </Button>
-          </Center>
+            <Button
+              gap="8px"
+              width="full"
+              marginTop="16px"
+              fontSize="14px"
+              isDisabled={showBlur}
+              onClick={toggleMnemonic}
+              variant="ghost"
+            >
+              <Icon as={isVisible ? EyeOffIcon : EyeIcon} boxSize="18px" color={color("400")} />
+              {isVisible ? "Hide phrase" : "Show phrase"}
+            </Button>
+          </Flex>
 
           <Button
             marginTop="30px"

--- a/apps/web/src/components/Onboarding/VerificationFlow/RecordSeedphraseModal.tsx
+++ b/apps/web/src/components/Onboarding/VerificationFlow/RecordSeedphraseModal.tsx
@@ -11,8 +11,7 @@ import {
   ModalHeader,
   Text,
 } from "@chakra-ui/react";
-import { useDynamicModalContext } from "@umami/components";
-import { useState } from "react";
+import { useDynamicModalContext, useToggleMnemonic } from "@umami/components";
 
 import { VerifySeedphraseModal } from "./VerifySeedphraseModal";
 import { CopyIcon, EyeIcon, EyeOffIcon, KeyIcon } from "../../../assets/icons";
@@ -30,7 +29,8 @@ export const RecordSeedphraseModal = ({ seedPhrase }: CopySeedphraseModalProps) 
   const color = useColor();
   const { openWith } = useDynamicModalContext();
   const words = seedPhrase.split(" ");
-  const [isHidden, setIsHidden] = useState(true);
+
+  const { isVisible, toggleMnemonic } = useToggleMnemonic();
 
   return (
     <ModalContent>
@@ -69,7 +69,7 @@ export const RecordSeedphraseModal = ({ seedPhrase }: CopySeedphraseModalProps) 
               borderColor={color("100")}
               borderRadius="full"
               index={index}
-              isHidden={isHidden}
+              isHidden={!isVisible}
               word={word}
             />
           ))}
@@ -82,12 +82,12 @@ export const RecordSeedphraseModal = ({ seedPhrase }: CopySeedphraseModalProps) 
             fontSize="14px"
             fontWeight="400"
             leftIcon={
-              <Icon as={isHidden ? EyeOffIcon : EyeIcon} boxSize="18px" color={color("400")} />
+              <Icon as={isVisible ? EyeOffIcon : EyeIcon} boxSize="18px" color={color("400")} />
             }
-            onClick={() => setIsHidden(!isHidden)}
+            onClick={toggleMnemonic}
             variant="ghost"
           >
-            {isHidden ? "Show" : "Hide"} seed phrase
+            {isVisible ? "Hide" : "Show"} phrase
           </Button>
           <CopyButton
             gap="8px"

--- a/apps/web/src/components/Onboarding/VerificationFlow/VerifySeedphraseModal.tsx
+++ b/apps/web/src/components/Onboarding/VerificationFlow/VerifySeedphraseModal.tsx
@@ -93,7 +93,7 @@ export const VerifySeedphraseModal = ({ seedPhrase }: VerifySeedphraseModalProps
                           variant: "mnemonic",
                           placeholder: `word #${index + 1}`,
                           fontSize: { base: "12px", md: "18px" },
-                          paddingLeft: { base: "36px", md: "46px" },
+                          paddingLeft: { base: "31px", md: "46px" },
                           height: "48px",
                         },
                         listProps: {
@@ -110,7 +110,11 @@ export const VerifySeedphraseModal = ({ seedPhrase }: VerifySeedphraseModalProps
                         fontSize: { base: "12px", md: "18px" },
                       }}
                     />
-                    {error?.message && <FormErrorMessage>{error.message}</FormErrorMessage>}
+                    {error?.message && (
+                      <FormErrorMessage fontSize={{ base: "12px", md: "16px" }}>
+                        {error.message}
+                      </FormErrorMessage>
+                    )}
                   </FormControl>
                 );
               })}

--- a/apps/web/src/styles/theme.ts
+++ b/apps/web/src/styles/theme.ts
@@ -143,14 +143,14 @@ const theme = extendTheme({
               borderColor: "gray.900",
             },
             ":not(:placeholder-shown)": {
-              paddingRight: "32px",
+              paddingRight: "16px",
             },
             borderRadius: "34px",
             border: "1px solid",
             background: "none",
             borderColor: "gray.100",
             fontSize: { md: "14px", base: "12px" },
-            paddingLeft: { base: "32px", md: "38px" },
+            paddingLeft: { base: "30px", md: "40px" },
             paddingRight: "10px",
             _placeholder: {
               color: "gray.400",
@@ -375,6 +375,20 @@ const theme = extendTheme({
         },
       },
       variants: {
+        ghost: {
+          _disabled: {
+            color: "gray.300",
+            bg: "transparent",
+            "& svg": {
+              color: "gray.300",
+            },
+          },
+          _hover: {
+            _disabled: {
+              bg: "transparent",
+            },
+          },
+        },
         iconButton: {
           height: "34px",
           width: "34px",

--- a/packages/components/src/components/MnemonicAutocomplete/MnemonicAutocomplete.test.tsx
+++ b/packages/components/src/components/MnemonicAutocomplete/MnemonicAutocomplete.test.tsx
@@ -1,6 +1,5 @@
 import { FormControl, Text } from "@chakra-ui/react";
 import { FormProvider, useForm } from "react-hook-form";
-import { act } from "@testing-library/react";
 
 import { MnemonicAutocomplete } from "./MnemonicAutocomplete";
 import { fireEvent, render, screen, waitFor } from "../../testUtils";
@@ -136,58 +135,6 @@ describe("<MnemonicAutocomplete />", () => {
       fireEvent.mouseDown(screen.getByText("absent"));
 
       await waitFor(() => expect(input).toHaveValue("absent"));
-    });
-  });
-
-  describe("hide/show mnemonic button", () => {
-    it("shows eye icon button only when input has value", () => {
-      render(<Fixture />);
-      const input = screen.getByTestId("mnemonic-input");
-
-      expect(screen.queryByTestId("eye-icon")).not.toBeInTheDocument();
-      expect(screen.queryByTestId("eye-slash-icon")).not.toBeInTheDocument();
-
-      fireEvent.change(input, { target: { value: "test" } });
-      expect(screen.getByTestId("eye-icon")).toBeInTheDocument();
-    });
-
-    it("toggles between show and hide password when clicking the eye icon", () => {
-      render(<Fixture />);
-      const input = screen.getByTestId("mnemonic-input");
-
-      fireEvent.change(input, { target: { value: "test" } });
-
-      expect(input).toHaveAttribute("type", "password");
-      expect(screen.getByTestId("eye-icon")).toBeInTheDocument();
-
-      fireEvent.click(screen.getByTestId("eye-icon"));
-      expect(input).toHaveAttribute("type", "text");
-      expect(screen.getByTestId("eye-slash-icon")).toBeInTheDocument();
-
-      fireEvent.click(screen.getByTestId("eye-slash-icon"));
-      expect(input).toHaveAttribute("type", "password");
-      expect(screen.getByTestId("eye-icon")).toBeInTheDocument();
-    });
-
-    it("automatically hides mnemonic after timeout", () => {
-      jest.useFakeTimers();
-
-      render(<Fixture />);
-      const input = screen.getByTestId("mnemonic-input");
-
-      fireEvent.change(input, { target: { value: "test" } });
-      fireEvent.click(screen.getByTestId("eye-icon"));
-
-      expect(input).toHaveAttribute("type", "text");
-
-      act(() => {
-        jest.advanceTimersByTime(60000);
-      });
-
-      expect(input).toHaveAttribute("type", "password");
-      expect(screen.getByTestId("eye-icon")).toBeInTheDocument();
-
-      jest.useRealTimers();
     });
   });
 });

--- a/packages/components/src/components/MnemonicAutocomplete/MnemonicAutocomplete.tsx
+++ b/packages/components/src/components/MnemonicAutocomplete/MnemonicAutocomplete.tsx
@@ -1,20 +1,7 @@
-import {
-  Button,
-  Input,
-  InputGroup,
-  type InputProps,
-  InputRightElement,
-  ListItem,
-  type ListProps,
-  UnorderedList,
-} from "@chakra-ui/react";
+import { Input, type InputProps, ListItem, type ListProps, UnorderedList } from "@chakra-ui/react";
 import { wordlists } from "bip39";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useState } from "react";
 import { type FieldValues, type Path, type RegisterOptions, useFormContext } from "react-hook-form";
-
-import { EyeIcon, EyeSlashIcon } from "../../../../../apps/desktop/src/assets/icons";
-
-const MNEMONIC_VISIBILITY_TIMEOUT = 60000;
 
 type MnemonicAutocompleteProps<T extends FieldValues, U extends Path<T>> = {
   inputName: U;
@@ -40,8 +27,6 @@ export const MnemonicAutocomplete = <T extends FieldValues, U extends Path<T>>({
   listProps,
 }: MnemonicAutocompleteProps<T, U>) => {
   const [hidden, setHidden] = useState(true);
-  const [showMnemonic, setShowMnemonic] = useState(false);
-  const timerRef = useRef<NodeJS.Timeout>();
 
   const { register, setValue, watch } = useFormContext<T>();
 
@@ -55,62 +40,23 @@ export const MnemonicAutocomplete = <T extends FieldValues, U extends Path<T>>({
     // if we found a single match there is no need in the suggestions
     (matching.length > 1 || matching[0] !== value);
 
-  const resetShowMnemonic = useCallback(() => {
-    setShowMnemonic(false);
-  }, []);
-
-  useEffect(() => {
-    if (showMnemonic) {
-      if (timerRef.current) {
-        clearTimeout(timerRef.current);
-      }
-
-      timerRef.current = setTimeout(resetShowMnemonic, MNEMONIC_VISIBILITY_TIMEOUT);
-    }
-
-    return () => {
-      if (timerRef.current) {
-        clearTimeout(timerRef.current);
-      }
-    };
-  }, [showMnemonic, resetShowMnemonic]);
-
   return (
     <>
-      <InputGroup height="full">
-        <Input
-          height="full"
-          autoComplete="off"
-          data-testid="mnemonic-input"
-          onFocus={() => setHidden(false)}
-          placeholder="Type here..."
-          type={showMnemonic ? "text" : "password"}
-          {...register(inputName, {
-            required: "Required",
-            validate,
-            onChange: () => setHidden(false),
-            onBlur: () => setHidden(true),
-          })}
-          {...inputProps}
-        />
-        {value && (
-          <InputRightElement width="fit-content" height="full">
-            <Button
-              minWidth="fit-content"
-              height="full"
-              paddingRight="12px"
-              onClick={() => setShowMnemonic(val => !val)}
-              variant="unstyled"
-            >
-              {showMnemonic ? (
-                <EyeSlashIcon color="currentColor" data-testid="eye-slash-icon" />
-              ) : (
-                <EyeIcon width="16.5px" color="currentColor" data-testid="eye-icon" />
-              )}
-            </Button>
-          </InputRightElement>
-        )}
-      </InputGroup>
+      <Input
+        height="full"
+        autoComplete="off"
+        data-testid="mnemonic-input"
+        onFocus={() => setHidden(false)}
+        placeholder="Type here..."
+        {...register(inputName, {
+          required: "Required",
+          validate,
+          onChange: () => setHidden(false),
+          onBlur: () => setHidden(true),
+        })}
+        {...inputProps}
+      />
+
       {showSuggestions && (
         <UnorderedList data-testid="suggestions" variant="suggestions" {...listProps}>
           {matching.map(word => (

--- a/packages/components/src/hooks/index.ts
+++ b/packages/components/src/hooks/index.ts
@@ -1,2 +1,3 @@
 export * from "./useStepHistory";
 export * from "./usePasswordValidation";
+export * from "./useToggleMnemonic";

--- a/packages/components/src/hooks/useToggleMnemonic.test.tsx
+++ b/packages/components/src/hooks/useToggleMnemonic.test.tsx
@@ -1,0 +1,79 @@
+import { act, renderHook } from "../testUtils";
+import { useToggleMnemonic } from "./useToggleMnemonic";
+
+describe("useHideMnemonic", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  it("should initialize with isVisible as false", () => {
+    const { result } = renderHook(() => useToggleMnemonic());
+
+    expect(result.current.isVisible).toBe(false);
+  });
+
+  it("should allow toggling isVisible state", () => {
+    const { result } = renderHook(() => useToggleMnemonic());
+
+    act(() => {
+      result.current.toggleMnemonic();
+    });
+
+    expect(result.current.isVisible).toBe(true);
+  });
+
+  it("should automatically hide mnemonic after default timeout (30s)", () => {
+    const { result } = renderHook(() => useToggleMnemonic());
+
+    act(() => {
+      result.current.toggleMnemonic();
+    });
+
+    expect(result.current.isVisible).toBe(true);
+
+    act(() => {
+      jest.advanceTimersByTime(30000);
+    });
+
+    expect(result.current.isVisible).toBe(false);
+  });
+
+  it("should respect custom timeout value", () => {
+    const customTimeout = 5000;
+    const { result } = renderHook(() => useToggleMnemonic(customTimeout));
+
+    act(() => {
+      result.current.toggleMnemonic();
+    });
+
+    expect(result.current.isVisible).toBe(true);
+
+    act(() => {
+      jest.advanceTimersByTime(4999);
+    });
+    expect(result.current.isVisible).toBe(true);
+
+    act(() => {
+      jest.advanceTimersByTime(1);
+    });
+    expect(result.current.isVisible).toBe(false);
+  });
+
+  it("should cleanup timeout on unmount", () => {
+    const clearTimeoutSpy = jest.spyOn(global, "clearTimeout");
+    const { result, unmount } = renderHook(() => useToggleMnemonic());
+
+    act(() => {
+      result.current.toggleMnemonic();
+    });
+
+    unmount();
+
+    expect(clearTimeoutSpy).toHaveBeenCalled();
+  });
+});

--- a/packages/components/src/hooks/useToggleMnemonic.tsx
+++ b/packages/components/src/hooks/useToggleMnemonic.tsx
@@ -1,0 +1,29 @@
+import { useEffect, useRef, useState } from "react";
+
+const MNEMONIC_VISIBILITY_TIMEOUT = 30000;
+
+export const useToggleMnemonic = (timeout = MNEMONIC_VISIBILITY_TIMEOUT) => {
+  const [isVisible, setIsVisible] = useState(false);
+  const timerRef = useRef<NodeJS.Timeout>();
+  const resetIsVisible = () => {
+    setIsVisible(false);
+  };
+
+  useEffect(() => {
+    if (isVisible) {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+      }
+
+      timerRef.current = setTimeout(resetIsVisible, timeout);
+    }
+
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+      }
+    };
+  }, [isVisible, timeout]);
+
+  return { isVisible, toggleMnemonic: () => setIsVisible(prev => !prev) };
+};


### PR DESCRIPTION
## Proposed changes

[Task link](https://linear.app/tezos/issue/UMA-1070/add-seed-phrase-account-having-an-eyereveal-per-word-is-not-be-the)

## Types of changes

- [ ] Bugfix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] UI fix

## Screenshots

Add the screenshots of how the app used to look like and how it looks now

<img width="573" alt="image" src="https://github.com/user-attachments/assets/f213f855-c6e4-4908-85f2-55e6c6e2e720" />

## Checklist

- [x] Tests that prove my fix is effective or that my feature works have been added
- [ ] Documentation has been added (if appropriate)
- [x] Screenshots are added (if any UI changes have been made)
- [ ] All TODOs have a corresponding task created (and the link is attached to it)
