### PR TITLE
[Web][UMA-1072] Update zIndex of close and back buttons on modal

### DIFF
--- a/apps/web/src/components/BackButton/BaseBackButton.tsx
+++ b/apps/web/src/components/BackButton/BaseBackButton.tsx
@@ -5,7 +5,7 @@ import { ArrowLeftCircleIcon } from "../../assets/icons";
 export const BaseBackButton = (props: Omit<IconButtonProps, "aria-label">) => (
   <IconButton
     position="absolute"
-    zIndex="100"
+    zIndex="2"
     top={{
       base: "12px",
       md: "18px",

--- a/apps/web/src/components/CloseButton/BaseCloseButton.tsx
+++ b/apps/web/src/components/CloseButton/BaseCloseButton.tsx
@@ -5,7 +5,7 @@ import { CloseIcon } from "../../assets/icons";
 export const BaseCloseButton = (props: Omit<IconButtonProps, "aria-label">) => (
   <IconButton
     position="absolute"
-    zIndex="100"
+    zIndex="2"
     top={{
       base: "12px",
       md: "18px",


### PR DESCRIPTION
## Proposed changes

[Task link](https://linear.app/tezos/issue/UMA-1072/account-selector-3-dot-menu-one-mobile-when-3-dot-menu-opens-it)

## Screenshots

<img width="540" alt="image" src="https://github.com/user-attachments/assets/b04408f1-b5ed-4533-8ae8-4d9c702bac19" />

## Types of changes

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] UI fix
