### PR TITLE
[Web][UMA-1058][UMA-1245] NFTs video not in drawer

### DIFF
--- a/apps/web/src/views/NFTs/NFTDrawerCard/NFTDrawerCard.tsx
+++ b/apps/web/src/views/NFTs/NFTDrawerCard/NFTDrawerCard.tsx
@@ -37,7 +37,7 @@ export const NFTDrawerCard = ({ nft }: { nft: NFTBalance }) => {
             size="full"
           >
             {isVideo ? (
-              <ReactPlayer data-testid="nft-video" loop playing url={url} />
+              <ReactPlayer controls data-testid="nft-video" loop playing playsinline url={url} />
             ) : (
               <Image
                 maxHeight={{ base: "366px", md: "446px" }}


### PR DESCRIPTION
## Proposed changes

[UMA-1058](https://linear.app/tezos/issue/UMA-1058/nfts-drawer-on-mobile-when-i-tap-on-a-video-nft-it-opens-up-the-video) NFTs Drawer on Mobile: When I tap on a video NFT, it opens up the video on my screen instead of showing me the drawer. When I close the video, then I can see the drawer.

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] UI fix

## Steps to reproduce

1. buy NFT https://ghostnet.objkt.com/tokens/KT1H2Ag5DyTxNWH4KAntHGX5WVS1ggZUoPUE/0
2. open NFT 
 - on laptop
 - on real mobile

## Screenshots

See vercel.

## Checklist

- [ ] Tests that prove my fix is effective or that my feature works have been added
- [ ] Documentation has been added (if appropriate)
- [ ] Screenshots are added (if any UI changes have been made)
- [ ] All TODOs have a corresponding task created (and the link is attached to it)
