### PR TITLE
[Web][UMA-1157] UI: baker name in the account card

### DIFF
--- a/apps/web/src/components/AccountCard/AccountBalanceDetails.test.tsx
+++ b/apps/web/src/components/AccountCard/AccountBalanceDetails.test.tsx
@@ -61,8 +61,8 @@ describe("<AccountBalanceDetails />", () => {
 
       render(<AccountBalanceDetails />, { store });
 
+      expect(screen.getByText("mega_baker", { exact: false })).toBeInTheDocument();
       expect(screen.getByText("Delegation")).toBeInTheDocument();
-      expect(screen.getByTestId("current-baker")).toHaveTextContent("To: mega_baker");
     });
 
     it("no delegation status if not delegated and no staking-related balances", () => {

--- a/apps/web/src/components/AccountCard/AccountBalanceDetails.tsx
+++ b/apps/web/src/components/AccountCard/AccountBalanceDetails.tsx
@@ -1,5 +1,4 @@
 import { Box, Divider, Flex, Text } from "@chakra-ui/react";
-import { useAddressPill } from "@umami/components";
 import {
   useCurrentAccount,
   useGetAccountBalanceDetails,
@@ -9,12 +8,14 @@ import { formatTezAmountMin0Decimals } from "@umami/tezos";
 import { BigNumber } from "bignumber.js";
 
 import { useColor } from "../../styles/useColor";
+import { AddressPill } from "../AddressPill";
 
 const RoundStatusDot = ({ background }: { background: string }) => (
   <Box
+    gap="4px"
     display="inline-block"
-    width="8px"
-    height="8px"
+    width="11px"
+    height="11px"
     marginRight="5px"
     background={background}
     borderRadius="100%"
@@ -34,7 +35,6 @@ export const AccountBalanceDetails = () => {
     totalBalance,
   } = useGetAccountBalanceDetails(address);
   const delegate = useGetAccountDelegate()(address);
-  const { addressAlias } = useAddressPill({ rawAddress: delegate || currentAccount.address });
 
   const BalanceLabel = ({ label }: { label: string }) => (
     <Text color={color("600")} fontWeight="600" size="sm">
@@ -83,7 +83,6 @@ export const AccountBalanceDetails = () => {
             background="rgba(197, 48, 48, 0.15)"
             borderRadius="100px"
             paddingX="3"
-            paddingY="1"
           >
             <RoundStatusDot background={color("red")} />
             <Text color={color("red")} size="sm">
@@ -103,30 +102,42 @@ export const AccountBalanceDetails = () => {
           <Flex
             alignItems="center"
             justifyContent="flex-end"
-            gap="6px"
+            gap="2px"
             background={color("greenLight")}
             borderRadius="100px"
-            paddingX="3"
-            paddingY="1"
-          >
-            <RoundStatusDot background={color("greenDark")} />
-            <Text color={color("green")} fontWeight="600" size="sm">
-              Delegation
-            </Text>
-          </Flex>
-          <Text
-            overflow="hidden"
-            maxWidth="50vw"
-            data-testid="current-baker"
-            size="sm"
+            paddingX="7px"
+            paddingY="3px"
             style={{
               whiteSpace: "nowrap",
               overflow: "hidden",
               textOverflow: "ellipsis",
             }}
           >
-            To: {addressAlias || delegate.address}
-          </Text>
+            <RoundStatusDot background={color("greenDark")} />
+            <Text color={color("green")} fontWeight="600" size="sm">
+              Delegation
+            </Text>
+          </Flex>
+          <Flex>
+            <Text
+              alignItems="center"
+              overflow="hidden"
+              width="30px"
+              data-testid="delegation-to"
+              paddingY="3px"
+              size="sm"
+            >
+              To:
+            </Text>
+            <AddressPill
+              overflow="hidden"
+              maxWidth="45vw"
+              whiteSpace="nowrap"
+              textOverflow="ellipsis"
+              address={delegate}
+              data-testid="current-baker"
+            />
+          </Flex>
         </Flex>
       )}
       {!spendableBalance.isEqualTo(totalBalance) && <Divider />}

--- a/apps/web/src/components/AddressPill/AddressPill.tsx
+++ b/apps/web/src/components/AddressPill/AddressPill.tsx
@@ -79,6 +79,7 @@ export const AddressPill = memo(
           <PopoverTrigger>
             <Center
               gap="4px"
+              overflow="hidden"
               width="fit-content"
               _focus={{ boxShadow: "none" }}
               data-testid="address-pill-copy-button"

--- a/packages/components/src/components/AddressPill/AddressPillText.tsx
+++ b/packages/components/src/components/AddressPill/AddressPillText.tsx
@@ -22,5 +22,9 @@ export const AddressPillText = ({
     return <Text {...props}>{formattedPkh}</Text>;
   }
 
-  return <Text {...props}>{nameOrLabel ? truncate(nameOrLabel, 25) : formattedPkh}</Text>;
+  return (
+    <Text overflow="hidden" textOverflow="ellipsis" {...props}>
+      {nameOrLabel ? truncate(nameOrLabel, 50) : formattedPkh}
+    </Text>
+  );
 };


### PR DESCRIPTION
## Proposed changes

[UMA-1157](https://linear.app/tezos/issue/UMA-1157/user-adapt-to-design-present-full-global-stakedunstakedavailable)

Updating baker view on the account card

## Types of changes

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] UI fix

## Steps to reproduce

## Screenshots

Add the screenshots of how the app used to look like and how it looks now

| Before | Now |
| ------ | --- |
|        | <img width="450" alt="image" src="https://github.com/user-attachments/assets/1b9ec954-ce64-4770-ae23-6c4adccfc0cd" /> |
|  | <img width="450" alt="image" src="https://github.com/user-attachments/assets/aca751bf-8913-47b8-972e-3758809f9b5a" /> |

## Checklist

- [ ] Tests that prove my fix is effective or that my feature works have been added
- [ ] Documentation has been added (if appropriate)
- [ ] Screenshots are added (if any UI changes have been made)
- [ ] All TODOs have a corresponding task created (and the link is attached to it)
