### PR TITLE
[Web][UMA-1063] Cropped account name for social login

### DIFF
--- a/apps/web/src/components/AccountTile/AccountTile.tsx
+++ b/apps/web/src/components/AccountTile/AccountTile.tsx
@@ -1,5 +1,6 @@
 import { Flex, type FlexProps, Heading } from "@chakra-ui/react";
 import { type ImplicitAccount } from "@umami/core";
+import { truncate } from "@umami/tezos";
 import { type PropsWithChildren } from "react";
 
 import { AccountTileIcon } from "./AccountTileIcon";
@@ -47,7 +48,7 @@ export const AccountTile = ({
         <Flex justifyContent="center" flexDirection="column" gap="2px">
           {!isSmall && (
             <Heading color={color("900")} size="sm">
-              {account.label}
+              {account.type === "social" ? truncate(account.label, 28) : account.label}
             </Heading>
           )}
           <CopyAddressButton address={address} isCopyDisabled={isSmall} {...copyButtonStyles} />

--- a/apps/web/src/components/NameAccountModal/NameAccountModal.test.tsx
+++ b/apps/web/src/components/NameAccountModal/NameAccountModal.test.tsx
@@ -29,6 +29,20 @@ describe("NameAccountModal", () => {
     expect(mockOnSubmit).toHaveBeenCalled();
   });
 
+  it("shows error for a long account name", async () => {
+    const user = userEvent.setup();
+    await renderInModal(<NameAccountModal onSubmit={mockOnSubmit} />);
+
+    await act(() => user.type(screen.getByLabelText("Account name (optional)"), "a".repeat(28)));
+    expect(screen.getByRole("button", { name: "Continue" })).toBeEnabled();
+
+    await act(() => user.type(screen.getByLabelText("Account name (optional)"), "a".repeat(29)));
+    expect(screen.getByRole("button", { name: "Continue" })).toBeDisabled();
+    expect(await screen.findByTestId("name-error")).toHaveTextContent(
+      "Maximum length is 28 characters"
+    );
+  });
+
   it("renders advanced settings when enabled", async () => {
     await renderInModal(<NameAccountModal onSubmit={mockOnSubmit} withAdvancedSettings />);
 

--- a/apps/web/src/components/NameAccountModal/NameAccountModal.tsx
+++ b/apps/web/src/components/NameAccountModal/NameAccountModal.tsx
@@ -2,6 +2,7 @@ import {
   Button,
   Center,
   FormControl,
+  FormErrorMessage,
   FormLabel,
   Heading,
   Icon,
@@ -40,7 +41,7 @@ export const NameAccountModal = ({
   const color = useColor();
 
   const form = useMultiForm({
-    mode: "onBlur",
+    mode: "all",
     defaultValues: {
       accountName: "",
       ...(withAdvancedSettings && {
@@ -50,7 +51,11 @@ export const NameAccountModal = ({
     },
   });
 
-  const { register, handleSubmit } = form;
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isValid },
+  } = form;
 
   return (
     <ModalContent data-testid="name-account-modal">
@@ -78,21 +83,30 @@ export const NameAccountModal = ({
       <FormProvider {...form}>
         <form onSubmit={handleSubmit(onSubmit)} style={{ width: "100%" }}>
           <ModalBody gap="30px">
-            <FormControl>
+            <FormControl isInvalid={!!errors.accountName}>
               <FormLabel>Account name (optional)</FormLabel>
               <Input
                 data-testid="accountName"
                 type="text"
                 {...register("accountName", {
                   required: false,
+                  maxLength: {
+                    value: 28,
+                    message: "Maximum length is 28 characters",
+                  },
                 })}
                 placeholder="Enter Account Name"
               />
+              {errors.accountName && (
+                <FormErrorMessage data-testid="name-error">
+                  {errors.accountName.message}
+                </FormErrorMessage>
+              )}
             </FormControl>
             {withAdvancedSettings && <AdvancedAccountSettings />}
           </ModalBody>
           <ModalFooter>
-            <Button width="full" type="submit" variant="primary">
+            <Button width="full" isDisabled={!isValid} type="submit" variant="primary">
               {buttonLabel}
             </Button>
           </ModalFooter>


### PR DESCRIPTION
## Proposed changes

[UMA-1063](https://linear.app/tezos/issue/UMA-1063/account-card-selector-long-account-name-is-not-cropped) Account Card Selector: Long account name is not cropped

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] UI fix

## Steps to reproduce

1. create account with very long name
2. login with social account with very long name
3. check account card
4. check account selector modal

## Screenshots

Add the screenshots of how the app used to look like and how it looks now

| Before | Now |
| ------ | --- |
| <img width="450" alt="image" src="https://github.com/user-attachments/assets/1a6a4e6a-1438-43f2-a534-b9808354ab25" /> | <img width="450" alt="image" src="https://github.com/user-attachments/assets/19b3fc54-5390-4141-b900-2b8fccb6959d" /> |
| <img width="450" alt="image" src="https://github.com/user-attachments/assets/5ec328ba-dfcd-4f69-be97-98dde5ece729" /> |  <img width="450" alt="image" src="https://github.com/user-attachments/assets/1014a587-d179-40f8-9abd-b840b8a082e3" /> |
| <img width="450" alt="image" src="https://github.com/user-attachments/assets/549910d9-6541-407c-bddd-d59a95fe1f33" /> | unchanged |

Maximum account name is now 28 symbols:
<img width="385" alt="image" src="https://github.com/user-attachments/assets/27d2755a-ce82-49c5-bcf5-a899a68ead2e" />


## Checklist

- [ ] Tests that prove my fix is effective or that my feature works have been added
- [ ] Documentation has been added (if appropriate)
- [x] Screenshots are added (if any UI changes have been made)
- [ ] All TODOs have a corresponding task created (and the link is attached to it)
