### PR TITLE
[Web][UMA-1247] Check confirmed password on password change

### DIFF
--- a/apps/web/src/components/Menu/ChangePasswordMenu/ChangePasswordMenu.test.tsx
+++ b/apps/web/src/components/Menu/ChangePasswordMenu/ChangePasswordMenu.test.tsx
@@ -85,6 +85,54 @@ describe("<ChangePasswordMenu />", () => {
         );
       });
     });
+
+    it("requires same password and clears error when fixed", async () => {
+      const user = userEvent.setup();
+      await renderInDrawer(<ChangePasswordMenu />);
+
+      const newPasswordInput = screen.getByTestId("new-password");
+      const newPasswordConfirmationInput = screen.getByTestId("new-password-confirmation");
+
+      // Step 1: Enter mismatched passwords
+      await user.type(newPasswordInput, "myPassword");
+      await user.type(newPasswordConfirmationInput, "myWrongPassword");
+      fireEvent.blur(newPasswordConfirmationInput);
+
+      await waitFor(() => {
+        expect(screen.getByTestId("new-password-confirmation-error")).toHaveTextContent(
+          "Your new passwords do not match"
+        );
+      });
+
+      // Step 2: Fix the password confirmation
+      await user.clear(newPasswordConfirmationInput);
+      await user.type(newPasswordConfirmationInput, "myPassword");
+      fireEvent.blur(newPasswordConfirmationInput);
+
+      await waitFor(() => {
+        expect(screen.queryByTestId("new-password-confirmation-error")).not.toBeInTheDocument();
+      });
+
+      // Step 3: Change `newPassword` after confirmation
+      await user.clear(newPasswordInput);
+      await user.type(newPasswordInput, "newSecurePassword");
+      fireEvent.blur(newPasswordInput);
+
+      await waitFor(() => {
+        expect(screen.getByTestId("new-password-confirmation-error")).toHaveTextContent(
+          "Your new passwords do not match"
+        );
+      });
+
+      // Step 4: Fix the confirmation again
+      await user.clear(newPasswordConfirmationInput);
+      await user.type(newPasswordConfirmationInput, "newSecurePassword");
+      fireEvent.blur(newPasswordConfirmationInput);
+
+      await waitFor(() => {
+        expect(screen.queryByTestId("new-password-confirmation-error")).not.toBeInTheDocument();
+      });
+    });
   });
 
   describe("Submit Button", () => {

--- a/apps/web/src/components/Menu/ChangePasswordMenu/ChangePasswordMenu.tsx
+++ b/apps/web/src/components/Menu/ChangePasswordMenu/ChangePasswordMenu.tsx
@@ -8,6 +8,7 @@ import {
   useAsyncActionHandler,
 } from "@umami/state";
 import { useCustomToast } from "@umami/utils";
+import { useEffect } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 
 import { PasswordInput } from "../../PasswordInput";
@@ -30,7 +31,14 @@ export const ChangePasswordMenu = () => {
     formState: { isValid },
     getValues,
     reset,
+    trigger,
+    watch,
   } = form;
+  const newPassword = watch("newPassword");
+
+  useEffect(() => {
+    void trigger("newPasswordConfirmation"); // Revalidate confirmation field when newPassword changes
+  }, [newPassword, trigger]);
 
   hj.stateChange("menu/change_password");
 


### PR DESCRIPTION
## Proposed changes

[Task link](https://linear.app/tezos/issue/UMA-1247/your-new-passwords-do-not-match-error-after-the-new-password-was)

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] UI fix

## Steps to reproduce

1. advanced -> change password
2. set new password 
3. set confirmation password different -> see error `Your new passwords do not match`
4. fix new password to match -> no error
5. change new password to different -> see error `Your new passwords do not match`

## Screenshots

<img width="391" alt="image" src="https://github.com/user-attachments/assets/31d0360e-15ce-474b-96df-bed4d7e8ccd3" />

## Checklist

- [x] Tests that prove my fix is effective or that my feature works have been added
```
pnpm test src/components/Menu/ChangePasswordMenu/ChangePasswordMenu.test.tsx
```
- [ ] Documentation has been added (if appropriate)
- [x] Screenshots are added (if any UI changes have been made)
- [ ] All TODOs have a corresponding task created (and the link is attached to it)
