### PR TITLE
[Web][UMA-1048] Column words in verify on mobile

### DIFF
--- a/apps/web/src/components/Onboarding/VerificationFlow/RecordSeedphraseModal.tsx
+++ b/apps/web/src/components/Onboarding/VerificationFlow/RecordSeedphraseModal.tsx
@@ -48,7 +48,7 @@ export const RecordSeedphraseModal = ({ seedPhrase }: CopySeedphraseModalProps) 
 
       <ModalBody>
         <Grid
-          gridRowGap={{ base: "12px", md: "18px" }}
+          gridRowGap={{ base: "8px", md: "18px" }}
           gridColumnGap={{ base: "8px", md: "12px" }}
           gridTemplateColumns={{ base: "repeat(3, 1fr)", md: "repeat(4, 1fr)" }}
           userSelect="none"
@@ -74,7 +74,7 @@ export const RecordSeedphraseModal = ({ seedPhrase }: CopySeedphraseModalProps) 
             />
           ))}
         </Grid>
-        <Flex gap="16px" width="100%" marginTop="16px">
+        <Flex gap="16px" width="100%" marginTop="10px">
           <Button
             gap="4px"
             display="flex"

--- a/apps/web/src/components/Onboarding/VerificationFlow/VerifySeedphraseModal.tsx
+++ b/apps/web/src/components/Onboarding/VerificationFlow/VerifySeedphraseModal.tsx
@@ -79,7 +79,12 @@ export const VerifySeedphraseModal = ({ seedPhrase }: VerifySeedphraseModalProps
       <FormProvider {...form}>
         <form onSubmit={handleSubmit(onSubmit)}>
           <ModalBody>
-            <Flex gap={{ base: "6px", md: "12px" }} userSelect="none">
+            <Flex
+              flexDirection={{ base: "column", md: "row" }}
+              gap={{ base: "6px", md: "12px" }}
+              userSelect="none"
+              data-testid="mnemonic-words"
+            >
               {randomElements.map(({ index, value }) => {
                 const inputName = `word${index + 1}`;
                 const error = errors[inputName as keyof typeof errors];


### PR DESCRIPTION
## Proposed changes

[UMA-1048](https://linear.app/tezos/issue/UMA-1048/verify-your-account-on-mobile-i-suggest-showing-the-seed-phrase) Verify your account: On mobile, I suggest showing the seed phrase verification fields in 3 separate rows instead of 1 row with 3 columns.

## Types of changes

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] UI fix

## Steps to reproduce

## Screenshots

Add the screenshots of how the app used to look like and how it looks now

| Case | Before | Now |
| -- | ------ | --- |
| laptop | <img width="350" alt="image" src="https://github.com/user-attachments/assets/cb8b0e2f-3b72-490e-b34c-add9f0dcd832" /> | <img width="350" alt="image" src="https://github.com/user-attachments/assets/988fe7e8-73bf-4c5b-894c-cac815fe7f47" /> |
| mobile | <img width="350" alt="image" src="https://github.com/user-attachments/assets/aeba56f3-42c4-46e9-84cc-6949f8fb44da" /> | <img width="350" alt="image" src="https://github.com/user-attachments/assets/22695ffb-061b-45c4-a255-0e4126ac78fb" /> |
| surface duo, 540px | <img width="350" alt="image" src="https://github.com/user-attachments/assets/208279a1-9425-46bd-86db-165c66777181" /> | <img width="350" alt="image" src="https://github.com/user-attachments/assets/881870fb-574a-43f6-b6df-69535635363b" /> |
| record seed phrase | <img width="350" alt="image" src="https://github.com/user-attachments/assets/64dc3c39-6e38-4f45-b20b-db4f83c5a97a" /> | <img width="350" alt="image" src="https://github.com/user-attachments/assets/b9f5eaf9-044a-4ff5-8be3-8f84d51c9a19" /> |


## Checklist

- [ ] Tests that prove my fix is effective or that my feature works have been added
- [ ] Documentation has been added (if appropriate)
- [x] Screenshots are added (if any UI changes have been made)
- [ ] All TODOs have a corresponding task created (and the link is attached to it)
