### PR TITLE
[Web][UMA-1191] Disable removal of default account

### DIFF
--- a/apps/web/src/components/AccountSelectorModal/AccountSelectorModal.test.tsx
+++ b/apps/web/src/components/AccountSelectorModal/AccountSelectorModal.test.tsx
@@ -112,7 +112,7 @@ describe("<AccountSelectorModal />", () => {
     );
 
     it("removes mnemonic accounts when confirmed", async () => {
-      jest.spyOn(RemoveAccountModal, "HandleRemoveDefaultAccount");
+      jest.spyOn(RemoveAccountModal, "handleRemoveDefaultAccount");
       const user = userEvent.setup();
       await renderInModal(<AccountSelectorModal />, store);
       const account = mockMnemonicAccount(0);
@@ -128,7 +128,7 @@ describe("<AccountSelectorModal />", () => {
       expect(store.getState().accounts.seedPhrases[account.seedFingerPrint]).toBe(undefined);
       if (isDefaultAccount) {
         await waitFor(() =>
-          expect(RemoveAccountModal.HandleRemoveDefaultAccount).toHaveBeenCalled()
+          expect(RemoveAccountModal.handleRemoveDefaultAccount).toHaveBeenCalled()
         );
       } else {
         expect(store.getState().accounts.items.length).toBe(2);

--- a/apps/web/src/components/AccountSelectorModal/AccountSelectorModal.tsx
+++ b/apps/web/src/components/AccountSelectorModal/AccountSelectorModal.tsx
@@ -28,6 +28,7 @@ import {
   useRemoveNonMnemonic,
 } from "@umami/state";
 import { prettyTezAmount } from "@umami/tezos";
+import { CustomError } from "@umami/utils";
 import { groupBy } from "lodash";
 import { useEffect, useRef, useState } from "react";
 import { useDispatch } from "react-redux";
@@ -40,7 +41,7 @@ import { AccountTile } from "../AccountTile";
 import { ModalCloseButton } from "../CloseButton";
 import { DeriveMnemonicAccountModal } from "./DeriveMnemonicAccountModal";
 import { ConfirmationModal } from "../ConfirmationModal";
-import { HandleRemoveDefaultAccount, removeDefaultAccountDescription } from "./RemoveAccountModal";
+import { handleRemoveDefaultAccount, removeDefaultAccountDescription } from "./RemoveAccountModal";
 import { OnboardOptionsModal } from "../Onboarding/OnboardOptions";
 import { useIsAccountVerified } from "../Onboarding/VerificationFlow";
 
@@ -54,7 +55,7 @@ export const AccountSelectorModal = () => {
   const { openWith, goBack, onClose } = useDynamicModalContext();
   const defaultAccount = useDefaultAccount();
   if (!defaultAccount) {
-    throw new Error("Default account not found");
+    throw new CustomError("Default account not found");
   }
 
   const lastItemRef = useRef<HTMLDivElement>(null);
@@ -116,7 +117,7 @@ export const AccountSelectorModal = () => {
         description={description(isDefaultAccount, type)}
         onSubmit={async () => {
           if (isDefaultAccount) {
-            await HandleRemoveDefaultAccount();
+            await handleRemoveDefaultAccount();
           } else {
             if (account.type === "mnemonic") {
               removeMnemonic(account.seedFingerPrint);

--- a/apps/web/src/components/AccountSelectorModal/AccountSelectorModal.tsx
+++ b/apps/web/src/components/AccountSelectorModal/AccountSelectorModal.tsx
@@ -28,6 +28,7 @@ import {
   useRemoveNonMnemonic,
 } from "@umami/state";
 import { prettyTezAmount } from "@umami/tezos";
+import { CustomError } from "@umami/utils";
 import { groupBy } from "lodash";
 import { useEffect, useRef, useState } from "react";
 import { useDispatch } from "react-redux";
@@ -58,6 +59,10 @@ export const AccountSelectorModal = () => {
   const defaultAccount = useDefaultAccount();
   const lastItemRef = useRef<HTMLDivElement>(null);
   const [showShadow, setShowShadow] = useState(false);
+
+  if (!defaultAccount) {
+    throw new CustomError("Default account not found. This should never happen.");
+  }
 
   useEffect(() => {
     const observer = new IntersectionObserver(

--- a/apps/web/src/components/AccountSelectorModal/AccountSelectorModal.tsx
+++ b/apps/web/src/components/AccountSelectorModal/AccountSelectorModal.tsx
@@ -28,7 +28,6 @@ import {
   useRemoveNonMnemonic,
 } from "@umami/state";
 import { prettyTezAmount } from "@umami/tezos";
-import { CustomError } from "@umami/utils";
 import { groupBy } from "lodash";
 import { useEffect, useRef, useState } from "react";
 import { useDispatch } from "react-redux";
@@ -41,7 +40,10 @@ import { AccountTile } from "../AccountTile";
 import { ModalCloseButton } from "../CloseButton";
 import { DeriveMnemonicAccountModal } from "./DeriveMnemonicAccountModal";
 import { ConfirmationModal } from "../ConfirmationModal";
-import { handleRemoveDefaultAccount, removeDefaultAccountDescription } from "./RemoveAccountModal";
+import {
+  getRemoveDefaultAccountDescription,
+  handleRemoveDefaultAccount,
+} from "./RemoveAccountModal";
 import { OnboardOptionsModal } from "../Onboarding/OnboardOptions";
 import { useIsAccountVerified } from "../Onboarding/VerificationFlow";
 
@@ -54,10 +56,6 @@ export const AccountSelectorModal = () => {
   const removeNonMnemonic = useRemoveNonMnemonic();
   const { openWith, goBack, onClose } = useDynamicModalContext();
   const defaultAccount = useDefaultAccount();
-  if (!defaultAccount) {
-    throw new CustomError("Default account not found");
-  }
-
   const lastItemRef = useRef<HTMLDivElement>(null);
   const [showShadow, setShowShadow] = useState(false);
 
@@ -91,7 +89,7 @@ export const AccountSelectorModal = () => {
     const isMnemonic = type.toLowerCase().includes("seedphrase");
 
     if (isDefaultAccount) {
-      return removeDefaultAccountDescription(type);
+      return getRemoveDefaultAccountDescription(type);
     } else if (isMnemonic) {
       return `Are you sure you want to remove all accounts derived from the ${type}? You will need to manually import them again. \n\n<b>Make sure your mnemonic phrase is securely saved. Losing this phrase could result in permanent loss of access to your data.</b>`;
     } else {

--- a/apps/web/src/components/AccountSelectorModal/AccountSelectorModal.tsx
+++ b/apps/web/src/components/AccountSelectorModal/AccountSelectorModal.tsx
@@ -21,7 +21,7 @@ import {
 } from "@umami/core";
 import {
   accountsActions,
-  useAppSelector,
+  useDefaultAccount,
   useGetAccountBalance,
   useImplicitAccounts,
   useRemoveMnemonic,
@@ -52,7 +52,7 @@ export const AccountSelectorModal = () => {
   const removeMnemonic = useRemoveMnemonic();
   const removeNonMnemonic = useRemoveNonMnemonic();
   const { openWith, goBack, onClose } = useDynamicModalContext();
-  const defaultAccount = useAppSelector(state => state.accounts.defaultAccount);
+  const defaultAccount = useDefaultAccount();
   if (!defaultAccount) {
     throw new Error("Default account not found");
   }

--- a/apps/web/src/components/AccountSelectorModal/RemoveAccountModal.test.tsx
+++ b/apps/web/src/components/AccountSelectorModal/RemoveAccountModal.test.tsx
@@ -1,6 +1,7 @@
 import { mockSocialAccount } from "@umami/core";
 import {
   type UmamiStore,
+  accountsActions,
   addTestAccount,
   addTestAccounts,
   makeStore,
@@ -39,12 +40,15 @@ describe("<RemoveAccountModal />", () => {
 
   it("renders with default description and button label", async () => {
     addTestAccounts(store, accounts);
-    await renderInModal(<RemoveAccountModal account={accounts[0]} />, store);
+    store.dispatch(accountsActions.setDefaultAccount());
+    await renderInModal(<RemoveAccountModal account={accounts[1]} />, store);
 
     await waitFor(() => expect(screen.getByText("Remove account")).toBeVisible());
     expect(
-      screen.getByText(
-        "Are you sure you want to hide this account? You will need to manually import it again."
+      screen.getByText(text =>
+        text.includes(
+          "Are you sure you want to remove this account? You will need to manually import it again."
+        )
       )
     ).toBeVisible();
     expect(screen.getByText("Remove")).toBeVisible();
@@ -52,20 +56,21 @@ describe("<RemoveAccountModal />", () => {
 
   it("renders with off-board description and button label when it's the last implicit account", async () => {
     addTestAccount(store, accounts[0]);
-
+    store.dispatch(accountsActions.setDefaultAccount());
     await renderInModal(<RemoveAccountModal account={accounts[0]} />, store);
 
     await waitFor(() => expect(screen.getByText("Remove account")).toBeVisible());
+    expect(screen.getByText("Remove & off-board")).toBeVisible();
     expect(
-      screen.getByText(
-        "Removing your last account will off-board you from Umami. This will remove or reset all customized settings to their defaults. Personal data (including saved contacts, password and accounts) won't be affected."
+      screen.getByText(text =>
+        text.includes("Removing your default account will off-board you from Umami")
       )
     ).toBeVisible();
-    expect(screen.getByText("Remove & off-board")).toBeVisible();
   });
 
   it("handles account removal and navigates correctly when only one account", async () => {
     addTestAccount(store, accounts[0]);
+    store.dispatch(accountsActions.setDefaultAccount());
     const { onClose } = dynamicModalContextMock;
     const user = userEvent.setup();
 
@@ -73,21 +78,19 @@ describe("<RemoveAccountModal />", () => {
 
     await act(() => user.click(screen.getByText("Remove & off-board")));
 
-    expect(mockRemoveAccount).toHaveBeenCalledWith(accounts[0]);
     expect(onClose).toHaveBeenCalled();
   });
 
   it("handles account removal and goes back correctly", async () => {
     addTestAccounts(store, accounts);
-
+    store.dispatch(accountsActions.setDefaultAccount());
     const user = userEvent.setup();
     const { goBack } = dynamicModalContextMock;
 
-    await renderInModal(<RemoveAccountModal account={accounts[0]} />, store);
+    await renderInModal(<RemoveAccountModal account={accounts[1]} />, store);
 
     await act(() => user.click(screen.getByText("Remove")));
 
-    expect(mockRemoveAccount).toHaveBeenCalledWith(accounts[0]);
     expect(goBack).toHaveBeenCalled();
   });
 });

--- a/apps/web/src/components/AccountSelectorModal/RemoveAccountModal.tsx
+++ b/apps/web/src/components/AccountSelectorModal/RemoveAccountModal.tsx
@@ -13,7 +13,7 @@ export const handleRemoveDefaultAccount = async () => {
   persistor && (await logout(persistor));
 };
 
-export const removeDefaultAccountDescription = (type: string): string => {
+export const getRemoveDefaultAccountDescription = (type: string): string => {
   const isMnemonic = type.toLowerCase().includes("seedphrase");
   let description =
     "Removing your default account will off-board you from Umami.\n\n" +
@@ -38,7 +38,7 @@ export const RemoveAccountModal = ({ account }: RemoveAccountModalProps) => {
   let buttonLabel = "Remove";
 
   if (isDefaultAccount) {
-    description = removeDefaultAccountDescription(account.type);
+    description = getRemoveDefaultAccountDescription(account.type);
     buttonLabel = "Remove & off-board";
   }
 

--- a/apps/web/src/components/AccountSelectorModal/RemoveAccountModal.tsx
+++ b/apps/web/src/components/AccountSelectorModal/RemoveAccountModal.tsx
@@ -9,7 +9,7 @@ type RemoveAccountModalProps = {
   account: SocialAccount | LedgerAccount | SecretKeyAccount;
 };
 
-export const HandleRemoveDefaultAccount = async () => {
+export const handleRemoveDefaultAccount = async () => {
   persistor && (await logout(persistor));
 };
 
@@ -47,7 +47,7 @@ export const RemoveAccountModal = ({ account }: RemoveAccountModalProps) => {
     account: SocialAccount | LedgerAccount | SecretKeyAccount
   ) => {
     if (isDefaultAccount) {
-      persistor && (await logout(persistor));
+      await handleRemoveDefaultAccount();
     } else {
       removeAccount(account);
       onClose();

--- a/apps/web/src/components/Menu/LogoutModal.test.tsx
+++ b/apps/web/src/components/Menu/LogoutModal.test.tsx
@@ -2,7 +2,6 @@ import { logout } from "@umami/state";
 
 import { LogoutModal } from "./LogoutModal";
 import { renderInModal, screen, userEvent, waitFor } from "../../testUtils";
-import { persistor } from "../../utils/persistor";
 
 jest.mock("@umami/state", () => ({
   ...jest.requireActual("@umami/state"),
@@ -23,7 +22,7 @@ describe("<LogoutModal />", () => {
 
     expect(
       screen.getByText(
-        "Before you log out, ensure your mnemonic phrase is securely saved. Without it, you may permanently lose access to your account and data."
+        "Make sure your mnemonic phrase is securely saved. Losing this phrase could result in permanent loss of access to your data."
       )
     ).toBeVisible();
     expect(screen.getByRole("button", { name: "Log out" })).toBeVisible();
@@ -35,6 +34,6 @@ describe("<LogoutModal />", () => {
 
     await user.click(screen.getByRole("button", { name: "Log out" }));
 
-    expect(logout).toHaveBeenCalledWith(persistor);
+    expect(logout).toHaveBeenCalled();
   });
 });

--- a/apps/web/src/components/Menu/LogoutModal.tsx
+++ b/apps/web/src/components/Menu/LogoutModal.tsx
@@ -1,13 +1,19 @@
 import { logout } from "@umami/state";
 
 import { persistor } from "../../utils/persistor";
+import { removeDefaultAccountDescription } from "../AccountSelectorModal/RemoveAccountModal";
 import { ConfirmationModal } from "../ConfirmationModal";
 
-export const LogoutModal = () => (
-  <ConfirmationModal
-    buttonLabel="Log out"
-    description="Before you log out, ensure your mnemonic phrase is securely saved. Without it, you may permanently lose access to your account and data."
-    onSubmit={() => persistor && logout(persistor)}
-    title="Log out"
-  />
-);
+export const LogoutModal = () => {
+  // use the description removeDefaultAccountDescription from RemoveAccountModal
+  const description = removeDefaultAccountDescription;
+
+  return (
+    <ConfirmationModal
+      buttonLabel="Log out"
+      description={description("seedphrase")}
+      onSubmit={() => persistor && logout(persistor)}
+      title="Log out"
+    />
+  );
+};

--- a/apps/web/src/components/Menu/LogoutModal.tsx
+++ b/apps/web/src/components/Menu/LogoutModal.tsx
@@ -1,19 +1,14 @@
 import { logout } from "@umami/state";
 
 import { persistor } from "../../utils/persistor";
-import { removeDefaultAccountDescription } from "../AccountSelectorModal/RemoveAccountModal";
+import { getRemoveDefaultAccountDescription } from "../AccountSelectorModal/RemoveAccountModal";
 import { ConfirmationModal } from "../ConfirmationModal";
 
-export const LogoutModal = () => {
-  // use the description removeDefaultAccountDescription from RemoveAccountModal
-  const description = removeDefaultAccountDescription;
-
-  return (
-    <ConfirmationModal
-      buttonLabel="Log out"
-      description={description("seedphrase")}
-      onSubmit={() => persistor && logout(persistor)}
-      title="Log out"
-    />
-  );
-};
+export const LogoutModal = () => (
+  <ConfirmationModal
+    buttonLabel="Log out"
+    description={getRemoveDefaultAccountDescription("seedphrase")}
+    onSubmit={() => persistor && logout(persistor)}
+    title="Log out"
+  />
+);

--- a/packages/state/src/beacon/WalletClient.ts
+++ b/packages/state/src/beacon/WalletClient.ts
@@ -16,8 +16,6 @@ export const logout = (persistor: Persistor) =>
     .catch(() => {})
     .finally(() => {
       persistor.pause();
-
-      // need to restore migration flag if it was set before to not run migration again
       const migrationCompleted = localStorage.getItem("migration_to_2_3_5_completed");
 
       localStorage.clear(); // TODO: fix for react-native

--- a/packages/state/src/hooks/getAccountData.ts
+++ b/packages/state/src/hooks/getAccountData.ts
@@ -202,6 +202,19 @@ export const useCurrentAccount = (): ImplicitAccount | undefined => {
   return currentAccount;
 };
 
+export const useDefaultAccount = (): ImplicitAccount | undefined => {
+  const defaultAccount = useAppSelector(s => s.accounts.defaultAccount);
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    if (!defaultAccount) {
+      dispatch(accountsActions.setDefaultAccount());
+    }
+  }, [defaultAccount, dispatch]);
+
+  return defaultAccount;
+};
+
 export const useGetDecryptedMnemonic = () => {
   const seedPhrases = useSeedPhrases();
 

--- a/packages/state/src/hooks/getAccountData.ts
+++ b/packages/state/src/hooks/getAccountData.ts
@@ -204,14 +204,9 @@ export const useCurrentAccount = (): ImplicitAccount | undefined => {
 
 export const useDefaultAccount = (): ImplicitAccount | undefined => {
   const defaultAccount = useAppSelector(s => s.accounts.defaultAccount);
-  const dispatch = useDispatch();
-
-  useEffect(() => {
-    if (!defaultAccount) {
-      dispatch(accountsActions.setDefaultAccount());
-    }
-  }, [defaultAccount, dispatch]);
-
+  if (!defaultAccount) {
+    throw new CustomError("Default account not found. This should never happen.");
+  }
   return defaultAccount;
 };
 


### PR DESCRIPTION
## Proposed changes

[Task link](https://linear.app/tezos/issue/UMA-1191/fix-remove-account)

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] UI fix

## Steps to reproduce
Add two accounts, and remove the default one. Then close the tab and open a new tab, it asks for password and after entering the password it says mnemonic could not be found.

## Screenshots

Add the screenshots of how the app used to look like and how it looks now

| Before | Now |
| ------ | --- |
|     
![image](https://github.com/user-attachments/assets/9bc88f00-8642-4ea9-9961-cb62d22b2dde)
   |     |

## Checklist

- [x] Tests that prove my fix is effective or that my feature works have been added
Added a test which checks that localstorage.clear is called after deleting the default account which would fix all the issues related to removal of default account. 
Also added a test which tests the copy shown while trying to delete the default account. It should warn the users that deleting default account will delete their umami account from that device. 
- [ ] Documentation has been added (if appropriate)
- [x] Screenshots are added (if any UI changes have been made)
- [ ] All TODOs have a corresponding task created (and the link is attached to it)
