### PR TITLE
[Web][UMA-1067] Account selection modal is closed when the modal overlay is clicked

### DIFF
--- a/apps/web/src/components/AccountCard/AccountCard.tsx
+++ b/apps/web/src/components/AccountCard/AccountCard.tsx
@@ -28,7 +28,9 @@ export const AccountCard = () => {
         background={color("100")}
         account={currentAccount}
         id="account-tile"
-        onClick={() => openWith(<AccountSelectorModal />, { canBeOverridden: true })}
+        onClick={() =>
+          openWith(<AccountSelectorModal />, { canBeOverridden: true, closeOnOverlayClick: true })
+        }
       >
         <IconButton
           alignSelf="center"

--- a/packages/components/src/components/DynamicDisclosure/DynamicDisclosure.tsx
+++ b/packages/components/src/components/DynamicDisclosure/DynamicDisclosure.tsx
@@ -24,6 +24,7 @@ interface DynamicDisclosureContextType {
     props?: ThemingProps & {
       onClose?: () => void | Promise<void>;
       closeOnEsc?: boolean;
+      closeOnOverlayClick?: boolean;
       canBeOverridden?: boolean;
     }
   ) => Promise<void>;
@@ -67,6 +68,7 @@ type DisclosureStackItem = {
   props: ThemingProps & {
     onClose: () => void | Promise<void>;
     closeOnEsc?: boolean;
+    closeOnOverlayClick?: boolean;
     canBeOverridden?: boolean; // protects WalletConnect and Beacon modals from being overriden
   };
   formValues: Record<string, any>;
@@ -93,6 +95,7 @@ export const useDynamicDisclosure = () => {
     props: ThemingProps & {
       onClose?: () => void | Promise<void>;
       closeOnEsc?: boolean;
+      closeOnOverlayClick?: boolean;
       canBeOverridden?: boolean;
     } = {}
   ) => {
@@ -152,13 +155,14 @@ export const useDynamicDisclosure = () => {
     hasPrevious: stackRef.current.length > 1,
     allFormValues,
     canBeOverridden: !!currentItem?.props.canBeOverridden,
+    closeOnOverlayClick: !!currentItem?.props.closeOnOverlayClick,
   };
 };
 
 export const useDynamicModal = () => {
   const disclosure = useDynamicDisclosure();
 
-  const { isOpen, props, content, onClose } = disclosure;
+  const { isOpen, props, content, onClose, closeOnOverlayClick } = disclosure;
 
   return {
     ...disclosure,
@@ -166,7 +170,7 @@ export const useDynamicModal = () => {
       <Modal
         autoFocus={false}
         blockScrollOnMount={false}
-        closeOnOverlayClick={false}
+        closeOnOverlayClick={closeOnOverlayClick}
         isCentered
         isOpen={isOpen}
         motionPreset="slideInBottom"


### PR DESCRIPTION
## Proposed changes

[Task link](https://linear.app/tezos/issue/UMA-1067/account-selector-users-can-only-close-the-modals-by-using-the-close)

## Types of changes

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [X] UI fix

## Steps to reproduce
1) Login into the wallet
2) Click on the arrows near your account 
3) The modal pop up
4) Now click on the blurred overlay to see the modal disappear

## Screenshots

Add the screenshots of how the app used to look like and how it looks now

| Before | Now |
| ------ | --- |
|        |     |

## Checklist

- [ ] Tests that prove my fix is effective or that my feature works have been added
        - test were not possible to be written as the chakra-ui modal used is probably not using the normal listener for click events on the overlay or any other modal-related items
- [ ] Documentation has been added (if appropriate)
- [ ] Screenshots are added (if any UI changes have been made)
- [ ] All TODOs have a corresponding task created (and the link is attached to it)
