### PR TITLE
[WEB][UMA-1243] Trims too long dApps account name

### DIFF
--- a/apps/web/src/components/AddressPill/AddressPill.tsx
+++ b/apps/web/src/components/AddressPill/AddressPill.tsx
@@ -65,9 +65,12 @@ export const AddressPill = memo(
       <Flex
         ref={elementRef}
         justifyContent="space-around"
+        overflow="hidden"
         width="fit-content"
         background={bgColor}
         borderRadius="full"
+        whiteSpace="nowrap"
+        textOverflow="ellipsis"
         cursor="pointer"
         data-testid="address-pill"
         onMouseEnter={() => setIsMouseHover(true)}

--- a/apps/web/src/components/Menu/AppsMenu/GenericConnections.tsx
+++ b/apps/web/src/components/Menu/AppsMenu/GenericConnections.tsx
@@ -110,15 +110,16 @@ const PeerRow = ({ peerInfo }: { peerInfo: ExtendedPeerSession }) => {
       height="60px"
       data-testid="peer-row"
     >
-      <Flex height="100%">
-        <Center width="60px" marginRight="12px">
+      <Flex minWidth="0" height="100%">
+        <Center flex="0 0 auto" width="60px" marginRight="12px">
           <Image
+            borderRadius="50%"
             objectFit="cover"
             fallback={<CodeSandboxIcon width="36px" height="36px" />}
             src={peerInfo.icon}
           />
         </Center>
-        <Center alignItems="flex-start" flexDirection="column" gap="6px">
+        <Center alignItems="flex-start" flexDirection="column" gap="6px" minWidth="0">
           <Heading color={color("900")} size="lg">
             {peerInfo.name}
           </Heading>
@@ -146,7 +147,7 @@ const StoredPeerInfo = ({ peerInfo }: { peerInfo: ExtendedPeerSession }) => {
   }
 
   return (
-    <Flex>
+    <Flex width="100%">
       <AddressPill marginRight="10px" address={parsePkh(connectionInfo.accountPkh)} />
       <Divider marginRight="10px" orientation="vertical" />
       <Text marginTop="2px" marginRight="4px" fontWeight={600} size="sm">

--- a/apps/web/src/components/Menu/AppsMenu/GenericConnections.tsx
+++ b/apps/web/src/components/Menu/AppsMenu/GenericConnections.tsx
@@ -110,7 +110,7 @@ const PeerRow = ({ peerInfo }: { peerInfo: ExtendedPeerSession }) => {
       height="60px"
       data-testid="peer-row"
     >
-      <Flex minWidth="0" height="100%">
+      <Flex width="100%" minWidth="0" height="100%">
         <Center flex="0 0 auto" width="60px" marginRight="12px">
           <Image
             borderRadius="50%"
@@ -119,7 +119,7 @@ const PeerRow = ({ peerInfo }: { peerInfo: ExtendedPeerSession }) => {
             src={peerInfo.icon}
           />
         </Center>
-        <Center alignItems="flex-start" flexDirection="column" gap="6px" minWidth="0">
+        <Center alignItems="flex-start" flexDirection="column" gap="6px" width="100%" minWidth="0">
           <Heading color={color("900")} size="lg">
             {peerInfo.name}
           </Heading>
@@ -147,13 +147,31 @@ const StoredPeerInfo = ({ peerInfo }: { peerInfo: ExtendedPeerSession }) => {
   }
 
   return (
-    <Flex width="100%">
-      <AddressPill marginRight="10px" address={parsePkh(connectionInfo.accountPkh)} />
+    <Flex width="100%" maxWidth="100%">
+      <AddressPill
+        minWidth="15%"
+        marginRight="10px"
+        address={parsePkh(connectionInfo.accountPkh)}
+      />
       <Divider marginRight="10px" orientation="vertical" />
-      <Text marginTop="2px" marginRight="4px" fontWeight={600} size="sm">
+      <Text
+        display={{ base: "none", md: "inline" }}
+        marginTop="2px"
+        marginRight="4px"
+        fontWeight={600}
+        size="sm"
+      >
         Network:
       </Text>
-      <Text marginTop="2px" data-testid="dapp-connection-network" size="sm">
+      <Text
+        overflow="hidden"
+        minWidth="15%"
+        marginTop="2px"
+        whiteSpace="nowrap"
+        textOverflow="ellipsis"
+        data-testid="dapp-connection-network"
+        size="sm"
+      >
         {capitalize(connectionInfo.networkType)}
       </Text>
     </Flex>


### PR DESCRIPTION
## Proposed changes

[Task link](https://linear.app/tezos/issue/UMA-1243/corrupted-dapps-list-if-account-name-is-very-long)

## Types of changes

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [X] UI fix

## Steps to reproduce
a) Connect a dApps to an Account with a long name
or
b) make your chrome window width very narrow 

## Screenshots

Add the screenshots of how the app used to look like and how it looks now

| Before | Now |
| ------ | --- |
|
![localhost_5173_activity(iPhone XR)](https://github.com/user-attachments/assets/e44cd87d-fe4e-4351-bb00-b5fe124100f5)
|  
![localhost_5173_activity(iPhone XR) (1)](https://github.com/user-attachments/assets/3d64f726-bec8-42fa-975e-9ad423d4dfbe) |

## Checklist

- [ ] Tests that prove my fix is effective or that my feature works have been added
        - no test were added as this is just a css style change
- [ ] Documentation has been added (if appropriate)
- [X] Screenshots are added (if any UI changes have been made)
- [ ] All TODOs have a corresponding task created (and the link is attached to it)
